### PR TITLE
chore: bump version to 1.118.1 (build 1021081766/251)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,8 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 35
         kotlinVersion = "2.0.21"
-        ndkVersion = "27.1.12297006"
+        // NDK r28 required for 16KB page size support (Google Play requirement 2025)
+        ndkVersion = "28.0.13004108"
 
         // Add these version configurations for react-native-svg
         androidXVersion = "1.9.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -35,7 +35,7 @@ RELEASE_KEY_ALIAS=mobilestack-key-alias
 
 # Setting this manually based on version number until we have this deploying via Cloud Build
 # Example: v1.5.1 deployment number 1 = 1005001001 (1 005 001 001)
-VERSION_CODE=1021081764
+VERSION_CODE=1021081766
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/ios/MobileStack/Info.plist
+++ b/ios/MobileStack/Info.plist
@@ -52,7 +52,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>250</string>
+	<string>251</string>
 	<key>CleverTapAccountID</key>
 	<string>$(CLEVERTAP_ACCOUNT_ID)</string>
 	<key>CleverTapToken</key>


### PR DESCRIPTION
- Android: 1.118.1 build 1021081766
- iOS: 1.118.1 build 251
- NDK r28 for 16KB page size support (Google Play requirement)

### Description

<!-- A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR? -->

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->

### Celo compatibility

- [ ] Changes are compatible with Celo mainnet and Celo Sepolia testnet
