### PR TITLE
chore(logger): remove dead showMessage and showError methods

### DIFF
--- a/src/RevokePhoneNumber.tsx
+++ b/src/RevokePhoneNumber.tsx
@@ -14,7 +14,7 @@ import { Screens } from 'src/navigator/Screens'
 import { useSelector } from 'src/redux/hooks'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import Logger from 'src/utils/Logger'
+import { showToast } from 'src/components/showToast'
 import { useRevokeCurrentPhoneNumber } from 'src/verify/hooks'
 
 interface Props {
@@ -38,9 +38,10 @@ export const RevokePhoneNumber = ({ forwardedRef }: Props) => {
       setShowRevokeSuccess(true)
     } else if (revokeNumberAsync.status === 'error') {
       forwardedRef.current?.close()
-      Logger.showError(
-        t('revokePhoneNumber.revokeError') ?? new Error('Could not unlink phone number')
-      )
+      showToast({
+        message: t('revokePhoneNumber.revokeError') ?? 'Could not unlink phone number',
+        variant: NotificationVariant.Error,
+      })
     }
 
     const timeout = setTimeout(() => setShowRevokeSuccess(false), TOAST_DISMISS_TIMEOUT_MS)

--- a/src/account/ProfileSubmenu.test.tsx
+++ b/src/account/ProfileSubmenu.test.tsx
@@ -12,9 +12,10 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as Keychain from 'react-native-keychain'
 const mockFetch = fetch as FetchMock
 const mockedKeychain = jest.mocked(Keychain)
-import Logger from 'src/utils/Logger'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import { showToast } from 'src/components/showToast'
 
-jest.mock('src/utils/Logger')
+jest.mock('src/components/showToast')
 
 mockedKeychain.getGenericPassword.mockResolvedValue({
   username: 'some username',
@@ -101,7 +102,10 @@ describe('ProfileSubmenu', () => {
     })
 
     await waitFor(() =>
-      expect(Logger.showError).toHaveBeenCalledWith('revokePhoneNumber.revokeError')
+      expect(showToast).toHaveBeenCalledWith({
+        message: 'revokePhoneNumber.revokeError',
+        variant: NotificationVariant.Error,
+      })
     )
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })

--- a/src/account/reducer.ts
+++ b/src/account/reducer.ts
@@ -9,7 +9,8 @@ import {
   ActionTypes as OnboardingActionTypes,
 } from 'src/onboarding/actions'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
-import Logger from 'src/utils/Logger'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import { showToast } from 'src/components/showToast'
 import { isE164NumberStrict } from 'src/utils/phoneNumbers'
 import { Actions as Web3Actions, ActionTypes as Web3ActionTypes } from 'src/web3/actions'
 
@@ -195,9 +196,9 @@ export const reducer = (
     case Actions.DEV_MODE_TRIGGER_CLICKED:
       const newClickCount = (state.devModeClickCount + 1) % 10
       if (newClickCount === 5) {
-        Logger.showMessage('Debug Mode Activated')
+        showToast({ message: 'Debug Mode Activated', variant: NotificationVariant.Info })
       } else if (newClickCount === 0) {
-        Logger.showMessage('Debug Mode Deactivated')
+        showToast({ message: 'Debug Mode Deactivated', variant: NotificationVariant.Info })
       }
       return {
         ...state,

--- a/src/pincode/PincodeSet.tsx
+++ b/src/pincode/PincodeSet.tsx
@@ -39,7 +39,8 @@ import { getCachedPin, setCachedPin } from 'src/pincode/PasswordCache'
 import Pincode from 'src/pincode/Pincode'
 import { RootState } from 'src/redux/reducers'
 import Colors from 'src/styles/colors'
-import Logger from 'src/utils/Logger'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import { showToast } from 'src/components/showToast'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 interface StateProps {
@@ -203,10 +204,13 @@ export class PincodeSet extends React.Component<Props, State> {
         const updated = await updatePin(this.props.account, this.state.oldPin, pin2)
         if (updated) {
           AppAnalytics.track(SettingsEvents.change_pin_new_pin_confirmed)
-          Logger.showMessage(this.props.t('pinChanged'))
+          showToast({ message: this.props.t('pinChanged') })
         } else {
           AppAnalytics.track(SettingsEvents.change_pin_new_pin_error)
-          Logger.showMessage(this.props.t('pinChangeFailed'))
+          showToast({
+            message: this.props.t('pinChangeFailed'),
+            variant: NotificationVariant.Error,
+          })
         }
       } else {
         this.props.setPincodeSuccess(PincodeType.CustomPin)

--- a/src/pincode/authentication.ts
+++ b/src/pincode/authentication.ts
@@ -36,6 +36,8 @@ import {
   retrieveStoredItem,
   storeItem,
 } from 'src/storage/keychain'
+import { NotificationVariant } from 'src/components/InLineNotification'
+import { showToast } from 'src/components/showToast'
 import Logger from 'src/utils/Logger'
 import { isValidAddress, normalizeAddress } from 'src/utils/address'
 import { ensureError } from 'src/utils/ensureError'
@@ -463,9 +465,10 @@ export async function ensureCorrectPassword(
     return result
   } catch (error) {
     Logger.error(TAG, 'Error attempting to unlock wallet', error, true)
-    Logger.showError(
-      i18n.t(ErrorMessages.ACCOUNT_UNLOCK_FAILED) ?? new Error('Error attempting to unlock wallet')
-    )
+    showToast({
+      message: i18n.t(ErrorMessages.ACCOUNT_UNLOCK_FAILED) ?? 'Error attempting to unlock wallet',
+      variant: NotificationVariant.Error,
+    })
     return false
   }
 }

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -2,7 +2,6 @@
 import { format } from 'date-fns'
 import { Platform } from 'react-native'
 import * as RNFS from 'react-native-fs'
-import Toast from 'react-native-simple-toast'
 import { DEFAULT_SENTRY_NETWORK_ERRORS, LOGGER_LEVEL } from 'src/config'
 import { LoggerLevel } from 'src/utils/LoggerLevels'
 import { ensureError } from 'src/utils/ensureError'
@@ -102,20 +101,6 @@ class Logger {
 
   setNetworkErrors = (errors: string[]) => {
     this.networkErrors = errors
-  }
-
-  // TODO: see what to do with this on iOS since there's not native toast
-  showMessage = (message: string) => {
-    Toast.showWithGravity(message, Toast.SHORT, Toast.BOTTOM)
-    this.debug('Toast', message)
-  }
-
-  // TODO(Rossy) Remove this. We should be using the error banner instead.
-  // Do not add new code that uses this.
-  showError = (error: string | Error) => {
-    const errorMsg = this.getErrorMessage(error)
-    Toast.showWithGravity(errorMsg, Toast.SHORT, Toast.BOTTOM)
-    this.error('Toast', errorMsg)
   }
 
   getErrorMessage = (error?: string | Error) => {


### PR DESCRIPTION
## Summary

Stacked on #136. Removes two now-unused Logger methods (`showMessage`, `showError`) and the `react-native-simple-toast` import within `src/utils/Logger.ts`. After #135 + #136 merged, no source file calls either method.

15 lines deleted. Trivial cleanup.

## What stays

- `react-native-simple-toast` package: still used by `src/components/Toast.tsx`, `src/transactions/feed/queryHelper.ts`, `src/positions/saga.ts`, `src/components/DataFieldWithCopy.tsx`.
- `Logger.getErrorMessage`: still used internally by `Logger.sanitizeError`.

## Merge order

Merge after #136. If #136 changes, rebase this on the updated base.

## Test plan

- [x] `yarn build:ts` -> 0 errors
- [x] `yarn lint src/utils/Logger.ts` -> 0 errors
- [x] No source file calls `Logger.showMessage` or `Logger.showError` (verified via grep, see #135 and #136 PR bodies)