### PR TITLE
chore(ci): only run Vulnerabilities + Knip Regression on main-bound PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,12 @@ jobs:
   vulnerability:
     name: Vulnerabilities
     runs-on: ubuntu-latest
+    # Only block release-quality flows (main PRs, merge queue, cron, manual).
+    # On Development PRs new transitive CVEs land daily and aren't authored by
+    # the PR — skip the gate so day-to-day work isn't blocked. The same scan
+    # still runs on the daily schedule and on the PR to main when we cut a
+    # release, so nothing slips into production unchecked.
+    if: github.event_name != 'pull_request' || github.base_ref == 'main'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/yarn-install
@@ -61,6 +67,11 @@ jobs:
   knip-regression:
     name: Knip Regression
     runs-on: ubuntu-latest
+    # Release-quality concern: prevents unused exports / dead files from
+    # piling up between releases. Runs on PRs to main, merge queue, cron,
+    # and manual dispatch. Skipped on Development PRs so adding a single
+    # legitimate export (e.g. a new component's type) doesn't block work.
+    if: github.event_name != 'pull_request' || github.base_ref == 'main'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

PRs targeting Development have been getting blocked by two checks that trigger on signals not authored by the PR:

- **Vulnerabilities** (`yarn audit --level high`) fails any time a new CVE lands in a transitive dep we don't control. CVE-2026-44705 in `tmp` landed 2026-05-27 and broke every open PR overnight.
- **Knip Regression** fails any time a PR introduces a single new exported type/file, even when the export is intentional and immediately used inside the same PR (e.g. `StateVariant` from the new StateCard component).

Both checks remain valuable as **release gates**, so they keep running on:

- PRs targeting `main` (release-quality)
- `merge_group` (final gate before merging into main)
- `schedule` (daily cron at 8:30 pm)
- `workflow_dispatch` (manual run)

Skipping them on `pull_request` events whose `base_ref` is `Development` removes the noise from day-to-day work without lowering the bar on anything that actually ships.

## What stays running on every Development PR

| Check | Why |
|---|---|
| Lint | catches obvious code-quality issues in the PR's own diff |
| yarn.lock Up-to-date | prevents lockfile drift |
| Licenses | OSS compliance |
| Dependencies (knip-depcheck) | dead deps in package.json |
| Mobile Tests | unit-test regressions in the PR's own changes |
| Semantic PR title | conventional-commit hygiene |

## Change

```yaml
if: github.event_name != 'pull_request' || github.base_ref == 'main'
```

Added to the `vulnerability` and `knip-regression` jobs in `.github/workflows/check.yml`.

## Test plan

- [x] Manual diff review of the workflow file
- [ ] After merge: open the next PR to Development and verify neither check runs in the PR view, while Lint / Mobile / etc. still run
- [ ] When we cut release/1.118.5 to main: confirm both checks fire on that PR