### PR TITLE
fix(swap): use display name (Pesos/Dólares/Oro) in balance subtitle (BUG-004)

### DIFF
--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -89,7 +89,8 @@ const SwapAmountInput = ({
                 <Text style={styles.tokenName}>{getTokenSymbol(t, token.symbol)}</Text>
                 {showBalance && token.balance && (
                   <Text style={styles.tokenBalance}>
-                    {t('swapScreen.balance')}: {token.balance.toFormat(2)} {token.symbol}
+                    {t('swapScreen.balance')}: {token.balance.toFormat(2)}{' '}
+                    {getTokenSymbol(t, token.symbol, token.tokenId)}
                   </Text>
                 )}
               </View>


### PR DESCRIPTION
## Summary

Closes the symbol half of **BUG-004** in `docs/KNOWN_ISSUES.md`.

The "Saldo:" subtitle under each swap token selector was rendering the on-chain symbol raw:

- `Saldo: 22.560,82 cCOP`
- `Saldo: 1,22 USD₮`

The rest of the swap screen (token names, success screens, transaction feed) already maps these to `Pesos` / `Dólares` / `Oro` via the existing `getTokenSymbol(t, symbol, tokenId)` helper exported from `src/components/TokenDisplay.tsx`. The balance subtitle was the only holdout.

## Change

One line in `src/swap/SwapAmountInput.tsx` — pipe `token.symbol` + `token.tokenId` through `getTokenSymbol`. The helper is already imported in this file.

```diff
-{t('swapScreen.balance')}: {token.balance.toFormat(2)} {token.symbol}
+{t('swapScreen.balance')}: {token.balance.toFormat(2)}{' '}
+{getTokenSymbol(t, token.symbol, token.tokenId)}
```

## Test plan

- [x] `yarn build:ts` passes
- [x] `yarn test --testPathPattern="SwapScreen"` — 51/51 pass
- [x] Manual: Swap screen on Android emulator + iPhone 17 Pro Max sim — subtitle now reads `Saldo: <amount> Pesos` / `Saldo: <amount> Dólares` for COPm / USDT respectively