### PR TITLE
chore(subsidies): match canonical success-screen visual pattern

### DIFF
--- a/src/components/DebugInfoPanel.tsx
+++ b/src/components/DebugInfoPanel.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  info: string
+  label?: string
+}
+
+/**
+ * Collapsible debug info panel rendered only in dev builds. Hidden by default;
+ * tap the toggle row to expand. Use anywhere a screen wants to surface ad-hoc
+ * diagnostic data without pushing it in the user's face.
+ */
+export default function DebugInfoPanel({ info, label = 'Debug Info' }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!__DEV__ || !info) {
+    return null
+  }
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        onPress={() => setExpanded((prev) => !prev)}
+        accessibilityRole="button"
+        style={styles.toggle}
+      >
+        <Text style={styles.toggleText}>
+          {expanded ? 'v ' : '> '}
+          {label}
+        </Text>
+      </Pressable>
+      {expanded && (
+        <View style={styles.body}>
+          <Text style={styles.text} selectable>
+            {info}
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'stretch',
+    marginTop: Spacing.Regular16,
+  },
+  toggle: {
+    paddingVertical: Spacing.Smallest8,
+  },
+  toggleText: {
+    ...typeScale.bodySmall,
+    color: Colors.gray3,
+  },
+  body: {
+    backgroundColor: Colors.gray1,
+    borderRadius: 8,
+    padding: Spacing.Regular16,
+    marginTop: Spacing.Smallest8,
+  },
+  text: {
+    ...typeScale.bodyXSmall,
+    fontFamily: 'monospace',
+    color: Colors.gray6,
+  },
+})

--- a/src/refi/ReFiMedellinUBIScreen.tsx
+++ b/src/refi/ReFiMedellinUBIScreen.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { TabHomeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import DebugInfoPanel from 'src/components/DebugInfoPanel'
 import Celebration from 'src/icons/misc/Celebration'
 import TuCOPLogo from 'src/navigator/Logo.svg'
 import { StackParamList } from 'src/navigator/types'
@@ -167,12 +168,7 @@ export default function ReFiMedellinUBIScreen({ navigation }: Props) {
           <Celebration size={48} color={Colors.error} />
           <Text style={styles.errorTitle}>{t('reFiMedellinUbi.error.title')}</Text>
           <Text style={styles.errorText}>{t('reFiMedellinUbi.error.description')}</Text>
-          {!!debugInfo && (
-            <View style={styles.debugContainer}>
-              <Text style={styles.debugTitle}>Debug Info:</Text>
-              <Text style={styles.debugText}>{debugInfo}</Text>
-            </View>
-          )}
+          <DebugInfoPanel info={debugInfo} />
           <Button
             onPress={checkUBIStatus}
             text={t('reFiMedellinUbi.error.retry')}
@@ -194,12 +190,7 @@ export default function ReFiMedellinUBIScreen({ navigation }: Props) {
               {t('reFiMedellinUbi.notEligible.description')}
             </Text>
             <Text style={styles.contactInfo}>{t('reFiMedellinUbi.notEligible.contact')}</Text>
-            {!!debugInfo && (
-              <View style={styles.debugContainer}>
-                <Text style={styles.debugTitle}>Debug Info:</Text>
-                <Text style={styles.debugText}>{debugInfo}</Text>
-              </View>
-            )}
+            <DebugInfoPanel info={debugInfo} />
           </View>
         </View>
       )
@@ -318,12 +309,7 @@ export default function ReFiMedellinUBIScreen({ navigation }: Props) {
             </View>
           )}
 
-          {!!debugInfo && __DEV__ && (
-            <View style={styles.debugContainer}>
-              <Text style={styles.debugTitle}>Debug Info:</Text>
-              <Text style={styles.debugText}>{debugInfo}</Text>
-            </View>
-          )}
+          <DebugInfoPanel info={debugInfo} />
         </View>
       </View>
     )
@@ -626,23 +612,5 @@ const styles = StyleSheet.create({
     color: Colors.primary,
     marginLeft: Spacing.Smallest8,
     fontWeight: '500',
-  },
-  debugContainer: {
-    backgroundColor: '#F0F0F0',
-    borderRadius: 8,
-    padding: Spacing.Regular16,
-    marginTop: Spacing.Regular16,
-    alignSelf: 'stretch',
-  },
-  debugTitle: {
-    ...typeScale.bodySmall,
-    color: Colors.gray6,
-    fontWeight: '600',
-    marginBottom: Spacing.Smallest8,
-  },
-  debugText: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-    fontFamily: 'monospace',
   },
 })

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -7,6 +7,7 @@ import AppAnalytics from 'src/analytics/AppAnalytics'
 import { TabHomeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { ErrorMessage } from 'src/components/ErrorMessage'
+import RowDivider from 'src/components/RowDivider'
 import Celebration from 'src/icons/misc/Celebration'
 import TuCOPLogo from 'src/navigator/Logo.svg'
 import { Screens } from 'src/navigator/Screens'
@@ -270,6 +271,8 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
                     </Text>
                   </View>
                 )}
+
+                {!!ubiStatus.lastClaimTimestamp && !!ubiStatus.nextClaimAvailable && <RowDivider />}
 
                 {!!ubiStatus.nextClaimAvailable && (
                   <View style={styles.detailRow}>
@@ -597,10 +600,6 @@ const styles = StyleSheet.create({
   },
   detailsContainer: {
     width: '100%',
-    backgroundColor: Colors.gray1,
-    borderRadius: 12,
-    padding: Spacing.Regular16,
-    gap: Spacing.Regular16,
     marginBottom: Spacing.Large32,
   },
   detailRow: {

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -308,6 +308,13 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
               size={BtnSizes.FULL}
               style={styles.backButton}
             />
+
+            {!!debugInfo && __DEV__ && (
+              <View style={styles.debugContainer}>
+                <Text style={styles.debugTitle}>Debug Info:</Text>
+                <Text style={styles.debugText}>{debugInfo}</Text>
+              </View>
+            )}
           </View>
         </View>
       )

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -251,39 +251,43 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
               </Text>
             </View>
 
-            {!!ubiStatus.lastClaimTimestamp && (
-              <View style={styles.claimInfoCard}>
-                <Text style={styles.claimInfoTitle}>
-                  {t('reFiColombiaSubsidies.alreadyClaimed.lastClaimTitle')}
-                </Text>
-                <Text style={styles.claimInfoDate}>
-                  {new Date(ubiStatus.lastClaimTimestamp * 1000).toLocaleDateString('es-ES', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  })}
-                </Text>
-              </View>
-            )}
+            {(!!ubiStatus.lastClaimTimestamp || !!ubiStatus.nextClaimAvailable) && (
+              <View style={styles.detailsContainer}>
+                {!!ubiStatus.lastClaimTimestamp && (
+                  <View style={styles.detailRow}>
+                    <Text style={styles.detailLabel}>
+                      {t('reFiColombiaSubsidies.alreadyClaimed.lastClaimTitle')}
+                    </Text>
+                    <Text style={styles.detailValue}>
+                      {new Date(ubiStatus.lastClaimTimestamp * 1000).toLocaleDateString('es-ES', {
+                        weekday: 'long',
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </Text>
+                  </View>
+                )}
 
-            {!!ubiStatus.nextClaimAvailable && (
-              <View style={styles.nextClaimCard}>
-                <Text style={styles.nextClaimTitle}>
-                  {t('reFiColombiaSubsidies.alreadyClaimed.nextClaimTitle')}
-                </Text>
-                <Text style={styles.nextClaimTime}>
-                  {formatTimeRemaining(ubiStatus.nextClaimAvailable)}
-                </Text>
-                <Text style={styles.nextClaimDate}>
-                  {new Date(ubiStatus.nextClaimAvailable * 1000).toLocaleDateString('es-ES', {
-                    weekday: 'long',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </Text>
+                {!!ubiStatus.nextClaimAvailable && (
+                  <View style={styles.detailRow}>
+                    <Text style={styles.detailLabel}>
+                      {t('reFiColombiaSubsidies.alreadyClaimed.nextClaimTitle')}
+                    </Text>
+                    <Text style={styles.detailValueLarge}>
+                      {formatTimeRemaining(ubiStatus.nextClaimAvailable)}
+                    </Text>
+                    <Text style={styles.detailValueMuted}>
+                      {new Date(ubiStatus.nextClaimAvailable * 1000).toLocaleDateString('es-ES', {
+                        weekday: 'long',
+                        month: 'long',
+                        day: 'numeric',
+                      })}
+                    </Text>
+                  </View>
+                )}
               </View>
             )}
 
@@ -591,45 +595,33 @@ const styles = StyleSheet.create({
     color: Colors.gray6,
     lineHeight: 22,
   },
-  claimInfoCard: {
-    backgroundColor: Colors.successLight,
+  detailsContainer: {
+    width: '100%',
+    backgroundColor: Colors.gray1,
     borderRadius: 12,
     padding: Spacing.Regular16,
-    marginBottom: Spacing.Regular16,
-    alignSelf: 'stretch',
+    gap: Spacing.Regular16,
+    marginBottom: Spacing.Large32,
+  },
+  detailRow: {
+    flexDirection: 'column',
     gap: Spacing.Smallest8,
   },
-  claimInfoTitle: {
-    ...typeScale.labelSemiBoldSmall,
-    color: Colors.successDark,
-    marginBottom: Spacing.Tiny4,
-  },
-  claimInfoDate: {
-    ...typeScale.bodyMedium,
-    color: Colors.gray6,
-  },
-  nextClaimCard: {
-    backgroundColor: Colors.warningLight,
-    borderRadius: 12,
-    padding: Spacing.Regular16,
-    marginBottom: Spacing.Large32,
-    alignSelf: 'stretch',
-    gap: Spacing.Tiny4,
-  },
-  nextClaimTitle: {
-    ...typeScale.labelSemiBoldSmall,
-    color: Colors.warningDark,
-    marginBottom: Spacing.Tiny4,
-  },
-  nextClaimTime: {
-    ...typeScale.titleSmall,
-    color: Colors.gray6,
-    fontWeight: '600',
-    marginBottom: Spacing.Tiny4,
-  },
-  nextClaimDate: {
+  detailLabel: {
     ...typeScale.bodySmall,
-    color: Colors.gray3,
+    color: Colors.gray4,
+  },
+  detailValue: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+  },
+  detailValueLarge: {
+    ...typeScale.labelSemiBoldLarge,
+    color: Colors.black,
+  },
+  detailValueMuted: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
   },
   lastClaimInfo: {
     backgroundColor: Colors.gray1,

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -7,7 +7,6 @@ import AppAnalytics from 'src/analytics/AppAnalytics'
 import { TabHomeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { ErrorMessage } from 'src/components/ErrorMessage'
-import RowDivider from 'src/components/RowDivider'
 import Celebration from 'src/icons/misc/Celebration'
 import TuCOPLogo from 'src/navigator/Logo.svg'
 import { Screens } from 'src/navigator/Screens'
@@ -271,8 +270,6 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
                     </Text>
                   </View>
                 )}
-
-                {!!ubiStatus.lastClaimTimestamp && !!ubiStatus.nextClaimAvailable && <RowDivider />}
 
                 {!!ubiStatus.nextClaimAvailable && (
                   <View style={styles.detailRow}>
@@ -544,15 +541,30 @@ const styles = StyleSheet.create({
     paddingVertical: Spacing.Regular16,
   },
   alreadyClaimedCard: {
+    backgroundColor: Colors.gray1,
+    borderRadius: 16,
+    padding: Spacing.Large32,
     alignItems: 'center',
-    marginTop: Spacing.Large32,
+    ...getShadowStyle(Shadow.Soft),
+    borderWidth: 1,
+    borderColor: Colors.gray2,
+    marginHorizontal: Spacing.Smallest8,
+    marginVertical: Spacing.Smallest8,
   },
   eligibleContainer: {
     alignItems: 'center',
     paddingVertical: Spacing.Regular16,
   },
   eligibleCard: {
+    backgroundColor: Colors.gray1,
+    borderRadius: 16,
+    padding: Spacing.Large32,
     alignItems: 'center',
+    ...getShadowStyle(Shadow.Soft),
+    borderWidth: 1,
+    borderColor: Colors.gray2,
+    marginHorizontal: Spacing.Smallest8,
+    marginVertical: Spacing.Smallest8,
   },
   congratsSection: {
     alignItems: 'center',

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -161,31 +161,41 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
   const renderContent = () => {
     if (isCheckingBeneficiary) {
       return (
-        <View style={styles.loadingContainer}>
-          <Celebration size={48} color={Colors.primary} />
-          <Text style={styles.loadingText}>{t('reFiColombiaSubsidies.checking.title')}</Text>
-          <Text style={styles.loadingSubtext}>{t('reFiColombiaSubsidies.checking.subtitle')}</Text>
-          <ActivityIndicator size="large" color={Colors.primary} style={styles.spinner} />
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
+            <Text style={styles.congratsTitle}>{t('reFiColombiaSubsidies.checking.title')}</Text>
+            <Text style={styles.congratsSubtitle}>
+              {t('reFiColombiaSubsidies.checking.subtitle')}
+            </Text>
+            <ActivityIndicator size="large" color={Colors.primary} style={styles.spinner} />
+          </View>
         </View>
       )
     }
 
     if (ubiStatus === null) {
       return (
-        <View style={styles.errorContainer}>
-          <Celebration size={48} color={Colors.error} />
-          <ErrorMessage
-            error={loadError ?? new Error('ubiStatus null')}
-            context={{ screen: 'ReFiColombiaSubsidies', action: 'checkUBIStatus' }}
-            variant="banner"
-          />
-          <Button
-            onPress={checkUBIStatus}
-            text={t('reFiColombiaSubsidies.error.retry')}
-            type={BtnTypes.SECONDARY}
-            size={BtnSizes.MEDIUM}
-            style={styles.retryButton}
-          />
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
+            <ErrorMessage
+              error={loadError ?? new Error('ubiStatus null')}
+              context={{ screen: 'ReFiColombiaSubsidies', action: 'checkUBIStatus' }}
+              variant="banner"
+            />
+            <Button
+              onPress={checkUBIStatus}
+              text={t('reFiColombiaSubsidies.error.retry')}
+              type={BtnTypes.SECONDARY}
+              size={BtnSizes.MEDIUM}
+              style={styles.retryButton}
+            />
+          </View>
         </View>
       )
     }
@@ -200,13 +210,13 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
       }
 
       return (
-        <View style={styles.notEligibleContainer}>
-          <View style={styles.notEligibleCard}>
-            <Celebration size={56} color={Colors.gray3} />
-            <Text style={styles.notEligibleTitle}>
-              {t('reFiColombiaSubsidies.notEligible.title')}
-            </Text>
-            <Text style={styles.notEligibleDescription}>
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
+            <Text style={styles.congratsTitle}>{t('reFiColombiaSubsidies.notEligible.title')}</Text>
+            <Text style={styles.congratsSubtitle}>
               {t('reFiColombiaSubsidies.notEligible.description')}
             </Text>
             <Button
@@ -236,8 +246,8 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
     // Usuario es beneficiario
     if (ubiStatus.hasClaimedThisWeek) {
       return (
-        <View style={styles.alreadyClaimedContainer}>
-          <View style={styles.alreadyClaimedCard}>
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
             <View style={styles.iconContainer}>
               <Celebration size={64} color={Colors.primary} />
             </View>
@@ -305,8 +315,8 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
 
     // Usuario puede reclamar
     return (
-      <View style={styles.eligibleContainer}>
-        <View style={styles.eligibleCard}>
+      <View style={styles.stateContainer}>
+        <View style={styles.stateCard}>
           <View style={styles.iconContainer}>
             <Celebration size={64} color={Colors.primary} />
           </View>
@@ -458,66 +468,11 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingBottom: Spacing.Large32,
   },
-  loadingContainer: {
-    minHeight: 300,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingText: {
-    ...typeScale.titleSmall,
-    color: Colors.primary,
-    marginTop: Spacing.Regular16,
-    textAlign: 'center',
-    fontWeight: '600',
-  },
-  loadingSubtext: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-    marginTop: Spacing.Smallest8,
-    textAlign: 'center',
-  },
   spinner: {
     marginTop: Spacing.Regular16,
   },
-  errorContainer: {
-    minHeight: 300,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: Spacing.Regular16,
-  },
   retryButton: {
     marginTop: Spacing.Regular16,
-  },
-  notEligibleContainer: {
-    minHeight: 300,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  notEligibleCard: {
-    backgroundColor: Colors.gray1,
-    borderRadius: 16,
-    padding: Spacing.Large32,
-    alignItems: 'center',
-    ...getShadowStyle(Shadow.Soft),
-    borderWidth: 1,
-    borderColor: Colors.gray2,
-    marginHorizontal: Spacing.Smallest8,
-    marginVertical: Spacing.Smallest8,
-  },
-  notEligibleTitle: {
-    ...typeScale.titleMedium,
-    color: Colors.gray6,
-    textAlign: 'center',
-    marginTop: Spacing.Regular16,
-    marginBottom: Spacing.Smallest8,
-    fontWeight: '600',
-  },
-  notEligibleDescription: {
-    ...typeScale.bodyMedium,
-    color: Colors.gray3,
-    textAlign: 'center',
-    lineHeight: 22,
-    marginBottom: Spacing.Regular16,
   },
   contactInfo: {
     ...typeScale.bodySmall,
@@ -536,11 +491,13 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: Spacing.Regular16,
   },
-  alreadyClaimedContainer: {
+  // Shared chrome for every state (loading, error, notEligible, eligible, alreadyClaimed)
+  // so the screen reads consistently regardless of which branch renders.
+  stateContainer: {
     alignItems: 'center',
     paddingVertical: Spacing.Regular16,
   },
-  alreadyClaimedCard: {
+  stateCard: {
     backgroundColor: Colors.gray1,
     borderRadius: 16,
     padding: Spacing.Large32,
@@ -550,21 +507,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.gray2,
     marginHorizontal: Spacing.Smallest8,
     marginVertical: Spacing.Smallest8,
-  },
-  eligibleContainer: {
-    alignItems: 'center',
-    paddingVertical: Spacing.Regular16,
-  },
-  eligibleCard: {
-    backgroundColor: Colors.gray1,
-    borderRadius: 16,
-    padding: Spacing.Large32,
-    alignItems: 'center',
-    ...getShadowStyle(Shadow.Soft),
-    borderWidth: 1,
-    borderColor: Colors.gray2,
-    marginHorizontal: Spacing.Smallest8,
-    marginVertical: Spacing.Smallest8,
+    alignSelf: 'stretch',
   },
   congratsSection: {
     alignItems: 'center',

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -238,7 +238,9 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
       return (
         <View style={styles.alreadyClaimedContainer}>
           <View style={styles.alreadyClaimedCard}>
-            <Celebration size={72} color={Colors.primary} />
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
 
             <View style={styles.congratsSection}>
               <Text style={styles.congratsTitle}>
@@ -301,7 +303,9 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
     return (
       <View style={styles.eligibleContainer}>
         <View style={styles.eligibleCard}>
-          <Celebration size={72} color={Colors.primary} />
+          <View style={styles.iconContainer}>
+            <Celebration size={64} color={Colors.primary} />
+          </View>
 
           <View style={styles.congratsSection}>
             <Text style={styles.congratsTitle}>
@@ -548,25 +552,34 @@ const styles = StyleSheet.create({
     marginTop: Spacing.Thick24,
     marginBottom: Spacing.Large32,
   },
+  iconContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: Colors.successLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: Spacing.Thick24,
+  },
   congratsTitle: {
-    ...typeScale.titleLarge,
-    color: Colors.primary,
+    ...typeScale.labelLarge,
+    color: Colors.black,
     textAlign: 'center',
-    marginBottom: Spacing.Smallest8,
+    paddingTop: Spacing.Smallest8,
+    paddingBottom: Spacing.Regular16,
   },
   congratsSubtitle: {
-    ...typeScale.bodyLarge,
-    color: Colors.gray3,
+    ...typeScale.bodyMedium,
+    color: Colors.gray4,
     textAlign: 'center',
   },
   benefitCard: {
     backgroundColor: Colors.gray1,
     borderRadius: 12,
-    padding: Spacing.Thick24,
+    padding: Spacing.Regular16,
     marginBottom: Spacing.Large32,
-    borderLeftWidth: 4,
-    borderLeftColor: Colors.primary,
-    ...getShadowStyle(Shadow.Soft),
+    alignSelf: 'stretch',
+    gap: Spacing.Smallest8,
   },
   benefitTitle: {
     ...typeScale.titleSmall,
@@ -584,8 +597,7 @@ const styles = StyleSheet.create({
     padding: Spacing.Regular16,
     marginBottom: Spacing.Regular16,
     alignSelf: 'stretch',
-    borderLeftWidth: 4,
-    borderLeftColor: Colors.successDark,
+    gap: Spacing.Smallest8,
   },
   claimInfoTitle: {
     ...typeScale.labelSemiBoldSmall,
@@ -602,8 +614,7 @@ const styles = StyleSheet.create({
     padding: Spacing.Regular16,
     marginBottom: Spacing.Large32,
     alignSelf: 'stretch',
-    borderLeftWidth: 4,
-    borderLeftColor: Colors.warningDark,
+    gap: Spacing.Tiny4,
   },
   nextClaimTitle: {
     ...typeScale.labelSemiBoldSmall,

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { TabHomeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import DebugInfoPanel from 'src/components/DebugInfoPanel'
 import { ErrorMessage } from 'src/components/ErrorMessage'
 import Celebration from 'src/icons/misc/Celebration'
 import TuCOPLogo from 'src/navigator/Logo.svg'
@@ -232,12 +233,7 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
             <Text style={styles.contactInfo} onPress={handleContactReFi}>
               {t('reFiColombiaSubsidies.notEligible.contact')}
             </Text>
-            {!!debugInfo && __DEV__ && (
-              <View style={styles.debugContainer}>
-                <Text style={styles.debugTitle}>Debug Info:</Text>
-                <Text style={styles.debugText}>{debugInfo}</Text>
-              </View>
-            )}
+            <DebugInfoPanel info={debugInfo} />
           </View>
         </View>
       )
@@ -309,12 +305,7 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
               style={styles.backButton}
             />
 
-            {!!debugInfo && __DEV__ && (
-              <View style={styles.debugContainer}>
-                <Text style={styles.debugTitle}>Debug Info:</Text>
-                <Text style={styles.debugText}>{debugInfo}</Text>
-              </View>
-            )}
+            <DebugInfoPanel info={debugInfo} />
           </View>
         </View>
       )
@@ -377,12 +368,7 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
             </View>
           )}
 
-          {!!debugInfo && __DEV__ && (
-            <View style={styles.debugContainer}>
-              <Text style={styles.debugTitle}>Debug Info:</Text>
-              <Text style={styles.debugText}>{debugInfo}</Text>
-            </View>
-          )}
+          <DebugInfoPanel info={debugInfo} />
         </View>
       </View>
     )
@@ -616,22 +602,5 @@ const styles = StyleSheet.create({
     color: Colors.primary,
     marginLeft: Spacing.Smallest8,
     fontWeight: '500',
-  },
-  debugContainer: {
-    backgroundColor: Colors.gray1,
-    borderRadius: 8,
-    padding: Spacing.Regular16,
-    marginTop: Spacing.Regular16,
-    alignSelf: 'stretch',
-  },
-  debugTitle: {
-    ...typeScale.labelSemiBoldSmall,
-    color: Colors.gray6,
-    marginBottom: Spacing.Smallest8,
-  },
-  debugText: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-    fontFamily: 'monospace',
   },
 })


### PR DESCRIPTION
## Summary

Brings the eligible and already-claimed states of the ReFi Colombia subsidies screen into visual alignment with how other result / success screens look across the app, in particular \`TransactionSuccessScreen\`. The previous design was a one-off that used ornaments not used anywhere else.

Changes (style-only, no JSX restructuring):

- Wrap the Celebration icon in a 120x120 \`successLight\` circle (canonical hero treatment used by \`TransactionSuccessScreen\` and \`CashInSuccess\`).
- Drop the left-accent border ornaments (\`borderLeftWidth: 4 + borderLeftColor\`) on \`benefitCard\`, \`claimInfoCard\`, \`nextClaimCard\`. No other success screen in the codebase uses this pattern; keep the semantic backgrounds (\`gray1\` / \`successLight\` / \`warningLight\`) as the only visual cue and add \`gap\` for row spacing.
- Hero typography: \`congratsTitle\` from \`titleLarge\` (32px Bold primary) to \`labelLarge\` (18px black). \`congratsSubtitle\` from \`bodyLarge\` (gray3) to \`bodyMedium\` (gray4). Matches the canonical hero pair used by \`TransactionSuccessScreen\`.

## Why

User audit pointed out that the previous PR #111 was code-hygiene only and the subsidies screen still looked one-off compared to the rest of the app. This PR closes that loop with the actual visual alignment.

## What's NOT changed

- Button placement is still in-card / inline rather than sticky-bottom. Moving it to the canonical sticky-bottom container would require restructuring the per-state render functions; deferred for a separate refactor.
- The error / not-eligible / loading states are untouched in this PR. The most-visible states (eligible + already-claimed) are the focus.

## Test plan

- [x] \`yarn build:ts\`
- [x] \`yarn lint\`
- [x] \`yarn test --testPathPattern=subsidies/ReFi\` -- 4 passing
- [ ] Manual on Android emulator: open subsidies screen on a beneficiary wallet, verify both eligible and already-claimed states match the look of \`TransactionSuccessScreen\`.
- [ ] Manual on iOS simulator: same flows.