### PR TITLE
fix(env): Change auth0 domains back to valora

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -10,7 +10,7 @@ APP_STORE_ID=6738967491
 APP_DISPLAY_NAME=TuCop
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnet.plist
 SENTRY_ENABLED=false
-AUTH0_DOMAIN=tucopwallet.us.auth0.com
+AUTH0_DOMAIN=auth.valora.xyz
 ONBOARDING_FEATURES_ENABLED=CloudBackup,CloudBackupSetupInOnboarding,EnableBiometry,ProtectWallet
 DEEP_LINK_URL_SCHEME=tucopwallet
 # APP_REGISTRY_NAME should not contain spaces, it is used for the app buildable name and user agent header

--- a/.env.mainnetdev
+++ b/.env.mainnetdev
@@ -12,7 +12,7 @@ APP_STORE_ID=1520414263
 APP_DISPLAY_NAME=TuCop (dev)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnetdev.plist
 SENTRY_ENABLED=false
-AUTH0_DOMAIN=auth.tucop.org
+AUTH0_DOMAIN=auth.valora.xyz
 ONBOARDING_FEATURES_ENABLED=CloudBackup,CloudBackupSetupInOnboarding,EnableBiometry,ProtectWallet
 DEEP_LINK_URL_SCHEME=tucopwallet
 # APP_REGISTRY_NAME should not contain spaces, it is used for the app buildable name and user agent header


### PR DESCRIPTION
### Description

This is necessary for Cloud Account Backup (login with iOS / Google) to work. 
