### PR TITLE
fix(hooks): make pre-push hook work under newer Node + Husky

### DIFF
--- a/scripts/hooks/pre-push.js
+++ b/scripts/hooks/pre-push.js
@@ -59,9 +59,23 @@ function getDateFromFirstCommit(fromSHA, toSHA) {
 /// MAIN
 ////////////////////////////////////////////////////////////////
 
-const [remoteName, remoteUrl] = process.env.HUSKY_GIT_PARAMS.split(' ')
+// Read from process.argv and stdin instead of legacy Husky 3 env vars
+// (HUSKY_GIT_PARAMS / HUSKY_GIT_STDIN), which are no longer populated under
+// newer Node/Husky combos. argv + stdin is what Git itself passes to any
+// pre-push hook, so this works under any Husky version (or without Husky).
+const [remoteName, remoteUrl] = process.argv.slice(2)
 
-const changes = process.env.HUSKY_GIT_STDIN.split('\n')
+let stdinData = ''
+try {
+  stdinData = require('fs').readFileSync(0, 'utf-8')
+} catch {
+  // No stdin available (e.g. when invoked manually outside a git push) - treat
+  // as no changes and exit cleanly.
+  stdinData = ''
+}
+
+const changes = stdinData
+  .split('\n')
   .filter((line) => line !== '')
   .map((line) => {
     const [localRef, localSHA, remoteRef, remoteSHA] = line.split(' ')


### PR DESCRIPTION
## Summary

The pre-push hook crashes with `Cannot read properties of undefined (reading 'split')` under newer Node/Husky combos because `HUSKY_GIT_PARAMS` and `HUSKY_GIT_STDIN` env vars are no longer populated.

Fix: read directly from `process.argv` (remote name + URL) and `process.stdin` (the ref/SHA lines that Git pipes in). This is what Git itself passes to any pre-push hook, so the script now works under any Husky version (or without Husky at all).

## Why

Without this fix every push to the repo from a current Node/Husky setup needs `--no-verify`, which silently bypasses the actual safety checks (no `.env.mnemonic` files in the diff, no commits from before 2019).

## Test plan
- [x] `node scripts/hooks/pre-push.js` no longer crashes when invoked manually (now reads stdin or treats absent stdin as no-op).
- [x] Will be exercised on every subsequent push to this repo, including the 4 follow-up PRs queued behind this one.