### PR TITLE
fix(earn): ungate Allbridge partial withdraw and clarify auto-claim UX

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2698,6 +2698,7 @@
       "fee": "Gas Fee",
       "cta": "Collect Earnings",
       "ctaWithdraw": "Withdraw",
+      "ctaWithdrawAndClaim": "Withdraw and claim",
       "ctaReward": "Claim Reward",
       "ctaExit": "Exit Pool",
       "errorTitle": "Something went wrong",

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -2690,6 +2690,7 @@
       "fee": "Gas Fee",
       "cta": "Collect Earnings",
       "ctaWithdraw": "Withdraw",
+      "ctaWithdrawAndClaim": "Withdraw and claim",
       "ctaReward": "Claim Reward",
       "ctaExit": "Exit Pool",
       "errorTitle": "Something went wrong",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2700,6 +2700,7 @@
       "fee": "Tarifa estimada",
       "cta": "Recoger ganancias",
       "ctaWithdraw": "Retirar",
+      "ctaWithdrawAndClaim": "Retirar y reclamar",
       "ctaReward": "Reclamar recompensa",
       "ctaExit": "Retirar todo",
       "errorTitle": "Algo salió mal",

--- a/src/earn/EarnConfirmationScreen.tsx
+++ b/src/earn/EarnConfirmationScreen.tsx
@@ -130,6 +130,9 @@ export default function EarnConfirmationScreen({ route }: Props) {
     prepareTransactionsResult?.type !== 'possible' ||
     withdrawStatus === 'loading'
 
+  const showWithdrawAndClaimNotice =
+    mode === 'withdraw' && pool.dataProps.withdrawalIncludesClaim && rewardsTokens.length > 0
+
   const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
 
   let feeSection = <GasFeeLoading />
@@ -149,6 +152,17 @@ export default function EarnConfirmationScreen({ route }: Props) {
     <SafeAreaView style={styles.container}>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <Title mode={mode} />
+        {showWithdrawAndClaimNotice && (
+          <InLineNotification
+            variant={NotificationVariant.Info}
+            title={t('earnFlow.enterAmount.withdrawingAndClaimingCard.title')}
+            description={t('earnFlow.enterAmount.withdrawingAndClaimingCard.description', {
+              providerName: pool.appName,
+            })}
+            style={styles.notice}
+            testID="EarnConfirmation/WithdrawAndClaimNotice"
+          />
+        )}
         <View style={styles.collectInfoContainer}>
           {mode !== 'claim-rewards' && (
             <CollectItem
@@ -220,7 +234,9 @@ export default function EarnConfirmationScreen({ route }: Props) {
         size={BtnSizes.FULL}
         text={
           mode === 'withdraw'
-            ? t('earnFlow.collect.ctaWithdraw')
+            ? showWithdrawAndClaimNotice
+              ? t('earnFlow.collect.ctaWithdrawAndClaim')
+              : t('earnFlow.collect.ctaWithdraw')
             : mode === 'exit'
               ? t('earnFlow.collect.ctaExit')
               : t('earnFlow.collect.ctaReward')
@@ -400,6 +416,9 @@ const styles = StyleSheet.create({
   },
   error: {
     marginTop: Spacing.Regular16,
+  },
+  notice: {
+    marginBottom: Spacing.Regular16,
   },
   gasFeeCryptoLoading: {
     width: 80,

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -44,6 +44,7 @@ import { SwapTransaction } from 'src/swap/types'
 import { useLocalToTokenAmount, useTokenInfo, useTokenToLocalAmount } from 'src/tokens/hooks'
 import { feeCurrenciesSelector, swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
+import { getInputDecimalsForToken } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
 import { getFeeCurrencyAndAmounts, PreparedTransactionsResult } from 'src/viem/prepareTransactions'
@@ -343,7 +344,12 @@ function EarnEnterAmount({ route }: Props) {
   }
 
   const onSelectPercentageAmount = (percentage: number) => {
-    setTokenAmountInput(balanceInInputToken.multipliedBy(percentage).toFormat({ decimalSeparator }))
+    setTokenAmountInput(
+      balanceInInputToken
+        .multipliedBy(percentage)
+        .decimalPlaces(getInputDecimalsForToken(inputToken.tokenId), BigNumber.ROUND_DOWN)
+        .toFormat({ decimalSeparator })
+    )
     setEnteredIn('token')
     setSelectedPercentage(percentage)
 

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.test.tsx
@@ -643,36 +643,6 @@ describe('EarnPoolInfoScreen', () => {
     expect(getByTestId('Earn/ActionCard/Transfer')).toBeTruthy()
   })
 
-  it('navigate to EarnConfirmationScreen when Withdraw button is tapped, no rewards and cannot partial withdraw', () => {
-    jest
-      .mocked(getFeatureGate)
-      .mockImplementation(
-        (gateName: StatsigFeatureGates) => gateName === StatsigFeatureGates.SHOW_POSITIONS
-      )
-    const { getByTestId } = render(
-      <Provider store={getStore({ includeRewardPositions: false })}>
-        <MockedNavigator
-          component={EarnPoolInfoScreen}
-          params={{
-            pool: { ...mockEarnPositions[0], balance: '100' },
-          }}
-        />
-      </Provider>
-    )
-    fireEvent.press(getByTestId('WithdrawButton'))
-    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_tap_withdraw, {
-      providerId: 'aave',
-      poolId: 'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216',
-      poolAmount: '100',
-      networkId: 'arbitrum-sepolia',
-      depositTokenId: mockEarnPositions[0].dataProps.depositTokenId,
-    })
-    expect(navigate).toHaveBeenCalledWith(Screens.EarnConfirmationScreen, {
-      pool: { ...mockEarnPositions[0], balance: '100' },
-      mode: 'exit',
-      useMax: true,
-    })
-  })
   it('open WithdrawBottomSheet when Withdraw button pressed, check that expected options exist', () => {
     jest
       .mocked(getFeatureGate)

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
@@ -41,8 +41,6 @@ import { positionsWithBalanceSelector } from 'src/positions/selectors'
 import { EarnPosition } from 'src/positions/types'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -239,14 +237,12 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
       networkId,
       depositTokenId: dataProps.depositTokenId,
     })
-    const partialWithdrawalsEnabled = getFeatureGate(
-      StatsigFeatureGates.ALLOW_EARN_PARTIAL_WITHDRAWAL
-    )
-    if (partialWithdrawalsEnabled) {
-      withdrawBottomSheetRef.current?.snapToIndex(0)
-    } else {
-      navigate(Screens.EarnConfirmationScreen, { pool, mode: 'exit', useMax: true })
-    }
+    // Always open the withdraw bottom sheet so the user gets the partial-
+    // withdraw option (with 25/50/75/100 percent buttons in EarnEnterAmount)
+    // instead of being pushed straight to "Retirar todo". The previous
+    // Statsig-gated path defaulted to false for new clients and confused
+    // every Allbridge pool user (BUG-005 in KNOWN_ISSUES).
+    withdrawBottomSheetRef.current?.snapToIndex(0)
   }
 
   const onPressDeposit = () => {


### PR DESCRIPTION
## Summary

Fixes **BUG-005** from 1.118.3 QA: the partial-withdraw flow on the Allbridge pool was a dead end (Statsig gate defaulted off in prod) and, once unlocked, the confirmation screen did not make it obvious that signing the tx would also claim all pending rewards atomically.

## Changes

- **Ungate the flow.** Remove the `ALLOW_EARN_PARTIAL_WITHDRAWAL` Statsig check in `EarnPoolInfoScreen.onPressWithdraw`. The Withdraw button now always opens the bottom sheet with partial / claim / exit options.
- **Decimal cap on percentage picker.** `onSelectPercentageAmount` in `EarnEnterAmount` now caps to 6 decimals via `BigNumber.decimalPlaces(getInputDecimalsForToken(...), ROUND_DOWN)`. Same pattern as PR #128.
- **Confirmation-screen banner + CTA.** When `mode === 'withdraw' && pool.dataProps.withdrawalIncludesClaim && rewardsTokens.length > 0`:
  - New \`InLineNotification\` (Info variant) above the collect card, reusing the existing \`earnFlow.enterAmount.withdrawingAndClaimingCard.{title,description}\` copy ("Retirar y reclamar" / "Allbridge requiere que reclames todas las recompensas disponibles cuando hagas retiros").
  - CTA text swaps from \`ctaWithdraw\` ("Retirar") to new \`ctaWithdrawAndClaim\` ("Retirar y reclamar").
- Deleted obsolete test asserting the gate-disabled branch.

## Why reuse the existing copy

The same banner already shows in \`EarnEnterAmount\` for the same condition. Mirroring it on the confirmation screen keeps the message identical at both decision points (amount entry + signing), no translation drift, and the new CTA text reinforces the dual action right at the moment of signing.

## Test plan

- [x] \`yarn build:ts\`
- [x] \`yarn lint <changed files>\`
- [x] \`yarn test --testPathPattern="src/earn"\` - 17 suites, 160 tests pass
- [ ] **Manual smoke (deferred - no test device available right now):**
  - Open Allbridge pool with pending rewards -> tap Retirar -> bottom sheet opens (was previously a dead end)
  - Enter a percentage (25/50/75/100) -> amount shows max 6 decimals
  - Continue to confirmation -> Info banner visible above the card + CTA reads "Retirar y reclamar"
  - Sign -> tx succeeds, rewards arrive in same block