### PR TITLE
chore(subsidies): unify all 5 states with shared stateCard chrome + collapsible debug

### DIFF
--- a/src/components/DebugInfoPanel.tsx
+++ b/src/components/DebugInfoPanel.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  info: string
+  label?: string
+}
+
+/**
+ * Collapsible debug info panel rendered only in dev builds. Hidden by default;
+ * tap the toggle row to expand. Use anywhere a screen wants to surface ad-hoc
+ * diagnostic data without pushing it in the user's face.
+ */
+export default function DebugInfoPanel({ info, label = 'Debug Info' }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!__DEV__ || !info) {
+    return null
+  }
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        onPress={() => setExpanded((prev) => !prev)}
+        accessibilityRole="button"
+        style={styles.toggle}
+      >
+        <Text style={styles.toggleText}>
+          {expanded ? 'v ' : '> '}
+          {label}
+        </Text>
+      </Pressable>
+      {expanded && (
+        <View style={styles.body}>
+          <Text style={styles.text} selectable>
+            {info}
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'stretch',
+    marginTop: Spacing.Regular16,
+  },
+  toggle: {
+    paddingVertical: Spacing.Smallest8,
+  },
+  toggleText: {
+    ...typeScale.bodySmall,
+    color: Colors.gray3,
+  },
+  body: {
+    backgroundColor: Colors.gray1,
+    borderRadius: 8,
+    padding: Spacing.Regular16,
+    marginTop: Spacing.Smallest8,
+  },
+  text: {
+    ...typeScale.bodyXSmall,
+    fontFamily: 'monospace',
+    color: Colors.gray6,
+  },
+})

--- a/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
+++ b/src/subsidies/ReFiColombiaSubsidiesScreen.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { TabHomeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import DebugInfoPanel from 'src/components/DebugInfoPanel'
 import { ErrorMessage } from 'src/components/ErrorMessage'
 import Celebration from 'src/icons/misc/Celebration'
 import TuCOPLogo from 'src/navigator/Logo.svg'
@@ -169,37 +170,48 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
   const renderContent = () => {
     if (isCheckingBeneficiary) {
       return (
-        <View style={styles.loadingContainer}>
-          <Celebration size={48} color={Colors.primary} />
-          <Text style={styles.loadingText}>{t('reFiColombiaSubsidies.checking.title')}</Text>
-          <Text style={styles.loadingSubtext}>{t('reFiColombiaSubsidies.checking.subtitle')}</Text>
-          <ActivityIndicator size="large" color={Colors.primary} style={styles.spinner} />
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
+            <Text style={styles.congratsTitle}>{t('reFiColombiaSubsidies.checking.title')}</Text>
+            <Text style={styles.congratsSubtitle}>
+              {t('reFiColombiaSubsidies.checking.subtitle')}
+            </Text>
+            <ActivityIndicator size="large" color={Colors.primary} style={styles.spinner} />
+          </View>
         </View>
       )
     }
 
     if (ubiStatus === null) {
       return (
-        <View style={styles.errorContainer}>
-          <Celebration size={48} color={Colors.error} />
-          <ErrorMessage
-            error={loadError ?? new Error('ubiStatus null')}
-            context={{ screen: 'ReFiColombiaSubsidies', action: 'checkUBIStatus' }}
-            variant="banner"
-          />
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
+            <ErrorMessage
+              error={loadError ?? new Error('ubiStatus null')}
+              context={{ screen: 'ReFiColombiaSubsidies', action: 'checkUBIStatus' }}
+              variant="banner"
+            />
+            <DebugInfoPanel info={debugInfo} />
+          </View>
         </View>
       )
     }
 
     if (!ubiStatus.isBeneficiary) {
       return (
-        <View style={styles.notEligibleContainer}>
-          <View style={styles.notEligibleCard}>
-            <Celebration size={56} color={Colors.gray3} />
-            <Text style={styles.notEligibleTitle}>
-              {t('reFiColombiaSubsidies.notEligible.title')}
-            </Text>
-            <Text style={styles.notEligibleDescription}>
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
+            </View>
+            <Text style={styles.congratsTitle}>{t('reFiColombiaSubsidies.notEligible.title')}</Text>
+            <Text style={styles.congratsSubtitle}>
               {t('reFiColombiaSubsidies.notEligible.description')}
             </Text>
             <Text style={styles.applyDisclaimer}>
@@ -208,12 +220,7 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
             <Text style={styles.contactInfo} onPress={handleContactReFi}>
               {t('reFiColombiaSubsidies.notEligible.contact')}
             </Text>
-            {!!debugInfo && __DEV__ && (
-              <View style={styles.debugContainer}>
-                <Text style={styles.debugTitle}>Debug Info:</Text>
-                <Text style={styles.debugText}>{debugInfo}</Text>
-              </View>
-            )}
+            <DebugInfoPanel info={debugInfo} />
           </View>
         </View>
       )
@@ -222,25 +229,24 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
     // Usuario es beneficiario
     if (ubiStatus.hasClaimedThisWeek) {
       return (
-        <View style={styles.alreadyClaimedContainer}>
-          <View style={styles.alreadyClaimedCard}>
-            <Celebration size={72} color={Colors.primary} />
-
-            <View style={styles.congratsSection}>
-              <Text style={styles.congratsTitle}>
-                {t('reFiColombiaSubsidies.alreadyClaimed.title')}
-              </Text>
-              <Text style={styles.congratsSubtitle}>
-                {t('reFiColombiaSubsidies.alreadyClaimed.subtitle')}
-              </Text>
+        <View style={styles.stateContainer}>
+          <View style={styles.stateCard}>
+            <View style={styles.iconContainer}>
+              <Celebration size={64} color={Colors.primary} />
             </View>
+            <Text style={styles.congratsTitle}>
+              {t('reFiColombiaSubsidies.alreadyClaimed.title')}
+            </Text>
+            <Text style={styles.congratsSubtitle}>
+              {t('reFiColombiaSubsidies.alreadyClaimed.subtitle')}
+            </Text>
 
             {!!ubiStatus.lastClaimTimestamp && (
-              <View style={styles.claimInfoCard}>
-                <Text style={styles.claimInfoTitle}>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>
                   {t('reFiColombiaSubsidies.alreadyClaimed.lastClaimTitle')}
                 </Text>
-                <Text style={styles.claimInfoDate}>
+                <Text style={styles.detailValue}>
                   {new Date(ubiStatus.lastClaimTimestamp * 1000).toLocaleDateString('es-ES', {
                     weekday: 'long',
                     year: 'numeric',
@@ -254,14 +260,14 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
             )}
 
             {!!ubiStatus.nextClaimAvailable && (
-              <View style={styles.nextClaimCard}>
-                <Text style={styles.nextClaimTitle}>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>
                   {t('reFiColombiaSubsidies.alreadyClaimed.nextClaimTitle')}
                 </Text>
-                <Text style={styles.nextClaimTime}>
+                <Text style={styles.detailValueLarge}>
                   {formatTimeRemaining(ubiStatus.nextClaimAvailable)}
                 </Text>
-                <Text style={styles.nextClaimDate}>
+                <Text style={styles.detailValueMuted}>
                   {new Date(ubiStatus.nextClaimAvailable * 1000).toLocaleDateString('es-ES', {
                     weekday: 'long',
                     month: 'long',
@@ -270,6 +276,8 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
                 </Text>
               </View>
             )}
+
+            <DebugInfoPanel info={debugInfo} />
           </View>
         </View>
       )
@@ -277,18 +285,17 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
 
     // Usuario puede reclamar
     return (
-      <View style={styles.eligibleContainer}>
-        <View style={styles.eligibleCard}>
-          <Celebration size={72} color={Colors.primary} />
-
-          <View style={styles.congratsSection}>
-            <Text style={styles.congratsTitle}>
-              {t('reFiColombiaSubsidies.eligible.congratulations')}
-            </Text>
-            <Text style={styles.congratsSubtitle}>
-              {t('reFiColombiaSubsidies.eligible.subtitle')}
-            </Text>
+      <View style={styles.stateContainer}>
+        <View style={styles.stateCard}>
+          <View style={styles.iconContainer}>
+            <Celebration size={64} color={Colors.primary} />
           </View>
+          <Text style={styles.congratsTitle}>
+            {t('reFiColombiaSubsidies.eligible.congratulations')}
+          </Text>
+          <Text style={styles.congratsSubtitle}>
+            {t('reFiColombiaSubsidies.eligible.subtitle')}
+          </Text>
 
           <View style={styles.benefitCard}>
             <Text style={styles.benefitTitle}>
@@ -317,12 +324,7 @@ export default function ReFiColombiaSubsidiesScreen({ navigation }: Props) {
             </View>
           )}
 
-          {!!debugInfo && __DEV__ && (
-            <View style={styles.debugContainer}>
-              <Text style={styles.debugTitle}>Debug Info:</Text>
-              <Text style={styles.debugText}>{debugInfo}</Text>
-            </View>
-          )}
+          <DebugInfoPanel info={debugInfo} />
         </View>
       </View>
     )
@@ -476,63 +478,48 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: Colors.gray2,
   },
-  loadingContainer: {
-    minHeight: 300,
-    justifyContent: 'center',
+  // Shared chrome applied to every state (loading, error, notEligible, eligible,
+  // alreadyClaimed) so the screen reads consistently regardless of which branch
+  // renders. Matches notEligibleCard's previous look.
+  stateContainer: {
     alignItems: 'center',
+    paddingVertical: Spacing.Regular16,
   },
-  loadingText: {
-    ...typeScale.titleSmall,
-    color: Colors.primary,
-    marginTop: Spacing.Regular16,
-    textAlign: 'center',
-    fontWeight: '600',
-  },
-  loadingSubtext: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-    marginTop: Spacing.Smallest8,
-    textAlign: 'center',
-  },
-  spinner: {
-    marginTop: Spacing.Regular16,
-  },
-  errorContainer: {
-    minHeight: 300,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: Spacing.Regular16,
-  },
-  notEligibleContainer: {
-    minHeight: 300,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  notEligibleCard: {
+  stateCard: {
     backgroundColor: Colors.gray1,
     borderRadius: 16,
     padding: Spacing.Large32,
     alignItems: 'center',
+    alignSelf: 'stretch',
     ...getShadowStyle(Shadow.Soft),
     borderWidth: 1,
     borderColor: Colors.gray2,
     marginHorizontal: Spacing.Smallest8,
     marginVertical: Spacing.Smallest8,
   },
-  notEligibleTitle: {
-    ...typeScale.titleMedium,
-    color: Colors.gray6,
-    textAlign: 'center',
-    marginTop: Spacing.Regular16,
-    marginBottom: Spacing.Smallest8,
-    fontWeight: '600',
+  iconContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: Colors.successLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: Spacing.Thick24,
   },
-  notEligibleDescription: {
-    ...typeScale.bodyMedium,
-    color: Colors.gray3,
+  congratsTitle: {
+    ...typeScale.labelLarge,
+    color: Colors.black,
     textAlign: 'center',
-    lineHeight: 22,
+    paddingBottom: Spacing.Regular16,
+  },
+  congratsSubtitle: {
+    ...typeScale.bodyMedium,
+    color: Colors.gray4,
+    textAlign: 'center',
     marginBottom: Spacing.Regular16,
+  },
+  spinner: {
+    marginTop: Spacing.Regular16,
   },
   contactInfo: {
     ...typeScale.bodySmall,
@@ -547,97 +534,44 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: Spacing.Regular16,
   },
-  alreadyClaimedContainer: {
-    alignItems: 'center',
-    paddingVertical: Spacing.Regular16,
+  detailRow: {
+    flexDirection: 'column',
+    gap: Spacing.Tiny4,
+    alignSelf: 'stretch',
+    marginBottom: Spacing.Regular16,
   },
-  alreadyClaimedCard: {
-    alignItems: 'center',
-    marginTop: Spacing.Large32,
+  detailLabel: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
   },
-  eligibleContainer: {
-    alignItems: 'center',
-    paddingVertical: Spacing.Regular16,
+  detailValue: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
   },
-  eligibleCard: {
-    alignItems: 'center',
+  detailValueLarge: {
+    ...typeScale.labelSemiBoldLarge,
+    color: Colors.black,
   },
-  congratsSection: {
-    alignItems: 'center',
-    marginTop: Spacing.Thick24,
-    marginBottom: Spacing.Large32,
-  },
-  congratsTitle: {
-    ...typeScale.titleLarge,
-    color: Colors.primary,
-    textAlign: 'center',
-    marginBottom: Spacing.Smallest8,
-  },
-  congratsSubtitle: {
-    ...typeScale.bodyLarge,
-    color: Colors.gray3,
-    textAlign: 'center',
+  detailValueMuted: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
   },
   benefitCard: {
-    backgroundColor: Colors.gray1,
+    backgroundColor: Colors.white,
     borderRadius: 12,
-    padding: Spacing.Thick24,
-    marginBottom: Spacing.Large32,
-    borderLeftWidth: 4,
-    borderLeftColor: Colors.primary,
-    ...getShadowStyle(Shadow.Soft),
+    padding: Spacing.Regular16,
+    marginBottom: Spacing.Regular16,
+    alignSelf: 'stretch',
+    gap: Spacing.Smallest8,
   },
   benefitTitle: {
     ...typeScale.titleSmall,
     color: Colors.primary,
-    marginBottom: Spacing.Smallest8,
   },
   benefitDescription: {
     ...typeScale.bodyMedium,
     color: Colors.gray6,
     lineHeight: 22,
-  },
-  claimInfoCard: {
-    backgroundColor: Colors.successLight,
-    borderRadius: 12,
-    padding: Spacing.Regular16,
-    marginBottom: Spacing.Regular16,
-    alignSelf: 'stretch',
-    borderLeftWidth: 4,
-    borderLeftColor: Colors.successDark,
-  },
-  claimInfoTitle: {
-    ...typeScale.labelSemiBoldSmall,
-    color: Colors.successDark,
-    marginBottom: Spacing.Tiny4,
-  },
-  claimInfoDate: {
-    ...typeScale.bodyMedium,
-    color: Colors.gray6,
-  },
-  nextClaimCard: {
-    backgroundColor: Colors.warningLight,
-    borderRadius: 12,
-    padding: Spacing.Regular16,
-    marginBottom: Spacing.Large32,
-    alignSelf: 'stretch',
-    borderLeftWidth: 4,
-    borderLeftColor: Colors.warningDark,
-  },
-  nextClaimTitle: {
-    ...typeScale.labelSemiBoldSmall,
-    color: Colors.warningDark,
-    marginBottom: Spacing.Tiny4,
-  },
-  nextClaimTime: {
-    ...typeScale.titleSmall,
-    color: Colors.gray6,
-    fontWeight: '600',
-    marginBottom: Spacing.Tiny4,
-  },
-  nextClaimDate: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
   },
   lastClaimInfo: {
     backgroundColor: Colors.gray1,
@@ -665,22 +599,5 @@ const styles = StyleSheet.create({
     color: Colors.primary,
     marginLeft: Spacing.Smallest8,
     fontWeight: '500',
-  },
-  debugContainer: {
-    backgroundColor: Colors.gray1,
-    borderRadius: 8,
-    padding: Spacing.Regular16,
-    marginTop: Spacing.Regular16,
-    alignSelf: 'stretch',
-  },
-  debugTitle: {
-    ...typeScale.labelSemiBoldSmall,
-    color: Colors.gray6,
-    marginBottom: Spacing.Smallest8,
-  },
-  debugText: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-    fontFamily: 'monospace',
   },
 })


### PR DESCRIPTION
## Summary

Single squashed commit that replaces PR #115 (which got tangled with #117 during rebase).

Applies the same visual chrome to every state of \`ReFiColombiaSubsidiesScreen\` (loading, error, notEligible, eligible, alreadyClaimed):

- All states wrap content in \`stateCard\` (gray1 bg, 16px radius, Soft shadow, 1px gray2 border)
- All states use the same \`iconContainer\` (120x120 successLight circle with Celebration 64px primary inside)
- All states use \`congratsTitle\` (labelLarge black) and \`congratsSubtitle\` (bodyMedium gray4)
- Drops left-accent border patterns and the inconsistent ad-hoc info cards
- alreadyClaimed details use canonical row layout (label/value/muted)

Also adds the reusable \`<DebugInfoPanel>\` component (\`src/components/DebugInfoPanel.tsx\`): a collapsible container that hides debug data behind a chevron toggle. Only renders in \`__DEV__\`. Replaces the four ad-hoc "Debug Info:" gray boxes that used to push diagnostic text in the user's face.

## Closes
- #115 (will close after this merges)

## Test plan
- [x] \`yarn build:ts\`
- [x] \`yarn lint\`
- [x] \`yarn test --testPathPattern=subsidies\` -- 11 passing