### PR TITLE
fix(ios): bump CFBundleVersion in Info.plist to 253

### DIFF
--- a/ios/MobileStack/Info.plist
+++ b/ios/MobileStack/Info.plist
@@ -52,7 +52,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>252</string>
+	<string>253</string>
 	<key>CleverTapAccountID</key>
 	<string>$(CLEVERTAP_ACCOUNT_ID)</string>
 	<key>CleverTapToken</key>


### PR DESCRIPTION
## Summary

The 1.118.3 release bump (#121) updated `CURRENT_PROJECT_VERSION` in `project.pbxproj` from 252 to 253 but left the hardcoded `CFBundleVersion` in `MobileStack/Info.plist` at 252. Because the main target sets `INFOPLIST_FILE` without `GENERATE_INFOPLIST_FILE`, Xcode reads the literal plist value at archive time, so the just-produced .xcarchive came out labeled `1.118.3 (252)` -- which App Store Connect would reject as a duplicate build number against the already-shipped `1.118.2 (252)`.

Aligning the plist to 253 unblocks the iOS submission. Android is unaffected.

## Test plan

- [x] `Info.plist` `CFBundleVersion` now reads `253`
- [ ] Re-archive `MobileStack-mainnet` and confirm Organizer shows `1.118.3 (253)` before upload