### PR TITLE
chore(design-system): adopt StateCard in 6 more screens (Phase 2)

### DIFF
--- a/src/account/AccountErrorScreen.tsx
+++ b/src/account/AccountErrorScreen.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { StyleSheet, Text } from 'react-native'
+import { ScrollView, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import TextButton from 'src/components/TextButton'
-import { typeScale } from 'src/styles/fonts'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import StateCard from 'src/components/StateCard'
+import StickyCtaBottom from 'src/components/StickyCtaBottom'
 import { Spacing } from 'src/styles/styles'
 
 interface Props {
@@ -25,47 +26,44 @@ function AccountErrorScreen({
   onPressSecondary,
 }: Props) {
   return (
-    <SafeAreaView style={styles.content}>
-      <Text style={styles.title} testID={testID}>
-        {title}
-      </Text>
-      <Text style={styles.body}>{description}</Text>
-      <TextButton onPress={onPress} testID={`${testID}Button`}>
-        {buttonLabel}
-      </TextButton>
-      {!!secondaryButtonLabel && onPressSecondary && (
-        <TextButton
-          style={styles.secondaryButton}
-          onPress={onPressSecondary}
-          testID={`${testID}ButtonSecondary`}
-        >
-          {secondaryButtonLabel}
-        </TextButton>
-      )}
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <StateCard variant="error" title={title} subtitle={description} testID={testID} />
+      </ScrollView>
+      <StickyCtaBottom>
+        <Button
+          onPress={onPress}
+          text={buttonLabel}
+          type={BtnTypes.PRIMARY}
+          size={BtnSizes.FULL}
+          testID={`${testID}Button`}
+        />
+        {!!secondaryButtonLabel && onPressSecondary && (
+          <Button
+            style={styles.secondaryButton}
+            onPress={onPressSecondary}
+            text={secondaryButtonLabel}
+            type={BtnTypes.SECONDARY}
+            size={BtnSizes.FULL}
+            testID={`${testID}ButtonSecondary`}
+          />
+        )}
+      </StickyCtaBottom>
     </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
-  content: {
+  container: {
     flex: 1,
-    marginHorizontal: Spacing.Thick24,
+  },
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
-    alignItems: 'center',
-  },
-  title: {
-    ...typeScale.titleSmall,
-    textAlign: 'center',
-    paddingBottom: Spacing.Regular16,
-    paddingTop: Spacing.Regular16,
-  },
-  body: {
-    ...typeScale.bodyMedium,
-    textAlign: 'center',
-    paddingBottom: Spacing.Thick24,
+    paddingHorizontal: Spacing.Regular16,
   },
   secondaryButton: {
-    paddingTop: Spacing.Thick24,
+    marginTop: Spacing.Smallest8,
   },
 })
 

--- a/src/backup/BackupComplete.tsx
+++ b/src/backup/BackupComplete.tsx
@@ -1,23 +1,21 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { OnboardingEvents } from 'src/analytics/Events'
-import AppAnalytics from 'src/analytics/AppAnalytics'
 import { backupCompletedSelector } from 'src/account/selectors'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { OnboardingEvents } from 'src/analytics/Events'
+import StateCard from 'src/components/StateCard'
 import Checkmark from 'src/icons/status/Checkmark'
+import Colors from 'src/styles/colors'
 import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { useSelector } from 'src/redux/hooks'
-import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 
-/**
- * Component shown to the user upon completion of the Recovery Phrase setup flow. Informs the user that
- * they've successfully completed the backup process and automatically returns them to where they
- * came from.
- */
+const CHECK_SIZE = 64
 
 type Props = NativeStackScreenProps<StackParamList, Screens.BackupComplete>
 
@@ -40,12 +38,21 @@ function BackupComplete({ route }: Props) {
     return () => clearTimeout(timer)
   }, [])
 
+  if (!backupCompleted) {
+    return <SafeAreaView style={styles.container} edges={['top', 'bottom']} />
+  }
+
   return (
-    <SafeAreaView style={styles.container}>
-      <View testID="BackupComplete" style={styles.innerContainer}>
-        {backupCompleted && <Checkmark height={32} />}
-        {backupCompleted && <Text style={styles.h1}>{t('backupComplete.2')}</Text>}
-      </View>
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View testID="BackupComplete">
+          <StateCard
+            variant="success"
+            title={t('backupComplete.2')}
+            icon={<Checkmark height={CHECK_SIZE} color={Colors.successDark} />}
+          />
+        </View>
+      </ScrollView>
     </SafeAreaView>
   )
 }
@@ -54,15 +61,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  innerContainer: {
-    flex: 1,
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
-    alignItems: 'center',
-  },
-  h1: {
-    ...typeScale.titleMedium,
-    marginTop: 20,
-    paddingHorizontal: 40,
+    paddingHorizontal: Spacing.Regular16,
   },
 })
 

--- a/src/backup/__snapshots__/BackupComplete.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupComplete.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`BackupComplete renders correctly 1`] = `
   edges={
     {
       "bottom": "additive",
-      "left": "additive",
-      "right": "additive",
+      "left": "off",
+      "right": "off",
       "top": "additive",
     }
   }
@@ -16,42 +16,91 @@ exports[`BackupComplete renders correctly 1`] = `
     }
   }
 >
-  <View
-    style={
+  <RCTScrollView
+    contentContainerStyle={
       {
-        "alignItems": "center",
-        "flex": 1,
+        "flexGrow": 1,
         "justifyContent": "center",
+        "paddingHorizontal": 16,
       }
     }
-    testID="BackupComplete"
   >
-    <svg
-      fill="none"
-      height={32}
-      style={{}}
-      viewBox="0 0 24 24"
-      width={32}
-    >
-      <path
-        d="M20.5 7.33 9.186 18.643 4 13.458l1.33-1.33 3.856 3.847L19.17 6 20.5 7.33Z"
-        fill="#2F4ACD"
-        style={{}}
-      />
-    </svg>
-    <Text
-      style={
-        {
-          "fontFamily": "RedHatDisplayBold",
-          "fontSize": 24,
-          "lineHeight": 32,
-          "marginTop": 20,
-          "paddingHorizontal": 40,
-        }
-      }
-    >
-      backupComplete.2
-    </Text>
-  </View>
+    <View>
+      <View
+        testID="BackupComplete"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "backgroundColor": "#F8F9F9",
+              "borderColor": "#E6E6E6",
+              "borderRadius": 16,
+              "borderWidth": 1,
+              "elevation": 12,
+              "marginHorizontal": 8,
+              "marginVertical": 8,
+              "padding": 32,
+              "shadowColor": "rgba(156, 164, 169, 0.4)",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 12,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 60,
+                  "height": 120,
+                  "justifyContent": "center",
+                  "marginBottom": 24,
+                  "width": 120,
+                },
+                {
+                  "backgroundColor": "#F1FDF1",
+                },
+              ]
+            }
+          >
+            <svg
+              fill="none"
+              height={64}
+              style={{}}
+              viewBox="0 0 24 24"
+              width={32}
+            >
+              <path
+                d="M20.5 7.33 9.186 18.643 4 13.458l1.33-1.33 3.856 3.847L19.17 6 20.5 7.33Z"
+                fill="#137211"
+                style={{}}
+              />
+            </svg>
+          </View>
+          <Text
+            style={
+              {
+                "color": "#2E3338",
+                "fontFamily": "RedHatDisplayMedium",
+                "fontSize": 18,
+                "lineHeight": 28,
+                "paddingBottom": 16,
+                "paddingTop": 8,
+                "textAlign": "center",
+              }
+            }
+          >
+            backupComplete.2
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
 </RNCSafeAreaView>
 `;

--- a/src/fiatExchanges/CashInSuccess.tsx
+++ b/src/fiatExchanges/CashInSuccess.tsx
@@ -1,19 +1,21 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Image, StyleSheet, Text, View } from 'react-native'
-import { FiatExchangeEvents } from 'src/analytics/Events'
+import { Image, ScrollView, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
-import Button from 'src/components/Button'
+import { FiatExchangeEvents } from 'src/analytics/Events'
+import Button, { BtnSizes } from 'src/components/Button'
+import StateCard from 'src/components/StateCard'
+import StickyCtaBottom from 'src/components/StickyCtaBottom'
 import { fiatExchange } from 'src/images/Images'
 import { noHeaderGestureDisabled } from 'src/navigator/Headers'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
-import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 
-type RouteProps = NativeStackScreenProps<StackParamList, Screens.CashInSuccess>
-type Props = RouteProps
+type Props = NativeStackScreenProps<StackParamList, Screens.CashInSuccess>
 
 const capitalizeProvider = (provider?: string) => {
   if (provider) {
@@ -25,36 +27,36 @@ const capitalizeProvider = (provider?: string) => {
 
 function CashInSuccessScreen({ route }: Props) {
   const { t } = useTranslation()
-
   const { provider } = route.params
 
   useEffect(() => {
-    AppAnalytics.track(FiatExchangeEvents.cash_in_success, {
-      provider,
-    })
+    AppAnalytics.track(FiatExchangeEvents.cash_in_success, { provider })
   }, [])
 
   return (
-    <View style={styles.container}>
-      <View style={styles.content}>
-        <Image source={fiatExchange} resizeMode={'contain'} />
-        <Text style={styles.title}>{t('cicoSuccess.title')}</Text>
-        <Text style={styles.contentText}>
-          {provider
-            ? t('cicoSuccess.bodyWithProvider', { provider: capitalizeProvider(provider) })
-            : t('cicoSuccess.bodyWithoutProvider')}
-        </Text>
-      </View>
-      <View style={styles.buttonContainer}>
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <StateCard
+          variant="success"
+          title={t('cicoSuccess.title')}
+          subtitle={
+            provider
+              ? t('cicoSuccess.bodyWithProvider', { provider: capitalizeProvider(provider) })
+              : t('cicoSuccess.bodyWithoutProvider')
+          }
+          icon={<Image source={fiatExchange} resizeMode="contain" style={styles.brandImage} />}
+        />
+      </ScrollView>
+      <StickyCtaBottom>
         <Button
-          style={styles.button}
+          size={BtnSizes.FULL}
           text={t('continue')}
           accessibilityLabel={t('continue') ?? undefined}
           onPress={navigateHome}
-          testID={'SuccessContinue'}
+          testID="SuccessContinue"
         />
-      </View>
-    </View>
+      </StickyCtaBottom>
+    </SafeAreaView>
   )
 }
 
@@ -64,40 +66,16 @@ CashInSuccessScreen.navigationOptions = () => ({
 
 const styles = StyleSheet.create({
   container: {
-    overflow: 'hidden',
-    display: 'flex',
     flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: 32,
   },
-  title: {
-    ...typeScale.labelLarge,
-    paddingTop: 8,
-    paddingBottom: 16,
-  },
-  content: {
-    flex: 1,
-    padding: 16,
-    display: 'flex',
-    flexDirection: 'column',
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
-    alignItems: 'center',
+    paddingHorizontal: Spacing.Regular16,
   },
-  contentText: {
-    ...typeScale.bodyMedium,
-    textAlign: 'center',
-  },
-  buttonContainer: {
-    flexDirection: 'row',
-  },
-  button: {
-    minWidth: 200,
-    width: '100%',
-    alignSelf: 'stretch',
-    flex: 1,
-    flexDirection: 'column',
+  brandImage: {
+    width: 100,
+    height: 100,
   },
 })
 

--- a/src/fiatExchanges/__snapshots__/CashInSuccess.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/CashInSuccess.test.tsx.snap
@@ -1,70 +1,132 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CashinInSuccess renders correctly with a provider 1`] = `
-<View
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "additive",
+    }
+  }
   style={
     {
-      "alignItems": "center",
-      "display": "flex",
       "flex": 1,
-      "flexDirection": "column",
-      "justifyContent": "space-between",
-      "overflow": "hidden",
-      "padding": 32,
     }
   }
 >
-  <View
-    style={
+  <RCTScrollView
+    contentContainerStyle={
       {
-        "alignItems": "center",
-        "display": "flex",
-        "flex": 1,
-        "flexDirection": "column",
+        "flexGrow": 1,
         "justifyContent": "center",
-        "padding": 16,
+        "paddingHorizontal": 16,
       }
     }
   >
-    <Image
-      resizeMode="contain"
-      source={
-        {
-          "testUri": "../../../src/images/assets/fiat-exchange.png",
+    <View>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#F8F9F9",
+            "borderColor": "#E6E6E6",
+            "borderRadius": 16,
+            "borderWidth": 1,
+            "elevation": 12,
+            "marginHorizontal": 8,
+            "marginVertical": 8,
+            "padding": 32,
+            "shadowColor": "rgba(156, 164, 169, 0.4)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 12,
+          }
         }
-      }
-    />
-    <Text
-      style={
-        {
-          "fontFamily": "RedHatDisplayMedium",
-          "fontSize": 18,
-          "lineHeight": 28,
-          "paddingBottom": 16,
-          "paddingTop": 8,
-        }
-      }
-    >
-      cicoSuccess.title
-    </Text>
-    <Text
-      style={
-        {
-          "fontFamily": "RedHatDisplayRegular",
-          "fontSize": 12,
-          "lineHeight": 24,
-          "textAlign": "center",
-        }
-      }
-    >
-      cicoSuccess.bodyWithProvider, {"provider":"Moonpay"}
-    </Text>
-  </View>
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 60,
+                "height": 120,
+                "justifyContent": "center",
+                "marginBottom": 24,
+                "width": 120,
+              },
+              {
+                "backgroundColor": "#F1FDF1",
+              },
+            ]
+          }
+        >
+          <Image
+            resizeMode="contain"
+            source={
+              {
+                "testUri": "../../../src/images/assets/fiat-exchange.png",
+              }
+            }
+            style={
+              {
+                "height": 100,
+                "width": 100,
+              }
+            }
+          />
+        </View>
+        <Text
+          style={
+            {
+              "color": "#2E3338",
+              "fontFamily": "RedHatDisplayMedium",
+              "fontSize": 18,
+              "lineHeight": 28,
+              "paddingBottom": 16,
+              "paddingTop": 8,
+              "textAlign": "center",
+            }
+          }
+        >
+          cicoSuccess.title
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#666666",
+              "fontFamily": "RedHatDisplayRegular",
+              "fontSize": 12,
+              "lineHeight": 24,
+              "marginBottom": 32,
+              "textAlign": "center",
+            }
+          }
+        >
+          cicoSuccess.bodyWithProvider, {"provider":"Moonpay"}
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
   <View
     style={
-      {
-        "flexDirection": "row",
-      }
+      [
+        {
+          "backgroundColor": "#FFFFFF",
+          "paddingBottom": 16,
+          "paddingHorizontal": 24,
+          "paddingTop": 16,
+        },
+        {
+          "borderTopColor": "#E6E6E6",
+          "borderTopWidth": 1,
+        },
+      ]
     }
   >
     <View
@@ -87,15 +149,10 @@ exports[`CashinInSuccess renders correctly with a provider 1`] = `
         style={
           [
             {
-              "flexDirection": "row",
-            },
-            {
-              "alignSelf": "stretch",
-              "flex": 1,
               "flexDirection": "column",
-              "minWidth": 200,
               "width": "100%",
             },
+            undefined,
           ]
         }
       >
@@ -151,13 +208,14 @@ exports[`CashinInSuccess renders correctly with a provider 1`] = `
                   "alignItems": "center",
                   "backgroundColor": "#2F4ACD",
                   "flexDirection": "row",
+                  "flexGrow": 1,
                   "height": 48,
                   "justifyContent": "center",
                   "maxHeight": 56,
-                  "minWidth": 120,
                   "opacity": 1,
                   "paddingHorizontal": 24,
                   "paddingVertical": 5,
+                  "width": "100%",
                 },
                 undefined,
               ]
@@ -240,74 +298,136 @@ exports[`CashinInSuccess renders correctly with a provider 1`] = `
       </View>
     </View>
   </View>
-</View>
+</RNCSafeAreaView>
 `;
 
 exports[`CashinInSuccess renders correctly without a provider 1`] = `
-<View
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "additive",
+    }
+  }
   style={
     {
-      "alignItems": "center",
-      "display": "flex",
       "flex": 1,
-      "flexDirection": "column",
-      "justifyContent": "space-between",
-      "overflow": "hidden",
-      "padding": 32,
     }
   }
 >
-  <View
-    style={
+  <RCTScrollView
+    contentContainerStyle={
       {
-        "alignItems": "center",
-        "display": "flex",
-        "flex": 1,
-        "flexDirection": "column",
+        "flexGrow": 1,
         "justifyContent": "center",
-        "padding": 16,
+        "paddingHorizontal": 16,
       }
     }
   >
-    <Image
-      resizeMode="contain"
-      source={
-        {
-          "testUri": "../../../src/images/assets/fiat-exchange.png",
+    <View>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#F8F9F9",
+            "borderColor": "#E6E6E6",
+            "borderRadius": 16,
+            "borderWidth": 1,
+            "elevation": 12,
+            "marginHorizontal": 8,
+            "marginVertical": 8,
+            "padding": 32,
+            "shadowColor": "rgba(156, 164, 169, 0.4)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 12,
+          }
         }
-      }
-    />
-    <Text
-      style={
-        {
-          "fontFamily": "RedHatDisplayMedium",
-          "fontSize": 18,
-          "lineHeight": 28,
-          "paddingBottom": 16,
-          "paddingTop": 8,
-        }
-      }
-    >
-      cicoSuccess.title
-    </Text>
-    <Text
-      style={
-        {
-          "fontFamily": "RedHatDisplayRegular",
-          "fontSize": 12,
-          "lineHeight": 24,
-          "textAlign": "center",
-        }
-      }
-    >
-      cicoSuccess.bodyWithoutProvider
-    </Text>
-  </View>
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 60,
+                "height": 120,
+                "justifyContent": "center",
+                "marginBottom": 24,
+                "width": 120,
+              },
+              {
+                "backgroundColor": "#F1FDF1",
+              },
+            ]
+          }
+        >
+          <Image
+            resizeMode="contain"
+            source={
+              {
+                "testUri": "../../../src/images/assets/fiat-exchange.png",
+              }
+            }
+            style={
+              {
+                "height": 100,
+                "width": 100,
+              }
+            }
+          />
+        </View>
+        <Text
+          style={
+            {
+              "color": "#2E3338",
+              "fontFamily": "RedHatDisplayMedium",
+              "fontSize": 18,
+              "lineHeight": 28,
+              "paddingBottom": 16,
+              "paddingTop": 8,
+              "textAlign": "center",
+            }
+          }
+        >
+          cicoSuccess.title
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#666666",
+              "fontFamily": "RedHatDisplayRegular",
+              "fontSize": 12,
+              "lineHeight": 24,
+              "marginBottom": 32,
+              "textAlign": "center",
+            }
+          }
+        >
+          cicoSuccess.bodyWithoutProvider
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
   <View
     style={
-      {
-        "flexDirection": "row",
-      }
+      [
+        {
+          "backgroundColor": "#FFFFFF",
+          "paddingBottom": 16,
+          "paddingHorizontal": 24,
+          "paddingTop": 16,
+        },
+        {
+          "borderTopColor": "#E6E6E6",
+          "borderTopWidth": 1,
+        },
+      ]
     }
   >
     <View
@@ -330,15 +450,10 @@ exports[`CashinInSuccess renders correctly without a provider 1`] = `
         style={
           [
             {
-              "flexDirection": "row",
-            },
-            {
-              "alignSelf": "stretch",
-              "flex": 1,
               "flexDirection": "column",
-              "minWidth": 200,
               "width": "100%",
             },
+            undefined,
           ]
         }
       >
@@ -394,13 +509,14 @@ exports[`CashinInSuccess renders correctly without a provider 1`] = `
                   "alignItems": "center",
                   "backgroundColor": "#2F4ACD",
                   "flexDirection": "row",
+                  "flexGrow": 1,
                   "height": 48,
                   "justifyContent": "center",
                   "maxHeight": 56,
-                  "minWidth": 120,
                   "opacity": 1,
                   "paddingHorizontal": 24,
                   "paddingVertical": 5,
+                  "width": "100%",
                 },
                 undefined,
               ]
@@ -483,5 +599,5 @@ exports[`CashinInSuccess renders correctly without a provider 1`] = `
       </View>
     </View>
   </View>
-</View>
+</RNCSafeAreaView>
 `;

--- a/src/fiatconnect/kyc/KycDenied.tsx
+++ b/src/fiatconnect/kyc/KycDenied.tsx
@@ -2,11 +2,13 @@ import { KycStatus as FiatConnectKycStatus } from '@fiatconnect/fiatconnect-type
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import { ActivityIndicator, ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import StateCard from 'src/components/StateCard'
+import StickyCtaBottom from 'src/components/StickyCtaBottom'
 import getNavigationOptions from 'src/fiatconnect/kyc/getNavigationOptions'
 import { kycTryAgainLoadingSelector } from 'src/fiatconnect/selectors'
 import { kycTryAgain } from 'src/fiatconnect/slice'
@@ -15,7 +17,7 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
-import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.KycDenied>
@@ -57,6 +59,7 @@ function KycDenied({ route, navigation }: Props) {
       },
     })
   }
+
   if (tryAgainLoading) {
     return (
       <View testID="spinnerContainer" style={styles.activityIndicatorContainer}>
@@ -64,74 +67,53 @@ function KycDenied({ route, navigation }: Props) {
       </View>
     )
   }
-  if (retryable) {
-    return (
-      <SafeAreaView style={styles.container}>
-        <Text style={styles.title}>{t('fiatConnectKycStatusScreen.denied.retryable.title')}</Text>
-        <Text testID="descriptionText" style={styles.description}>
-          {t('fiatConnectKycStatusScreen.denied.retryable.description')}
-        </Text>
+
+  const title = retryable
+    ? t('fiatConnectKycStatusScreen.denied.retryable.title')
+    : t('fiatConnectKycStatusScreen.denied.final.title')
+  const subtitle = retryable
+    ? t('fiatConnectKycStatusScreen.denied.retryable.description')
+    : t('fiatConnectKycStatusScreen.denied.final.description')
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <StateCard variant="error" title={title} subtitle={subtitle} />
+      </ScrollView>
+      <StickyCtaBottom>
+        {retryable && (
+          <Button
+            testID="tryAgainButton"
+            onPress={onPressTryAgain}
+            text={t('fiatConnectKycStatusScreen.denied.retryable.tryAgain')}
+            type={BtnTypes.PRIMARY}
+            size={BtnSizes.FULL}
+          />
+        )}
         <Button
-          style={styles.tryAgainButton}
-          testID="tryAgainButton"
-          onPress={onPressTryAgain}
-          text={t('fiatConnectKycStatusScreen.denied.retryable.tryAgain')}
-          type={BtnTypes.PRIMARY}
-          size={BtnSizes.MEDIUM}
-        />
-        <Button
-          style={styles.switchButton}
+          style={retryable ? styles.secondaryButton : undefined}
           testID="switchButton"
           onPress={onPressSwitch}
           text={t('fiatConnectKycStatusScreen.denied.switch')}
           type={BtnTypes.SECONDARY}
-          size={BtnSizes.MEDIUM}
+          size={BtnSizes.FULL}
         />
-      </SafeAreaView>
-    )
-  } else {
-    return (
-      <SafeAreaView style={styles.container}>
-        <Text style={styles.title}>{t('fiatConnectKycStatusScreen.denied.final.title')}</Text>
-        <Text testID="descriptionText" style={styles.description}>
-          {t('fiatConnectKycStatusScreen.denied.final.description')}
-        </Text>
-        <Button
-          style={styles.switchButton}
-          testID="switchButton"
-          onPress={onPressSwitch}
-          text={t('fiatConnectKycStatusScreen.denied.switch')}
-          type={BtnTypes.SECONDARY}
-          size={BtnSizes.MEDIUM}
-        />
-      </SafeAreaView>
-    )
-  }
+      </StickyCtaBottom>
+    </SafeAreaView>
+  )
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    flexDirection: 'column',
+  },
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
-    alignItems: 'center',
+    paddingHorizontal: Spacing.Regular16,
   },
-  title: {
-    ...typeScale.titleSmall,
-    marginHorizontal: 16,
-  },
-  description: {
-    ...typeScale.bodyMedium,
-    textAlign: 'center',
-    marginVertical: 12,
-    marginHorizontal: 24,
-  },
-  tryAgainButton: {
-    marginTop: 12,
-  },
-  switchButton: {
-    marginTop: 12,
-    marginBottom: 100,
+  secondaryButton: {
+    marginTop: Spacing.Smallest8,
   },
   activityIndicatorContainer: {
     paddingVertical: variables.contentPadding,

--- a/src/fiatconnect/kyc/KycExpired.tsx
+++ b/src/fiatconnect/kyc/KycExpired.tsx
@@ -2,11 +2,13 @@ import { KycStatus as FiatConnectKycStatus } from '@fiatconnect/fiatconnect-type
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import { ActivityIndicator, ScrollView, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import StateCard from 'src/components/StateCard'
+import StickyCtaBottom from 'src/components/StickyCtaBottom'
 import getNavigationOptions from 'src/fiatconnect/kyc/getNavigationOptions'
 import { kycTryAgainLoadingSelector } from 'src/fiatconnect/selectors'
 import { kycTryAgain } from 'src/fiatconnect/slice'
@@ -15,7 +17,7 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
-import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.KycExpired>
@@ -67,27 +69,31 @@ function KycExpired({ route, navigation }: Props) {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>{t('fiatConnectKycStatusScreen.expired.title')}</Text>
-      <Text testID="descriptionText" style={styles.description}>
-        {t('fiatConnectKycStatusScreen.expired.description')}
-      </Text>
-      <Button
-        style={styles.tryAgainButton}
-        testID="tryAgainButton"
-        onPress={onPressTryAgain}
-        text={t('fiatConnectKycStatusScreen.expired.tryAgain')}
-        type={BtnTypes.PRIMARY}
-        size={BtnSizes.MEDIUM}
-      />
-      <Button
-        style={styles.switchButton}
-        testID="switchButton"
-        onPress={onPressSwitch}
-        text={t('fiatConnectKycStatusScreen.expired.switch')}
-        type={BtnTypes.SECONDARY}
-        size={BtnSizes.MEDIUM}
-      />
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <StateCard
+          variant="warning"
+          title={t('fiatConnectKycStatusScreen.expired.title')}
+          subtitle={t('fiatConnectKycStatusScreen.expired.description')}
+        />
+      </ScrollView>
+      <StickyCtaBottom>
+        <Button
+          testID="tryAgainButton"
+          onPress={onPressTryAgain}
+          text={t('fiatConnectKycStatusScreen.expired.tryAgain')}
+          type={BtnTypes.PRIMARY}
+          size={BtnSizes.FULL}
+        />
+        <Button
+          style={styles.secondaryButton}
+          testID="switchButton"
+          onPress={onPressSwitch}
+          text={t('fiatConnectKycStatusScreen.expired.switch')}
+          type={BtnTypes.SECONDARY}
+          size={BtnSizes.FULL}
+        />
+      </StickyCtaBottom>
     </SafeAreaView>
   )
 }
@@ -95,26 +101,14 @@ function KycExpired({ route, navigation }: Props) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    flexDirection: 'column',
+  },
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
-    alignItems: 'center',
+    paddingHorizontal: Spacing.Regular16,
   },
-  title: {
-    ...typeScale.titleSmall,
-    marginHorizontal: 16,
-  },
-  description: {
-    ...typeScale.bodyMedium,
-    textAlign: 'center',
-    marginVertical: 12,
-    marginHorizontal: 24,
-  },
-  tryAgainButton: {
-    marginTop: 12,
-  },
-  switchButton: {
-    marginTop: 12,
-    marginBottom: 100,
+  secondaryButton: {
+    marginTop: Spacing.Smallest8,
   },
   activityIndicatorContainer: {
     paddingVertical: variables.contentPadding,

--- a/src/nfts/NftsLoadError.tsx
+++ b/src/nfts/NftsLoadError.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { NftEvents } from 'src/analytics/Events'
+import StateCard from 'src/components/StateCard'
 import Touchable from 'src/components/Touchable'
 import RedLoadingSpinnerToInfo from 'src/icons/loading/RedLoadingSpinnerToInfo'
 import { navigate } from 'src/navigator/NavigationService'
@@ -20,29 +22,25 @@ interface Props {
 
 export default function NftsLoadError({ testID }: Props) {
   const { t } = useTranslation()
+
   function handleSupportPress() {
     Logger.debug(TAG, 'Support Contact pressed')
     navigate(Screens.SupportContact)
   }
 
   useEffect(() => {
-    // Whenever this screen is mounted we've failed to load the NFTs from blockchain-api
     AppAnalytics.track(NftEvents.nft_error_screen_open)
   }, [])
 
   return (
-    <SafeAreaView style={styles.safeArea} testID={testID}>
-      <ScrollView
-        contentContainerStyle={styles.contentContainerStyle}
-        style={styles.scrollContainer}
-      >
-        <View style={styles.center}>
-          <View style={styles.iconMargin}>
-            <RedLoadingSpinnerToInfo />
-          </View>
-          <Text style={styles.title}>{t('nftsLoadErrorScreen.loadErrorTitle')}</Text>
-          <Text style={styles.subTitle}>{t('nftsLoadErrorScreen.loadErrorSubtitle')}</Text>
-        </View>
+    <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']} testID={testID}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <StateCard
+          variant="error"
+          title={t('nftsLoadErrorScreen.loadErrorTitle')}
+          subtitle={t('nftsLoadErrorScreen.loadErrorSubtitle')}
+          icon={<RedLoadingSpinnerToInfo />}
+        />
         <View style={styles.contactSupportTouchableContainer}>
           <Touchable
             testID="NftsLoadErrorScreen/ContactSupport"
@@ -62,18 +60,24 @@ export default function NftsLoadError({ testID }: Props) {
 }
 
 const styles = StyleSheet.create({
-  center: {
-    alignItems: 'center',
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.Regular16,
   },
   contactSupportText: {
     ...typeScale.bodySmall,
     textAlign: 'center',
     color: colors.gray3,
   },
-  // Touchable are wrapped in a view to prevent the ripple effect from overflowing on Android
   contactSupportTouchableContainer: {
+    alignSelf: 'center',
     borderRadius: Spacing.Large32,
     overflow: 'hidden',
+    marginTop: Spacing.Regular16,
   },
   contactSupportTouchable: {
     padding: Spacing.Regular16,
@@ -81,31 +85,5 @@ const styles = StyleSheet.create({
   contactSupportLink: {
     color: colors.infoDark,
     textDecorationLine: 'underline',
-  },
-  contentContainerStyle: {
-    flexGrow: 1,
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  iconMargin: {
-    marginTop: '32%',
-    marginBottom: Spacing.Thick24,
-  },
-  safeArea: {
-    flex: 1,
-  },
-  scrollContainer: {
-    flex: 1,
-    marginHorizontal: Spacing.Thick24,
-  },
-  subTitle: {
-    ...typeScale.bodyMedium,
-    textAlign: 'center',
-    color: colors.gray3,
-  },
-  title: {
-    ...typeScale.titleSmall,
-    marginBottom: Spacing.Smallest8,
-    textAlign: 'center',
   },
 })


### PR DESCRIPTION
## Summary

Design System Phase 2: migrate inline state-card patterns to the shared `<StateCard>` + `<StickyCtaBottom>` components introduced in PR #126.

Policy decision (per user, 2026-05-28): migrate even screens whose code path is currently unreachable in production (FiatConnect KYC) so the codebase stays consistent if those flows are ever enabled. Cleanup of truly-dead code is a separate, deferred decision.

## Migrated screens

| Screen | Variant | Notes |
|---|---|---|
| `src/fiatconnect/kyc/KycDenied.tsx` | error | Retryable and final branches share layout |
| `src/fiatconnect/kyc/KycExpired.tsx` | warning | - |
| `src/backup/BackupComplete.tsx` | success | Checkmark via icon escape hatch |
| `src/fiatExchanges/CashInSuccess.tsx` | success | Brand image via icon escape hatch |
| `src/nfts/NftsLoadError.tsx` | error | RedLoadingSpinnerToInfo via icon escape hatch, support touchable kept below |
| `src/account/AccountErrorScreen.tsx` | error | Two callers (`AccountSetupFailureScreen`, `StoreWipeRecoveryScreen`) inherit new look transitively |

## Snapshot regen

Removed and regenerated:

- `src/backup/__snapshots__/BackupComplete.test.tsx.snap`
- `src/fiatExchanges/__snapshots__/CashInSuccess.test.tsx.snap`

## Test plan

- [x] `yarn build:ts`
- [x] `yarn lint` on 6 changed files
- [x] `yarn test --testPathPattern="(KycDenied|KycExpired|BackupComplete|CashInSuccess|NftsLoadError|AccountErrorScreen)"` -> 6 suites, 21 tests pass, 3 snapshots regenerated
- [ ] **Manual smoke (deferred - no test device available):** verify each screen renders, primary/secondary CTAs work, layout looks right on small + large screens

## Out of scope (Phase 3)

- Commit `docs/DESIGN_SYSTEM.md` with usage guide
- ESLint rule to flag new inline state-card patterns