### PR TITLE
fix(celo): switch Celo viem client to Forno and improve RPC error UX

### DIFF
--- a/src/components/DebugInfoPanel.tsx
+++ b/src/components/DebugInfoPanel.tsx
@@ -1,24 +1,45 @@
+import Clipboard from '@react-native-clipboard/clipboard'
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
+import Share from 'react-native-share'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import Logger from 'src/utils/Logger'
+
+const TAG = 'components/DebugInfoPanel'
 
 interface Props {
   info: string
   label?: string
 }
 
-/**
- * Collapsible debug info panel rendered only in dev builds. Hidden by default;
- * tap the toggle row to expand. Use anywhere a screen wants to surface ad-hoc
- * diagnostic data without pushing it in the user's face.
- */
 export default function DebugInfoPanel({ info, label = 'Debug Info' }: Props) {
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
+  const [copied, setCopied] = useState(false)
 
   if (!__DEV__ || !info) {
     return null
+  }
+
+  const handleCopy = () => {
+    Clipboard.setString(info)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  const handleShare = async () => {
+    try {
+      await Share.open({
+        message: info,
+        subject: t('errors.sheet.shareSubject'),
+        failOnCancel: false,
+      })
+    } catch (error) {
+      Logger.warn(TAG, 'Share dismissed or failed', error)
+    }
   }
 
   return (
@@ -38,6 +59,16 @@ export default function DebugInfoPanel({ info, label = 'Debug Info' }: Props) {
           <Text style={styles.text} selectable>
             {info}
           </Text>
+          <View style={styles.buttonRow}>
+            <Pressable style={styles.button} onPress={handleCopy}>
+              <Text style={styles.buttonText}>
+                {copied ? t('errors.sheet.copyConfirmation') : t('errors.sheet.copyButton')}
+              </Text>
+            </Pressable>
+            <Pressable style={styles.button} onPress={handleShare}>
+              <Text style={styles.buttonText}>{t('errors.sheet.shareButton')}</Text>
+            </Pressable>
+          </View>
         </View>
       )}
     </View>
@@ -66,5 +97,23 @@ const styles = StyleSheet.create({
     ...typeScale.bodyXSmall,
     fontFamily: 'monospace',
     color: Colors.gray6,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: Spacing.Regular16,
+    gap: Spacing.Smallest8,
+  },
+  button: {
+    paddingHorizontal: Spacing.Regular16,
+    paddingVertical: Spacing.Smallest8,
+    borderRadius: 25,
+    borderWidth: 1,
+    borderColor: Colors.primary,
+  },
+  buttonText: {
+    ...typeScale.bodySmall,
+    color: Colors.primary,
+    fontWeight: '600',
   },
 })

--- a/src/subsidies/ReFiColombiaSubsidiesContract.ts
+++ b/src/subsidies/ReFiColombiaSubsidiesContract.ts
@@ -40,18 +40,15 @@ export class ReFiColombiaSubsidiesContract {
   }
 
   /**
-   * Verifica si el contrato está desplegado y funcionando
+   * Verifica si el contrato está desplegado.
+   * Lanza el error original de viem (URL, método, etc.) si el RPC falla,
+   * para evitar el mensaje engañoso "No contract deployed" cuando el problema es de red.
    */
   async isContractDeployed(): Promise<boolean> {
-    try {
-      const code = await this.client.getCode({ address: REFI_COLOMBIA_SUBSIDIES_ADDRESS })
-      const isDeployed = !!(code && code !== '0x')
-      Logger.debug(TAG, `Contract deployed: ${isDeployed}, code length: ${code?.length || 0}`)
-      return isDeployed
-    } catch (error) {
-      Logger.error(TAG, 'Error checking contract deployment', error)
-      return false
-    }
+    const code = await this.client.getCode({ address: REFI_COLOMBIA_SUBSIDIES_ADDRESS })
+    const isDeployed = !!(code && code !== '0x')
+    Logger.debug(TAG, `Contract deployed: ${isDeployed}, code length: ${code?.length || 0}`)
+    return isDeployed
   }
 
   /**

--- a/src/viem/index.ts
+++ b/src/viem/index.ts
@@ -4,6 +4,7 @@ import {
   ALCHEMY_ETHEREUM_API_KEY,
   ALCHEMY_OPTIMISM_API_KEY,
   ALCHEMY_POLYGON_POS_API_KEY,
+  DEFAULT_FORNO_URL,
 } from 'src/config'
 import { Network } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
@@ -12,16 +13,13 @@ import { PublicClient, Transport, createPublicClient, http } from 'viem'
 export const INTERNAL_RPC_SUPPORTED_NETWORKS = [Network.Arbitrum] as const
 
 export const viemTransports: Record<Network, Transport> = {
-  [Network.Celo]: http(
-    'https://celo-mainnet.core.chainstack.com/ebf11308d0727573a6abe298515f9fa9',
-    {
-      fetchOptions: {
-        headers: {
-          'Content-Type': 'application/json',
-        },
+  [Network.Celo]: http(DEFAULT_FORNO_URL, {
+    fetchOptions: {
+      headers: {
+        'Content-Type': 'application/json',
       },
-    }
-  ),
+    },
+  }),
   [Network.Ethereum]: http(networkConfig.alchemyRpcUrl[Network.Ethereum], {
     fetchOptions: {
       headers: {
@@ -66,7 +64,7 @@ export const appViemTransports = {
 export const publicClient = {
   [Network.Celo]: createPublicClient({
     chain: networkConfig.viemChain.celo,
-    transport: http('https://celo-mainnet.core.chainstack.com/ebf11308d0727573a6abe298515f9fa9', {
+    transport: http(DEFAULT_FORNO_URL, {
       fetchOptions: {
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

- Switch Celo viem client from Chainstack to Forno - the hardcoded Chainstack RPC was timing out / failing on mobile clients (verified on Android emulator; Forno responds in ~1s from the same network). Uses the existing `DEFAULT_FORNO_URL` constant so there is one source of truth.
- Stop swallowing RPC errors in `isContractDeployed`. Previously any network failure to `eth_getCode` returned `false`, which the caller interpreted as "contract not deployed" and threw a misleading error. Now viem's real error (URL, method, body, timeout) propagates up to the `ErrorMessage` sheet, which is much more useful for debugging from the field.
- Add Copy and Share buttons to `DebugInfoPanel` (mirroring `TechDetailsAccordion`) so users can hand the full debug payload to support directly from the screen.

## Context

Discovered while QA-ing the 1.118.3 release on emulator: the ReFi Colombia subsidies screen hung indefinitely on "Verificando tu elegibilidad..." then surfaced "No contract deployed at address 0x947c...4946". The contract is in fact deployed (verified on Celoscan); the real problem was that the Chainstack RPC was unreachable from the emulator and the error path was lying about the root cause.

## Test plan

- [x] yarn build:ts passes
- [x] yarn lint passes on changed files
- [x] Manual: Android emulator now hits Forno (verified in logcat: URL: https://forno.celo.org/) and the misleading "No contract deployed" message is replaced by the real viem HTTP error
- [ ] Manual: tap Copy / Share inside the expanded Debug Info panel to confirm clipboard + share sheet behave as in TechDetailsAccordion