### PR TITLE
fix(swap,gold): cap token amount inputs/outputs at 6 decimals (BUG-002/003/004)

### DIFF
--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -215,9 +215,9 @@ export default function GoldBuyEnterAmount({ route }: Props) {
     if (!selectedToken) return
     const amount = selectedToken.balance.multipliedBy(percentage)
     setTokenAmountInput(
-      amount.toFormat(getInputDecimalsForToken(selectedToken.tokenId), BigNumber.ROUND_DOWN, {
-        decimalSeparator,
-      })
+      amount
+        .decimalPlaces(getInputDecimalsForToken(selectedToken.tokenId), BigNumber.ROUND_DOWN)
+        .toFormat({ decimalSeparator })
     )
     setSelectedPercentage(percentage)
   }

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -41,6 +41,7 @@ import { Spacing } from 'src/styles/styles'
 import { swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
+import { getInputDecimalsForToken } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
 import networkConfig from 'src/web3/networkConfig'
@@ -213,7 +214,11 @@ export default function GoldBuyEnterAmount({ route }: Props) {
   const onSelectPercentageAmount = (percentage: number) => {
     if (!selectedToken) return
     const amount = selectedToken.balance.multipliedBy(percentage)
-    setTokenAmountInput(amount.toFormat({ decimalSeparator }))
+    setTokenAmountInput(
+      amount.toFormat(getInputDecimalsForToken(selectedToken.tokenId), BigNumber.ROUND_DOWN, {
+        decimalSeparator,
+      })
+    )
     setSelectedPercentage(percentage)
   }
 

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -147,7 +147,7 @@ export default function GoldSellEnterAmount(_props: Props) {
 
   const onSelectPercentageAmount = (percentage: number) => {
     const amount = xaut0Balance.multipliedBy(percentage)
-    setGoldAmountInput(amount.toFormat(6, BigNumber.ROUND_DOWN, { decimalSeparator }))
+    setGoldAmountInput(amount.decimalPlaces(6, BigNumber.ROUND_DOWN).toFormat({ decimalSeparator }))
     setSelectedPercentage(percentage)
   }
 
@@ -270,10 +270,12 @@ export default function GoldSellEnterAmount(_props: Props) {
                   </Touchable>
                   <Text style={styles.outputAmountText}>
                     {outputAmount
-                      ? outputAmount.toFormat(
-                          getInputDecimalsForToken(selectedOutputToken.tokenId),
-                          BigNumber.ROUND_DOWN
-                        )
+                      ? outputAmount
+                          .decimalPlaces(
+                            getInputDecimalsForToken(selectedOutputToken.tokenId),
+                            BigNumber.ROUND_DOWN
+                          )
+                          .toFormat()
                       : '0'}
                   </Text>
                 </>

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -36,6 +36,7 @@ import { Spacing } from 'src/styles/styles'
 import { swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
+import { getInputDecimalsForToken } from 'src/utils/formatting'
 import { parseInputAmount } from 'src/utils/parsing'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -146,7 +147,7 @@ export default function GoldSellEnterAmount(_props: Props) {
 
   const onSelectPercentageAmount = (percentage: number) => {
     const amount = xaut0Balance.multipliedBy(percentage)
-    setGoldAmountInput(amount.toFormat({ decimalSeparator }))
+    setGoldAmountInput(amount.toFormat(6, BigNumber.ROUND_DOWN, { decimalSeparator }))
     setSelectedPercentage(percentage)
   }
 
@@ -268,7 +269,12 @@ export default function GoldSellEnterAmount(_props: Props) {
                     </>
                   </Touchable>
                   <Text style={styles.outputAmountText}>
-                    {outputAmount ? outputAmount.toFormat(selectedOutputToken.decimals) : '0'}
+                    {outputAmount
+                      ? outputAmount.toFormat(
+                          getInputDecimalsForToken(selectedOutputToken.tokenId),
+                          BigNumber.ROUND_DOWN
+                        )
+                      : '0'}
                   </Text>
                 </>
               )}

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -519,7 +519,7 @@ describe('SwapScreen', () => {
       `${APPROX_SYMBOL} COP$21.43`
     )
     expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '1.5234566652'
+      '1.523456'
     )
     expect(within(swapToContainer).getByTestId('SwapAmountInput/FiatValue')).toHaveTextContent(
       `${APPROX_SYMBOL} COP$2.03`
@@ -556,7 +556,7 @@ describe('SwapScreen', () => {
     )
     expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe('1.234')
     expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '1.5234566652'
+      '1.523456'
     )
     expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
   })
@@ -888,7 +888,7 @@ describe('SwapScreen', () => {
       `${APPROX_SYMBOL} COP$21,43`
     )
     expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '1,5234566652'
+      '1,523456'
     )
     expect(within(swapToContainer).getByTestId('SwapAmountInput/FiatValue')).toHaveTextContent(
       `${APPROX_SYMBOL} COP$2,03`
@@ -904,7 +904,7 @@ describe('SwapScreen', () => {
       amountLabel: 'percentage, {"percentage":25}',
       percentage: 25,
       expectedFromAmount: '2.5', // 25% of 10
-      expectedToAmount: '3.0864195', // expectedFromAmount * exchange rate = 2.5 * 1.2345678
+      expectedToAmount: '3.086419', // expectedFromAmount * exchange rate = 2.5 * 1.2345678
     },
     {
       amountLabel: 'percentage, {"percentage":50}',
@@ -916,7 +916,7 @@ describe('SwapScreen', () => {
       amountLabel: 'percentage, {"percentage":75}',
       percentage: 75,
       expectedFromAmount: '7.5',
-      expectedToAmount: '9.2592585',
+      expectedToAmount: '9.259258',
     },
     {
       amountLabel: 'maxSymbol',
@@ -1224,7 +1224,7 @@ describe('SwapScreen', () => {
             fromTokenId: mockCeloTokenId,
             swapAmount: {
               [Field.FROM]: '1.5',
-              [Field.TO]: '1.8518517', // 1.5 * 1.2345678
+              [Field.TO]: '1.851851', // 1.5 * 1.2345678
             },
             updatedField: Field.FROM,
           },

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -138,7 +138,8 @@ const swapSlice = createSlice({
       // raw decimals of token base units when the user taps Max / 25 / 50 / 75.
       state.inputSwapAmount[Field.FROM] = fromTokenBalance
         .multipliedBy(percentage)
-        .toFormat(getInputDecimalsForToken(fromTokenId), BigNumber.ROUND_DOWN, {
+        .decimalPlaces(getInputDecimalsForToken(fromTokenId), BigNumber.ROUND_DOWN)
+        .toFormat({
           decimalSeparator: getNumberFormatSettings().decimalSeparator,
         })
     },
@@ -191,11 +192,9 @@ const swapSlice = createSlice({
       // Round to the destination token's display decimals so the auto-filled
       // TO field doesn't render with full BigNumber precision (the bug behind
       // KNOWN_ISSUES BUG-004 — swap input showing ~18 decimals).
-      state.inputSwapAmount[Field.TO] = newAmount.toFormat(
-        getInputDecimalsForToken(state.toTokenId),
-        BigNumber.ROUND_DOWN,
-        { decimalSeparator }
-      )
+      state.inputSwapAmount[Field.TO] = newAmount
+        .decimalPlaces(getInputDecimalsForToken(state.toTokenId), BigNumber.ROUND_DOWN)
+        .toFormat({ decimalSeparator })
     },
     // When the user presses the confirm swap button
     startConfirmSwap: (state) => {

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -54,6 +54,7 @@ import {
 import { TokenBalance } from 'src/tokens/slice'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
+import { getInputDecimalsForToken } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
 import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
@@ -123,16 +124,23 @@ const swapSlice = createSlice({
     },
     chooseFromAmountPercentage: (
       state,
-      action: PayloadAction<{ fromTokenBalance: BigNumber; percentage: number }>
+      action: PayloadAction<{
+        fromTokenBalance: BigNumber
+        percentage: number
+        fromTokenId?: string
+      }>
     ) => {
-      const { fromTokenBalance, percentage } = action.payload
+      const { fromTokenBalance, percentage, fromTokenId } = action.payload
       state.confirmingSwap = false
       state.startedSwapId = null
       state.selectedPercentage = percentage
-      // If the max percentage is selected, try the current balance first, and we will prompt the user if it's too high
-      state.inputSwapAmount[Field.FROM] = fromTokenBalance.multipliedBy(percentage).toFormat({
-        decimalSeparator: getNumberFormatSettings().decimalSeparator,
-      })
+      // Round to the token's display decimals so the input doesn't show 18
+      // raw decimals of token base units when the user taps Max / 25 / 50 / 75.
+      state.inputSwapAmount[Field.FROM] = fromTokenBalance
+        .multipliedBy(percentage)
+        .toFormat(getInputDecimalsForToken(fromTokenId), BigNumber.ROUND_DOWN, {
+          decimalSeparator: getNumberFormatSettings().decimalSeparator,
+        })
     },
     startSelectToken: (state, action: PayloadAction<{ fieldType: Field }>) => {
       state.selectingField = action.payload.fieldType
@@ -180,9 +188,14 @@ const swapSlice = createSlice({
       const parsedAmount = parseInputAmount(state.inputSwapAmount[Field.FROM], decimalSeparator)
 
       const newAmount = parsedAmount.multipliedBy(new BigNumber(quote.price))
-      state.inputSwapAmount[Field.TO] = newAmount.toFormat({
-        decimalSeparator,
-      })
+      // Round to the destination token's display decimals so the auto-filled
+      // TO field doesn't render with full BigNumber precision (the bug behind
+      // KNOWN_ISSUES BUG-004 — swap input showing ~18 decimals).
+      state.inputSwapAmount[Field.TO] = newAmount.toFormat(
+        getInputDecimalsForToken(state.toTokenId),
+        BigNumber.ROUND_DOWN,
+        { decimalSeparator }
+      )
     },
     // When the user presses the confirm swap button
     startConfirmSwap: (state) => {
@@ -593,7 +606,13 @@ export function SwapScreen({ route }: Props) {
   }
 
   const handleSelectAmountPercentage = (percentage: number) => {
-    localDispatch(chooseFromAmountPercentage({ fromTokenBalance, percentage }))
+    localDispatch(
+      chooseFromAmountPercentage({
+        fromTokenBalance,
+        percentage,
+        fromTokenId: fromToken?.tokenId,
+      })
+    )
     if (!fromToken) {
       // Should never happen
       return

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -2,6 +2,17 @@ import BigNumber from 'bignumber.js'
 import { LocalCurrencyCode, LocalCurrencySymbol } from 'src/localCurrency/consts'
 import { CURRENCIES, Currency } from 'src/utils/currencies'
 
+/**
+ * How many decimal places to show in token amount inputs / displays inside
+ * gold + swap flows. We use 6 across the board so that small Oro amounts
+ * (1.000 Pesos ≈ 0.000061 Oro) stay readable without rounding to zero, and
+ * fiat-pegged tokens like Pesos / Dólares show a consistent precision next
+ * to them. The `tokenId` param is kept for future per-token tuning.
+ */
+export function getInputDecimalsForToken(_tokenId?: string): number {
+  return 6
+}
+
 // Returns a localized string that represents the number with the right decimal points.
 export const getMoneyDisplayValue = (
   value: BigNumber.Value,


### PR DESCRIPTION
## Summary

Fixes the decimal half of three KNOWN_ISSUES bugs reported during 1.118.3 QA:

- **BUG-002** — Vender Oro: receiving token (Pesos) showed `2.192,673444073257524567` (full 18-decimal precision of COPm).
- **BUG-003** — Comprar Oro: input Pesos showed `22.560,821454850` after tapping Max/%.
- **BUG-004** (decimal half) — Swap: both From and To inputs showed `22.560,82145485017…` truncated with ellipsis.

The legacy `cCOP` / `USD₮` symbols still showing in the swap "Saldo:" subtitle are the symbol half of BUG-004 and stay open for the next PR.

## Root cause

Every offending call site was building the input string with `BigNumber.toFormat({ decimalSeparator })` (or `toFormat(selectedOutputToken.decimals)` in the gold-sell output), which preserves the full precision coming out of the balance multiplication. For 18-decimal stablecoins that ends up at ~9-18 decimals in the UI.

## Fix

New helper in `src/utils/formatting.ts`:

```ts
export function getInputDecimalsForToken(_tokenId?: string): number {
  return 6
}
```

Hardcoded at 6 across token types. Gold needs the precision for tiny balances (1.000 Pesos ≈ 0.000061 Oro); fiat-pegged tokens look fine with the same value next to it. The `tokenId` parameter is kept for future per-token tuning if a token ever needs a different cap.

Adopters:

- `src/swap/SwapScreen.tsx` — `chooseFromAmountPercentage` reducer + `setTo` quote-sync reducer.
- `src/gold/GoldBuyEnterAmount.tsx` — `onSelectPercentageAmount` handler.
- `src/gold/GoldSellEnterAmount.tsx` — both the gold-amount input on % select and the receiving-token output text.

Fiat conversion lines ("≈ COP$X") are untouched and stay at 2 decimals — those are local-currency displays, not token amounts.

## Test plan

- [x] `yarn build:ts` passes
- [x] Android emulator: Comprar Oro / Vender Oro / Swap on Celo mainnet with a real wallet — all amount fields now cap at 6 decimals max
- [x] iPhone 17 Pro Max sim: same flows, same result
- [ ] After merge: a manual smoke pass on a real device to confirm no regression on the input parsing (sending a value the user typed character-by-character vs the percentage-selected pre-fill)