### PR TITLE
fix(transactions): wrap TransactionSuccessScreen in SafeAreaView (BUG-001)

### DIFF
--- a/src/transactions/TransactionSuccessScreen.tsx
+++ b/src/transactions/TransactionSuccessScreen.tsx
@@ -2,6 +2,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import Button from 'src/components/Button'
 import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
@@ -95,7 +96,7 @@ function TransactionSuccessScreen({ route }: Props) {
   }
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView edges={['top', 'bottom']} style={styles.container}>
       <View style={styles.content}>
         <View style={styles.iconContainer}>
           <Celebration size={64} color={colors.primary} />
@@ -191,7 +192,7 @@ function TransactionSuccessScreen({ route }: Props) {
           testID="TransactionSuccess/Continue"
         />
       </View>
-    </View>
+    </SafeAreaView>
   )
 }
 


### PR DESCRIPTION
## Summary

Fixes **BUG-001** in `docs/KNOWN_ISSUES.md`: the Continue button in the gold-buy success screen renders behind the bottom system inset on Infinix Note 30 Pro (XOS V14, Android 14). Combined with `noHeaderGestureDisabled` (no header back, no swipe-back), users have no way out of the screen and have to force-close the app.

## Change

`src/transactions/TransactionSuccessScreen.tsx`:
- Import `SafeAreaView` from `react-native-safe-area-context`.
- Replace the root `<View style={styles.container}>` with `<SafeAreaView edges={['top', 'bottom']} style={styles.container}>`.

Same pattern already used by `JumpstartShareLink`, `AccountSetupFailureScreen`, `CashInSuccess` — all other no-header success screens.

## Scope

Applies to every transaction type that lands on this screen — `swap`, `send`, `goldBuy`, `goldSell`, `earnDeposit`, `earnWithdraw`, `earnClaim`. Reported originally on `goldBuy` but the others may have been silently affected on the same OEM skins.

## Test plan

- [x] `yarn build:ts` passes
- [ ] Manual: trigger a gold buy on Infinix Note 30 Pro and confirm Continue button is now visible and tappable above the gesture bar
- [ ] Manual: smoke-test the same screen for send / swap / earnDeposit on the same device (button still tappable; no layout regression)