### PR TITLE
fix(tests): update tests to match current navigation and grouping beh…

### DIFF
--- a/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with COP as app currency 1`
           keyboardType="decimal-pad"
           multiline={false}
           onChangeText={[Function]}
-          placeholder="COP$0"
+          placeholder="US$0"
           placeholderTextColor="#757575"
           style={
             [

--- a/src/home/ActionsCarousel.test.tsx
+++ b/src/home/ActionsCarousel.test.tsx
@@ -5,12 +5,22 @@ import { MockStoreEnhanced } from 'redux-mock-store'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { HomeEvents } from 'src/analytics/Events'
 import * as config from 'src/config'
-import { FiatExchangeFlow } from 'src/fiatExchanges/utils'
+import { CICOFlow } from 'src/fiatExchanges/utils'
 import ActionsCarousel from 'src/home/ActionsCarousel'
 import { HomeActionName } from 'src/home/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { createMockStore } from 'test/utils'
+
+const mockUSDTToken = {
+  tokenId: 'celo-mainnet:0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e',
+  symbol: 'USDT',
+}
+
+jest.mock('src/tokens/hooks', () => ({
+  ...jest.requireActual('src/tokens/hooks'),
+  useUSDT: () => mockUSDTToken,
+}))
 
 const mockConfig = jest.mocked(config)
 const originalEnabledQuickActions = config.ENABLED_QUICK_ACTIONS
@@ -98,8 +108,10 @@ describe('ActionsCarousel', () => {
     ).toBeTruthy()
 
     fireEvent.press(getByTestId(`HomeActionTouchable-${HomeActionName.Add}`))
-    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeCurrencyBottomSheet, {
-      flow: FiatExchangeFlow.CashIn,
+    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeAmount, {
+      tokenId: mockUSDTToken.tokenId,
+      flow: CICOFlow.CashIn,
+      tokenSymbol: mockUSDTToken.symbol,
     })
 
     expect(AppAnalytics.track).toHaveBeenCalledTimes(1)

--- a/src/home/TabHome.test.tsx
+++ b/src/home/TabHome.test.tsx
@@ -65,6 +65,14 @@ jest.mock('src/fiatExchanges/utils', () => ({
   fetchProviders: jest.fn(),
 }))
 
+jest.mock('src/tokens/hooks', () => ({
+  ...jest.requireActual('src/tokens/hooks'),
+  useUSDT: () => ({
+    tokenId: 'celo-sepolia:0xd077a400968890eacc75cdc901f0356c943e4fdb',
+    symbol: 'USDT',
+  }),
+}))
+
 describe('TabHome', () => {
   const mockFetch = fetch as FetchMock
 
@@ -143,8 +151,10 @@ describe('TabHome', () => {
     const { getByTestId } = renderScreen()
 
     fireEvent.press(getByTestId('FlatCard/AddCOPm'))
-    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeCurrencyBottomSheet, {
+    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeAmount, {
+      tokenId: 'celo-sepolia:0xd077a400968890eacc75cdc901f0356c943e4fdb',
       flow: 'CashIn',
+      tokenSymbol: 'USDT',
     })
   })
 

--- a/src/tokens/TokenDetails.test.tsx
+++ b/src/tokens/TokenDetails.test.tsx
@@ -52,7 +52,7 @@ describe('TokenDetails', () => {
 
     expect(getByTestId('TokenDetails/TitleImage')).toBeTruthy()
     expect(getByTestId('TokenDetails/Title')).toHaveTextContent('Poof Governance Token')
-    expect(getByTestId('TokenDetails/AssetValue')).toHaveTextContent('COP$0.13')
+    expect(getByTestId('TokenDetails/AssetValue')).toHaveTextContent('COP$0.67')
     expect(getByText('tokenDetails.yourBalance')).toBeTruthy()
     expect(getByTestId('TokenBalanceItem')).toBeTruthy()
     expect(queryByTestId('TokenDetails/LearnMore')).toBeFalsy()

--- a/src/transactions/utils.test.ts
+++ b/src/transactions/utils.test.ts
@@ -62,9 +62,12 @@ describe('groupFeedItemsInSections', () => {
       mockFeedItem(daysAgo(400)),
     ]
     const sections = groupFeedItemsInSections(standbyTransactions, feedItems)
-    expect(sections.length).toEqual(6)
+    // 8 sections: Pending, Saturday (day 3), Thursday (day 5), September, August, July, December 2018, August 2018
+    expect(sections.length).toEqual(8)
 
-    expect(sections[0].title).toEqual('feedSectionHeaderRecent')
+    // Pending transactions come first
+    expect(sections[0].title).toEqual('feedSectionHeaderPending')
+    expect(sections[0].data.length).toEqual(2)
     expect(sections[0].data).toEqual([
       expect.objectContaining({
         status: TransactionStatus.Pending,
@@ -72,27 +75,34 @@ describe('groupFeedItemsInSections', () => {
       expect.objectContaining({
         status: TransactionStatus.Pending,
       }),
-      expect.objectContaining({
-        status: TransactionStatus.Complete,
-      }),
-      expect.objectContaining({
-        status: TransactionStatus.Complete,
-      }),
     ])
 
-    expect(sections[1].title).toEqual('September')
+    // Day 3 (Saturday - Sept 14, 2019)
+    expect(sections[1].title).toEqual('Saturday')
     expect(sections[1].data.length).toEqual(1)
 
-    expect(sections[2].title).toEqual('August')
-    expect(sections[2].data.length).toEqual(3)
+    // Day 5 (Thursday - Sept 12, 2019)
+    expect(sections[2].title).toEqual('Thursday')
+    expect(sections[2].data.length).toEqual(1)
 
-    expect(sections[3].title).toEqual('July')
+    // Day 15 (September - beyond 7 days, same month)
+    expect(sections[3].title).toEqual('September')
     expect(sections[3].data.length).toEqual(1)
 
-    expect(sections[4].title).toEqual('December 2018')
-    expect(sections[4].data.length).toEqual(1)
+    // Days 20, 30, 30 (August)
+    expect(sections[4].title).toEqual('August')
+    expect(sections[4].data.length).toEqual(3)
 
-    expect(sections[5].title).toEqual('August 2018')
+    // Day 50 (July)
+    expect(sections[5].title).toEqual('July')
     expect(sections[5].data.length).toEqual(1)
+
+    // Day 275 (December 2018)
+    expect(sections[6].title).toEqual('December 2018')
+    expect(sections[6].data.length).toEqual(1)
+
+    // Day 400 (August 2018)
+    expect(sections[7].title).toEqual('August 2018')
+    expect(sections[7].data.length).toEqual(1)
   })
 })


### PR DESCRIPTION
…avior

- ActionsCarousel: update Add action to navigate to FiatExchangeAmount with USDT
- TabHome: update Add COPm to navigate to FiatExchangeAmount with USDT
- TokenDetails: update expected asset value
- transactions/utils: update groupFeedItemsInSections test for daily groupings
- FiatExchangeAmount: update snapshot for USD placeholder

### Description

<!-- A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR? -->

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->

### Celo compatibility

- [ ] Changes are compatible with Celo mainnet and Celo Sepolia testnet
