### PR TITLE
chore(ci): speed up Mobile job on Development PRs (~6 min → ~2-3 min)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,24 +23,41 @@ jobs:
   mobile:
     name: Mobile
     runs-on: ubuntu-latest
+    env:
+      # On Development PRs, skip the slow Metro bundle build + Jest coverage
+      # report. Both are kept for main-bound PRs / merge queue / pushes so
+      # release-quality runs still validate bundling and ship a coverage
+      # report. This cuts the dev-PR Mobile job from ~6 min to ~2-3 min.
+      IS_DEV_PR: ${{ github.event_name == 'pull_request' && github.base_ref == 'Development' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/yarn-install
-      - name: Build
-        run: yarn build
+      - name: Typecheck
+        run: yarn build:ts
+      - name: Build (TS + Metro bundle)
+        if: env.IS_DEV_PR != 'true'
+        run: yarn build:metro
       - name: Update RootStateSchema if necessary
         run: yarn test:update-root-state-schema
       - name: Fail if someone forgot to commit "RootStateSchema.json"
         run: git diff --exit-code
-      - name: Run mobile tests
+      - name: Run mobile tests (with coverage)
+        if: env.IS_DEV_PR != 'true'
         run: |
           mkdir -p test-results/jest
           yarn test:ci
+      - name: Run mobile tests (fast, no coverage)
+        if: env.IS_DEV_PR == 'true'
+        run: |
+          mkdir -p test-results/jest
+          yarn test --maxWorkers=50%
       - name: Upload Coverage Report
+        if: env.IS_DEV_PR != 'true'
         uses: actions/upload-artifact@v4
         with:
           path: coverage/lcov-report
       - name: 'Upload to Codecov'
+        if: env.IS_DEV_PR != 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

The Mobile job was running the full release-quality test pipeline on every Development PR — ~6 min per run for things that aren't load-bearing on day-to-day work.

This PR splits the heavy work to only run on **main-bound PRs / merge_group / push**, and keeps Development PRs lean: typecheck + unit tests (no coverage, no Metro bundle, no Codecov upload).

## What stays on every PR (including Development)

| Step | Why |
|---|---|
| `yarn install` | always |
| `yarn build:ts` (typecheck) | catches TS errors in the PR's diff (~10 s) |
| `yarn test:update-root-state-schema` + `git diff --exit-code` | catches forgotten schema commits |
| `jest` (3919 tests) | catches real regressions in the PR's diff |

## What only runs on main / merge_group / push

| Step | Why dropped on dev |
|---|---|
| `yarn build:metro` (bundle then delete) | ~1-2 min validation of bundling — release-quality concern |
| `--coverage` flag on Jest | ~1.5 min added; not needed unless we're tracking trends |
| Upload coverage artifact | only useful with coverage |
| Codecov upload | trend tracker for shipped code |

## Other tweak

Jest workers go from a fixed `--maxWorkers=3` to `--maxWorkers=50%` on the dev path so we use whatever the GitHub runner gives us.

## Expected impact

`6 min → 2-3 min` per Development PR. Release-quality runs (PRs to `main`, merges into `main`, pushes to `main` / `Development`) untouched — same coverage, same bundling check, same Codecov upload.

## Test plan

- [x] YAML diff reviewed
- [ ] After merge: open the next PR to Development and confirm the Mobile job shows ~2-3 min and skips the "Build (TS + Metro bundle)" / "Upload Coverage Report" / "Upload to Codecov" steps
- [ ] When we cut release/1.118.5 to main: confirm the full pipeline (Metro bundle + coverage + Codecov) runs on that PR