### PR TITLE
chore(home): wire SHOW_DIGITAL_GOLD Statsig gate to GoldEntrypoint

### DIFF
--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -39,6 +39,8 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -55,6 +57,7 @@ function TabHome(_props: Props) {
   const appState = useSelector(appStateSelector)
   const recipientCache = useSelector(phoneRecipientCacheSelector)
   const isNumberVerified = useSelector(phoneNumberVerifiedSelector)
+  const showDigitalGold = getFeatureGate(StatsigFeatureGates.SHOW_DIGITAL_GOLD)
 
   const dispatch = useDispatch()
   const addCOPmBottomSheetRef = useRef<BottomSheetModalRefType>(null)
@@ -306,7 +309,7 @@ function TabHome(_props: Props) {
               </View>
             </FlatCard>
 
-            <GoldEntrypoint />
+            {showDigitalGold && <GoldEntrypoint />}
 
             <FlatCard
               testID="FlatCard/ReFiColombiaSubsidies"


### PR DESCRIPTION
## Summary

Closes the ROADMAP "Digital Gold polish" item that asked to gate the home-tab Gold entrypoint via the existing `StatsigFeatureGates.SHOW_DIGITAL_GOLD` enum value, which was defined in `src/statsig/types.ts:45` but never consumed.

Before this PR: `<GoldEntrypoint />` was always rendered unconditionally on the home tab.

After this PR: `<GoldEntrypoint />` only renders if Statsig reports `show_digital_gold = true`.

## Pattern

Mirrors `src/earn/EarnEntrypoint.tsx`, which already gates UK compliance the same way (`getFeatureGate(StatsigFeatureGates.SHOW_UK_COMPLIANT_VARIANT)`).

## ⚠️ Rollout requirement

`getFeatureGate` returns `false` by default for any gate that is not `ALLOW_HOOKS_PREVIEW` or `SHOW_ONBOARDING_PHONE_VERIFICATION` (see `src/statsig/index.ts`). If `show_digital_gold` is not explicitly set to `true` in the Statsig dashboard, the Gold entrypoint will silently disappear from production users on rollout.

**Action required before merging / cutting 1.118.5: configure `show_digital_gold = true` in Statsig dashboard.**

## Test plan

- [x] `yarn build:ts` -> 0 errors
- [x] `yarn lint src/home/TabHome.tsx` -> 0 errors
- [x] `yarn test --testPathPattern="src/home/TabHome"` -> 7 tests pass
- [ ] **Manual smoke (deferred):** with `show_digital_gold` ON in Statsig testnetdev, Gold entrypoint shows; with it OFF, entrypoint hides