### PR TITLE
feat(toast): add subscription-based ToastHost, migrate success Alerts

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import AppInitGate from 'src/app/AppInitGate'
 import ErrorBoundary from 'src/app/ErrorBoundary'
 import { AUTH0_CLIENT_ID, AUTH0_DOMAIN, isE2EEnv } from 'src/config'
 import { ErrorSheetHost } from 'src/components/ErrorMessage'
+import ToastHost from 'src/components/ToastHost'
 import i18n from 'src/i18n'
 import NavigatorWrapper from 'src/navigator/NavigatorWrapper'
 import { persistor, store } from 'src/redux/store'
@@ -85,6 +86,7 @@ export class App extends React.Component<Props> {
                     <BottomSheetModalProvider>
                       <NavigatorWrapper />
                       <ErrorSheetHost />
+                      <ToastHost />
                     </BottomSheetModalProvider>
                   </GestureHandlerRootView>
                 </ErrorBoundary>

--- a/src/backup/BackupPhraseContainer.tsx
+++ b/src/backup/BackupPhraseContainer.tsx
@@ -10,7 +10,7 @@ import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { vibrateInformative } from 'src/styles/hapticFeedback'
 import { Spacing } from 'src/styles/styles'
-import Logger from 'src/utils/Logger'
+import { showToast } from 'src/components/showToast'
 
 const PhraseInput = withTextInputPasteAware(TextInput, { top: undefined, right: 12, bottom: 12 })
 
@@ -68,7 +68,7 @@ export class BackupPhraseContainer extends React.Component<Props> {
       return
     }
     Clipboard.setString(words)
-    Logger.showMessage(t('copied'))
+    showToast({ message: t('copied') })
     vibrateInformative()
   }
 

--- a/src/components/AccountNumber.tsx
+++ b/src/components/AccountNumber.tsx
@@ -8,7 +8,7 @@ import { Screens } from 'src/navigator/Screens'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { vibrateInformative } from 'src/styles/hapticFeedback'
-import Logger from 'src/utils/Logger'
+import { showToast } from 'src/components/showToast'
 import { getAddressChunks } from 'src/utils/address'
 
 interface Props {
@@ -24,7 +24,7 @@ export default function AccountNumber({ address, touchDisabled, location }: Prop
       return
     }
     Clipboard.setString(address)
-    Logger.showMessage(t('addressCopied'))
+    showToast({ message: t('addressCopied') })
     vibrateInformative()
 
     if (location === Screens.TransactionDetailsScreen) {

--- a/src/components/ToastHost.tsx
+++ b/src/components/ToastHost.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import Toast from 'src/components/Toast'
+import { ShowToastInput, subscribeToToasts } from 'src/components/showToast'
+
+const DEFAULT_DURATION_MS = 3000
+
+export default function ToastHost() {
+  const [active, setActive] = useState<ShowToastInput | null>(null)
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearDismissTimer = () => {
+    if (dismissTimer.current) {
+      clearTimeout(dismissTimer.current)
+      dismissTimer.current = null
+    }
+  }
+
+  const dismiss = () => {
+    clearDismissTimer()
+    setActive(null)
+  }
+
+  useEffect(() => {
+    const unsubscribe = subscribeToToasts((input) => {
+      clearDismissTimer()
+      setActive(input)
+      const duration = input.duration ?? DEFAULT_DURATION_MS
+      dismissTimer.current = setTimeout(() => setActive(null), duration)
+    })
+    return () => {
+      unsubscribe()
+      clearDismissTimer()
+    }
+  }, [])
+
+  if (!active) {
+    return null
+  }
+
+  return (
+    <Toast
+      showToast
+      swipeable
+      onDismiss={dismiss}
+      variant={active.variant ?? NotificationVariant.Success}
+      title={active.title}
+      description={active.message}
+      testID="ToastHost"
+    />
+  )
+}

--- a/src/components/__tests__/showToast.test.tsx
+++ b/src/components/__tests__/showToast.test.tsx
@@ -1,0 +1,40 @@
+import { NotificationVariant } from 'src/components/InLineNotification'
+import {
+  __resetToastListeners,
+  showToast,
+  ShowToastInput,
+  subscribeToToasts,
+} from 'src/components/showToast'
+
+describe('showToast', () => {
+  afterEach(() => {
+    __resetToastListeners()
+  })
+
+  it('dispatches the input to every subscriber', () => {
+    const listenerA = jest.fn()
+    const listenerB = jest.fn()
+    subscribeToToasts(listenerA)
+    subscribeToToasts(listenerB)
+
+    const input: ShowToastInput = { message: 'hi', variant: NotificationVariant.Success }
+    showToast(input)
+
+    expect(listenerA).toHaveBeenCalledWith(input)
+    expect(listenerB).toHaveBeenCalledWith(input)
+  })
+
+  it('stops dispatching after unsubscribe', () => {
+    const listener = jest.fn()
+    const unsubscribe = subscribeToToasts(listener)
+    unsubscribe()
+
+    showToast({ message: 'ignored' })
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when called with no listeners', () => {
+    expect(() => showToast({ message: 'nobody home' })).not.toThrow()
+  })
+})

--- a/src/components/showToast.tsx
+++ b/src/components/showToast.tsx
@@ -1,0 +1,25 @@
+import { NotificationVariant } from 'src/components/InLineNotification'
+
+export interface ShowToastInput {
+  title?: string
+  message: string
+  variant?: NotificationVariant
+  duration?: number
+}
+
+type Listener = (input: ShowToastInput) => void
+
+const listeners = new Set<Listener>()
+
+export function subscribeToToasts(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function showToast(input: ShowToastInput): void {
+  listeners.forEach((listener) => listener(input))
+}
+
+export function __resetToastListeners(): void {
+  listeners.clear()
+}

--- a/src/earn/PoolList.tsx
+++ b/src/earn/PoolList.tsx
@@ -11,6 +11,8 @@ import {
   View,
 } from 'react-native'
 import { showErrorMessage } from 'src/components/ErrorMessage'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import { showToast } from 'src/components/showToast'
 import Animated from 'react-native-reanimated'
 import { useSelector } from 'react-redux'
 import { MARRANITOS_POSITION_TYPE, MY_MARRANITOS_POSITION_TYPE } from 'src/earn/EarnHome'
@@ -97,7 +99,7 @@ export default function PoolList({
 
                 if (success === true) {
                   onRefresh && onRefresh()
-                  Alert.alert(t('earnFlow.staking.withdrawSuccess'))
+                  showToast({ message: t('earnFlow.staking.withdrawSuccess') })
                 }
               },
             },
@@ -106,7 +108,7 @@ export default function PoolList({
       } else if (result === true) {
         // Retiro normal exitoso
         onRefresh && onRefresh()
-        Alert.alert(t('earnFlow.staking.withdrawSuccess'))
+        showToast({ message: t('earnFlow.staking.withdrawSuccess') })
       } else {
         showErrorMessage({
           error: new Error(t('earnFlow.staking.withdrawFailed')),
@@ -128,9 +130,11 @@ export default function PoolList({
 
   const handlePoolSelection = async (pool: any) => {
     if (!walletAddress) {
-      Alert.alert(t('earnFlow.staking.connectRequired'), t('earnFlow.staking.connectToStake'), [
-        { text: t('global.ok') },
-      ])
+      showToast({
+        title: t('earnFlow.staking.connectRequired'),
+        message: t('earnFlow.staking.connectToStake'),
+        variant: NotificationVariant.Warning,
+      })
       return
     }
 

--- a/src/earn/marranitos/MarranitoStaking.tsx
+++ b/src/earn/marranitos/MarranitoStaking.tsx
@@ -2,7 +2,6 @@ import { useRoute } from '@react-navigation/native'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -13,6 +12,7 @@ import {
 } from 'react-native'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { showErrorMessage } from 'src/components/ErrorMessage'
+import { showToast } from 'src/components/showToast'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -76,19 +76,11 @@ const MarranitoStaking = () => {
       )
 
       if (success) {
-        Alert.alert(
-          t('earnFlow.staking.success'),
-          t('earnFlow.staking.stakeSuccess', { days: pool.days }),
-          [
-            {
-              text: t('global.ok'),
-              onPress: () => {
-                // Navegar a la pantalla de mis inversiones después de completar el staking
-                navigate(Screens.EarnHome)
-              },
-            },
-          ]
-        )
+        showToast({
+          title: t('earnFlow.staking.success'),
+          message: t('earnFlow.staking.stakeSuccess', { days: pool.days }),
+        })
+        navigate(Screens.EarnHome)
       } else {
         showErrorMessage({
           error: new Error(t('earnFlow.staking.stakeFailed')),
@@ -98,10 +90,6 @@ const MarranitoStaking = () => {
       }
     } catch (error) {
       Logger.error(TAG, 'Error staking', error)
-      // Alert.alert(
-      //   t('earnFlow.staking.error'),
-      //   error instanceof Error ? error.message : t('earnFlow.staking.stakeFailed')
-      // )
     } finally {
       setIsStaking(false)
     }

--- a/src/earn/marranitos/MarranitosMyStakes.tsx
+++ b/src/earn/marranitos/MarranitosMyStakes.tsx
@@ -13,6 +13,7 @@ import { Shadow } from 'react-native-shadow-2'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { showErrorMessage } from 'src/components/ErrorMessage'
 import PasswordInput from 'src/components/PasswordInput'
+import { showToast } from 'src/components/showToast'
 import { getPassword } from 'src/pincode/authentication'
 import { useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
@@ -114,7 +115,7 @@ const MarranitosMyStakes = ({ listHeaderHeight }: { listHeaderHeight: number }) 
 
                 if (success === true) {
                   await loadStakes()
-                  Alert.alert(t('earnFlow.staking.withdrawSuccess'))
+                  showToast({ message: t('earnFlow.staking.withdrawSuccess') })
                 }
               },
             },
@@ -123,7 +124,7 @@ const MarranitosMyStakes = ({ listHeaderHeight }: { listHeaderHeight: number }) 
       } else if (result === true) {
         // Retiro normal exitoso
         await loadStakes()
-        Alert.alert(t('earnFlow.staking.withdrawSuccess'))
+        showToast({ message: t('earnFlow.staking.withdrawSuccess') })
       } else {
         showErrorMessage({
           error: new Error(t('earnFlow.staking.withdrawFailed')),
@@ -157,11 +158,10 @@ const MarranitosMyStakes = ({ listHeaderHeight }: { listHeaderHeight: number }) 
       )
 
       if (success) {
-        Alert.alert(
-          t('earnFlow.staking.withdrawSuccess'),
-          t('earnFlow.staking.withdrawSuccessMessage'),
-          [{ text: t('global.ok') }]
-        )
+        showToast({
+          title: t('earnFlow.staking.withdrawSuccess'),
+          message: t('earnFlow.staking.withdrawSuccessMessage'),
+        })
 
         // Reload stakes
         await loadStakes()

--- a/src/earn/marranitos/MarranitosPools.tsx
+++ b/src/earn/marranitos/MarranitosPools.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Alert,
   Animated,
   FlatList,
   NativeScrollEvent,
@@ -9,6 +8,8 @@ import {
   StyleSheet,
   View,
 } from 'react-native'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import { showToast } from 'src/components/showToast'
 import MarranitosPoolCard from 'src/earn/marranitos/MarranitosPoolCard'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -64,9 +65,11 @@ const MarranitosPools = ({
 
   const handlePoolSelection = async (pool: any) => {
     if (!walletAddress) {
-      Alert.alert(t('earnFlow.staking.connectRequired'), t('earnFlow.staking.connectToStake'), [
-        { text: t('global.ok') },
-      ])
+      showToast({
+        title: t('earnFlow.staking.connectRequired'),
+        message: t('earnFlow.staking.connectToStake'),
+        variant: NotificationVariant.Warning,
+      })
       return
     }
 

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -28,7 +28,7 @@ import {
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
-import Logger from 'src/utils/Logger'
+import { showToast } from 'src/components/showToast'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.OnboardingRecoveryPhrase>
 
@@ -77,7 +77,7 @@ function OnboardingRecoveryPhrase({ navigation, route }: Props) {
   const onPressCopy = () => {
     AppAnalytics.track(OnboardingEvents.protect_wallet_copy_phrase)
     Clipboard.setString(accountKey ?? '')
-    Logger.showMessage(t('recoveryPhrase.mnemonicCopied'))
+    showToast({ message: t('recoveryPhrase.mnemonicCopied') })
   }
   const onPressContinue = () => {
     AppAnalytics.track(OnboardingEvents.protect_wallet_complete)

--- a/src/qrcode/QRCode.tsx
+++ b/src/qrcode/QRCode.tsx
@@ -20,7 +20,7 @@ import variables from 'src/styles/variables'
 import { getSupportedNetworkIdsForTokenBalances } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
 import { navigateToURI } from 'src/utils/linking'
-import Logger from 'src/utils/Logger'
+import { showToast } from 'src/components/showToast'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 interface Props {
@@ -48,7 +48,7 @@ export default function QRCodeDisplay(props: Props) {
   const onPressCopy = () => {
     props.onPressCopy?.()
     Clipboard.setString(address || '')
-    Logger.showMessage(t('addressCopied'))
+    showToast({ message: t('addressCopied') })
     vibrateInformative()
   }
 


### PR DESCRIPTION
## Summary

Introduces a non-blocking toast surface that mirrors the existing `ErrorSheetHost` architecture, then adopts it across all of TuCop's silent / Android-only success surfaces.

## New infrastructure (commit 1)

- `src/components/showToast.tsx` - subscription-based dispatcher (`subscribeToToasts` + `showToast` + `__resetToastListeners` for tests). Accepts optional `title`, required `message`, optional `variant` (default Success), optional `duration` (default 3000ms).
- `src/components/ToastHost.tsx` - global subscriber that renders the existing `Toast` primitive with auto-dismiss timer.
- `src/app/App.tsx` - mounts `<ToastHost />` next to `<ErrorSheetHost />`.

## Migrated success Alert.alert callers (commit 1)

| File | What was Alert | Now |
|---|---|---|
| `src/earn/PoolList.tsx` | 2 withdraw success + 1 wallet-required | `showToast` (Success x2 + Warning x1) |
| `src/earn/marranitos/MarranitosMyStakes.tsx` | 3 withdraw success | `showToast` (Success x3) |
| `src/earn/marranitos/MarranitoStaking.tsx` | 1 stake success | `showToast` (Success); navigation now fires immediately alongside toast |
| `src/earn/marranitos/MarranitosPools.tsx` | 1 wallet-required | `showToast` (Warning) |

## Migrated clipboard handlers (commit 2)

`Logger.showMessage()` only works on Android (native Toast API) and is silent on iOS. Migrating to `showToast()` closes the cross-platform feedback gap on copy actions:

| File | Action |
|---|---|
| `src/qrcode/QRCode.tsx` | Copy wallet address |
| `src/components/AccountNumber.tsx` | Copy wallet address (TransactionDetails / ExternalExchanges / SettingsMenu) |
| `src/backup/BackupPhraseContainer.tsx` | Copy recovery phrase |
| `src/onboarding/registration/OnboardingRecoveryPhrase.tsx` | Copy mnemonic during onboarding |

All existing i18n keys (`addressCopied`, `copied`, `mnemonicCopied`) preserved.

## Kept as Alert.alert (correct API for cancel/confirm)

- PoolList early-withdraw confirmation
- MarranitosMyStakes early-withdraw confirmation
- positions/saga hooks-preview modal
- BackupQuiz skip-quiz confirmation
- appUpdateChecker forced-update dialog

## Design notes

- `showToast` accepts `NotificationVariant` directly (reuses `Toast` + `InLineNotification` styling primitives unchanged - no new visual surface).
- The existing `ShowErrorMessageInput`'s `'toast'` variant was NOT extended to use this host. The error pipeline classifies + redacts errors; the toast pipeline is for user-facing success / info copy. Different intents, separate paths.
- `MarranitoStaking` success: navigation now fires immediately alongside toast instead of waiting for the user to tap OK. Toast persists on the next screen long enough to be read; user is not blocked.

## Deferred to a follow-up PR

Logger.showMessage / Logger.showError still used in 4 auth-sensitive sites:
- `src/pincode/PincodeSet.tsx` (pin changed / pin change failed)
- `src/pincode/authentication.ts` (account unlock failed)
- `src/RevokePhoneNumber.tsx` (revoke phone failed)
- `src/account/reducer.ts` (debug mode toggle)

These touch auth flows; will migrate in a separate PR with more deliberate testing.

## Test plan

- [x] `yarn build:ts` -> 0 errors
- [x] `yarn lint <all changed files>` -> 0 errors
- [x] `yarn test --testPathPattern="(showToast|QRCode|AccountNumber|BackupPhraseContainer|OnboardingRecoveryPhrase)"` -> 9 suites, 40 tests pass
- [x] `yarn test --testPathPattern="src/(earn|app|components/(Toast|ErrorMessage|showToast))"` -> 30 suites, 238 tests pass (includes App.test.tsx verifying ToastHost mount)
- [ ] **Manual smoke (deferred - no test device available):**
  - Copy address from QRCode -> Toast at bottom appears, auto-dismisses in 3s (now visible on iOS, was silent before)
  - Same for AccountNumber, BackupPhraseContainer, OnboardingRecoveryPhrase
  - Withdraw from marranito pool -> success toast appears
  - Stake into marranito pool -> success toast + navigate to EarnHome
  - Tap marranito pool while wallet disconnected -> Warning toast