### PR TITLE
fix(redux): update test schema and snapshot for migration 245

### DIFF
--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -143,7 +143,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 244,
+          "version": 245,
         },
         "account": {
           "acceptedTerms": false,

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3666,6 +3666,17 @@ export const v244Schema = {
   },
 }
 
+// Migration 245 removed the deprecated divviProtocol slice from persisted state.
+// Schemas in this file never carried that slice explicitly, so the schema diff
+// from v244 is just the version bump.
+export const v245Schema = {
+  ...v244Schema,
+  _persist: {
+    ...v244Schema._persist,
+    version: 245,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v244Schema as Partial<RootState>
+  return v245Schema as Partial<RootState>
 }


### PR DESCRIPTION
## Summary

After #105 added redux migration 245 (drop deprecated \`divviProtocol\` slice) and bumped \`persistConfig.version\` to 245, the test harness was left out of sync:

- \`test/schemas.ts\` still returned \`v244Schema\` from \`getLatestSchema()\`, so the assertion \`_persistConfig.version === getLatestSchema()._persist.version\` failed (expected 244, received 245).
- The inline snapshot in \`src/redux/store.test.ts\` (rehydrated state shape) still pinned \`"version": 244\`.

Adds \`v245Schema\` (identical to \`v244Schema\` apart from the version bump, since the deprecated slice was never carried in the schema definitions) and updates the inline snapshot. \`yarn test\` is back to green: 3932 passing, 0 failing.

## Why this matters

This failure has been present on \`Development\` since #105 merged. It has been the only thing blocking CI green for every PR in the 1.118.3 release cycle, and was the reason every PR in this cycle reported "2 failing, pre-existing redux/store" in its test plan.

## Test plan
- [x] \`yarn build:ts\`
- [x] \`yarn lint\`
- [x] \`yarn test\` -- 3932 passing, 44 skipped, 0 failing