### PR TITLE
feat: add copy button to recovery phrase in all 3 screens

### DIFF
--- a/src/backup/BackupIntroduction.tsx
+++ b/src/backup/BackupIntroduction.tsx
@@ -1,7 +1,9 @@
+import Clipboard from '@react-native-clipboard/clipboard'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { OnboardingEvents } from 'src/analytics/Events'
@@ -11,7 +13,11 @@ import BackupPhraseContainer, {
 } from 'src/backup/BackupPhraseContainer'
 import { useAccountKey } from 'src/backup/utils'
 import Button from 'src/components/Button'
+import StickyCtaBottom from 'src/components/StickyCtaBottom'
 import TextButton from 'src/components/TextButton'
+import Touchable from 'src/components/Touchable'
+import { showToast } from 'src/components/showToast'
+import CopyIcon from 'src/icons/actions/CopyIcon'
 import Logo from 'src/images/Logo'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -19,6 +25,7 @@ import { StackParamList } from 'src/navigator/types'
 import { RootState } from 'src/redux/reducers'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
+import { vibrateInformative } from 'src/styles/hapticFeedback'
 import { Spacing } from 'src/styles/styles'
 
 interface StateProps {
@@ -91,22 +98,39 @@ function AccountKeyPostSetup() {
 
   const { t } = useTranslation()
 
+  const onPressCopy = () => {
+    if (!accountKey) return
+    Clipboard.setString(accountKey)
+    showToast({ message: t('copied') })
+    vibrateInformative()
+  }
+
   return (
-    <ScrollView>
-      <View testID="RecoveryPhraseContainer" style={styles.postSetupContainer}>
-        <Text style={styles.postSetupTitle}>{t('postSetupTitle')}</Text>
-        <BackupPhraseContainer
-          value={accountKey}
-          mode={BackupPhraseContainerMode.READONLY}
-          type={BackupPhraseType.BACKUP_KEY}
-          includeHeader={false}
-        />
-        <Text style={styles.postSetupBody}>{t('postSetupBody')}</Text>
-      </View>
-      <View style={styles.postSetupCTA}>
-        <TextButton onPress={goToAccountKeyGuide}>{t('postSetupCTA')}</TextButton>
-      </View>
-    </ScrollView>
+    <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View testID="RecoveryPhraseContainer" style={styles.postSetupContainer}>
+          <Text style={styles.postSetupTitle}>{t('postSetupTitle')}</Text>
+          <BackupPhraseContainer
+            value={accountKey}
+            mode={BackupPhraseContainerMode.READONLY}
+            type={BackupPhraseType.BACKUP_KEY}
+            includeHeader={false}
+          />
+          <Touchable borderless onPress={onPressCopy} testID="BackupPhrase/Copy">
+            <View style={styles.copyButton}>
+              <CopyIcon color={colors.accent} size={20} />
+              <Text style={styles.copyText}>{t('copy')}</Text>
+            </View>
+          </Touchable>
+          <Text style={styles.postSetupBody}>{t('postSetupBody')}</Text>
+        </View>
+      </ScrollView>
+      <StickyCtaBottom>
+        <TextButton onPress={goToAccountKeyGuide} style={styles.postSetupCTA}>
+          {t('postSetupCTA')}
+        </TextButton>
+      </StickyCtaBottom>
+    </SafeAreaView>
   )
 }
 
@@ -131,7 +155,7 @@ const styles = StyleSheet.create({
   },
   postSetupTitle: {
     ...typeScale.titleMedium,
-    marginBottom: Spacing.Smallest8,
+    marginBottom: Spacing.Regular16,
   },
   h1: {
     ...typeScale.titleMedium,
@@ -145,12 +169,26 @@ const styles = StyleSheet.create({
   postSetupBody: {
     ...typeScale.bodyMedium,
     marginVertical: Spacing.Regular16,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
   },
   postSetupCTA: {
     alignSelf: 'center',
+  },
+  copyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'center',
+    gap: Spacing.Smallest8,
     paddingVertical: Spacing.Regular16,
-    marginBottom: Spacing.Regular16,
+  },
+  copyText: {
+    ...typeScale.labelSemiBoldMedium,
+    color: colors.accent,
   },
 })
 

--- a/src/backup/BackupPhrase.tsx
+++ b/src/backup/BackupPhrase.tsx
@@ -1,3 +1,4 @@
+import Clipboard from '@react-native-clipboard/clipboard'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as React from 'react'
 import { useTranslation, WithTranslation } from 'react-i18next'
@@ -16,7 +17,10 @@ import { getStoredMnemonic, onGetMnemonicFail } from 'src/backup/utils'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import CancelButton from 'src/components/CancelButton'
 import CustomHeader from 'src/components/header/CustomHeader'
+import { showToast } from 'src/components/showToast'
 import Switch from 'src/components/Switch'
+import Touchable from 'src/components/Touchable'
+import CopyIcon from 'src/icons/actions/CopyIcon'
 import { withTranslation } from 'src/i18n'
 import { noHeader } from 'src/navigator/Headers'
 import { navigate, pushToStack } from 'src/navigator/NavigationService'
@@ -26,6 +30,8 @@ import { StackParamList } from 'src/navigator/types'
 import { RootState } from 'src/redux/reducers'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
+import { vibrateInformative } from 'src/styles/hapticFeedback'
+import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { currentAccountSelector } from 'src/web3/selectors'
 
@@ -104,6 +110,14 @@ class BackupPhrase extends React.Component<Props, State> {
     return this.props.route.params?.isAccountRemoval ?? false
   }
 
+  onPressCopy = () => {
+    const { mnemonic } = this.state
+    if (!mnemonic) return
+    Clipboard.setString(mnemonic)
+    showToast({ message: this.props.t('copied') })
+    vibrateInformative()
+  }
+
   render() {
     const { t, backupCompleted } = this.props
     const { mnemonic, isConfirmChecked } = this.state
@@ -126,6 +140,12 @@ class BackupPhrase extends React.Component<Props, State> {
             mode={BackupPhraseContainerMode.READONLY}
             type={BackupPhraseType.BACKUP_KEY}
           />
+          <Touchable borderless onPress={this.onPressCopy} testID="BackupPhrase/Copy">
+            <View style={styles.copyButton}>
+              <CopyIcon color={colors.accent} size={20} />
+              <Text style={styles.copyText}>{t('copy')}</Text>
+            </View>
+          </Touchable>
           <Text style={styles.body}>{t('backupKeyWarning')}</Text>
         </ScrollView>
         {(!backupCompleted || this.isAccountRemoval()) && (
@@ -199,6 +219,17 @@ const styles = StyleSheet.create({
   continueButton: {
     paddingHorizontal: variables.contentPadding,
     paddingBottom: variables.contentPadding,
+  },
+  copyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'center',
+    gap: Spacing.Smallest8,
+    paddingVertical: Spacing.Regular16,
+  },
+  copyText: {
+    ...typeScale.labelSemiBoldMedium,
+    color: colors.accent,
   },
 })
 

--- a/src/backup/__snapshots__/BackupPhrase.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupPhrase.test.tsx.snap
@@ -236,6 +236,78 @@ exports[`BackupPhrase renders correctly with backup completed 1`] = `
           testID="AccountKeyWordsContainer"
         />
       </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        nativeBackgroundAndroid={
+          {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="BackupPhrase/Copy"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "flexDirection": "row",
+              "gap": 8,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <svg
+            fill="none"
+            height={20}
+            viewBox="0 0 27 27"
+            width={20}
+          >
+            <path
+              d="M26.2938 5.42769L21.5723 0.706167C21.1154 0.249244 20.5061 0 19.8554 0H12.1154C9.24923 0 6.92308 2.32615 6.92308 5.19231V5.53846H5.19231C2.32615 5.53846 0 7.86462 0 10.7308V21.8077C0 24.6738 2.32615 27 5.19231 27H14.8846C17.7508 27 20.0769 24.6738 20.0769 21.8077V21.4615H21.8077C24.6738 21.4615 27 19.1354 27 16.2692V7.14462C27 6.5077 26.7508 5.88461 26.2938 5.42769ZM21.4615 3.53077L23.4554 5.52462H22.9292C22.1123 5.52462 21.4615 4.86001 21.4615 4.05693V3.53077ZM18 21.7939C18 23.5108 16.6015 24.9092 14.8846 24.9092H5.19231C3.47538 24.9092 2.07692 23.5108 2.07692 21.7939V10.7169C2.07692 9.00001 3.47538 7.60155 5.19231 7.60155H6.92308V16.2554C6.92308 19.1215 9.24923 21.4477 12.1154 21.4477H18V21.7939ZM21.8077 19.3708H12.1154C10.3985 19.3708 9 17.9723 9 16.2554V5.17847C9 3.46155 10.3985 2.06308 12.1154 2.06308H19.3846V4.05693C19.3846 6.00924 20.9769 7.60155 22.9292 7.60155H24.9231V16.2554C24.9231 17.9723 23.5246 19.3708 21.8077 19.3708Z"
+              fill="#2F4ACD"
+            />
+          </svg>
+          <Text
+            style={
+              {
+                "color": "#2F4ACD",
+                "fontFamily": "RedHatDisplaySemiBold",
+                "fontSize": 12,
+                "lineHeight": 24,
+              }
+            }
+          >
+            copy
+          </Text>
+        </View>
+      </View>
       <Text
         style={
           {
@@ -488,6 +560,78 @@ exports[`BackupPhrase renders correctly with backup not completed 1`] = `
           }
           testID="AccountKeyWordsContainer"
         />
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        nativeBackgroundAndroid={
+          {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="BackupPhrase/Copy"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "flexDirection": "row",
+              "gap": 8,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <svg
+            fill="none"
+            height={20}
+            viewBox="0 0 27 27"
+            width={20}
+          >
+            <path
+              d="M26.2938 5.42769L21.5723 0.706167C21.1154 0.249244 20.5061 0 19.8554 0H12.1154C9.24923 0 6.92308 2.32615 6.92308 5.19231V5.53846H5.19231C2.32615 5.53846 0 7.86462 0 10.7308V21.8077C0 24.6738 2.32615 27 5.19231 27H14.8846C17.7508 27 20.0769 24.6738 20.0769 21.8077V21.4615H21.8077C24.6738 21.4615 27 19.1354 27 16.2692V7.14462C27 6.5077 26.7508 5.88461 26.2938 5.42769ZM21.4615 3.53077L23.4554 5.52462H22.9292C22.1123 5.52462 21.4615 4.86001 21.4615 4.05693V3.53077ZM18 21.7939C18 23.5108 16.6015 24.9092 14.8846 24.9092H5.19231C3.47538 24.9092 2.07692 23.5108 2.07692 21.7939V10.7169C2.07692 9.00001 3.47538 7.60155 5.19231 7.60155H6.92308V16.2554C6.92308 19.1215 9.24923 21.4477 12.1154 21.4477H18V21.7939ZM21.8077 19.3708H12.1154C10.3985 19.3708 9 17.9723 9 16.2554V5.17847C9 3.46155 10.3985 2.06308 12.1154 2.06308H19.3846V4.05693C19.3846 6.00924 20.9769 7.60155 22.9292 7.60155H24.9231V16.2554C24.9231 17.9723 23.5246 19.3708 21.8077 19.3708Z"
+              fill="#2F4ACD"
+            />
+          </svg>
+          <Text
+            style={
+              {
+                "color": "#2F4ACD",
+                "fontFamily": "RedHatDisplaySemiBold",
+                "fontSize": 12,
+                "lineHeight": 24,
+              }
+            }
+          >
+            copy
+          </Text>
+        </View>
       </View>
       <Text
         style={
@@ -898,6 +1042,78 @@ exports[`BackupPhrase still renders when mnemonic doesnt show up 1`] = `
           }
           testID="AccountKeyWordsContainer"
         />
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        nativeBackgroundAndroid={
+          {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="BackupPhrase/Copy"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "flexDirection": "row",
+              "gap": 8,
+              "paddingVertical": 16,
+            }
+          }
+        >
+          <svg
+            fill="none"
+            height={20}
+            viewBox="0 0 27 27"
+            width={20}
+          >
+            <path
+              d="M26.2938 5.42769L21.5723 0.706167C21.1154 0.249244 20.5061 0 19.8554 0H12.1154C9.24923 0 6.92308 2.32615 6.92308 5.19231V5.53846H5.19231C2.32615 5.53846 0 7.86462 0 10.7308V21.8077C0 24.6738 2.32615 27 5.19231 27H14.8846C17.7508 27 20.0769 24.6738 20.0769 21.8077V21.4615H21.8077C24.6738 21.4615 27 19.1354 27 16.2692V7.14462C27 6.5077 26.7508 5.88461 26.2938 5.42769ZM21.4615 3.53077L23.4554 5.52462H22.9292C22.1123 5.52462 21.4615 4.86001 21.4615 4.05693V3.53077ZM18 21.7939C18 23.5108 16.6015 24.9092 14.8846 24.9092H5.19231C3.47538 24.9092 2.07692 23.5108 2.07692 21.7939V10.7169C2.07692 9.00001 3.47538 7.60155 5.19231 7.60155H6.92308V16.2554C6.92308 19.1215 9.24923 21.4477 12.1154 21.4477H18V21.7939ZM21.8077 19.3708H12.1154C10.3985 19.3708 9 17.9723 9 16.2554V5.17847C9 3.46155 10.3985 2.06308 12.1154 2.06308H19.3846V4.05693C19.3846 6.00924 20.9769 7.60155 22.9292 7.60155H24.9231V16.2554C24.9231 17.9723 23.5246 19.3708 21.8077 19.3708Z"
+              fill="#2F4ACD"
+            />
+          </svg>
+          <Text
+            style={
+              {
+                "color": "#2F4ACD",
+                "fontFamily": "RedHatDisplaySemiBold",
+                "fontSize": 12,
+                "lineHeight": 24,
+              }
+            }
+          >
+            copy
+          </Text>
+        </View>
       </View>
       <Text
         style={

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -14,7 +14,9 @@ import BackupPhraseContainer, {
 import { useAccountKey } from 'src/backup/utils'
 import BottomSheetLegacy from 'src/components/BottomSheetLegacy'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { showToast } from 'src/components/showToast'
 import TextButton from 'src/components/TextButton'
+import Touchable from 'src/components/Touchable'
 import CopyIcon from 'src/icons/actions/CopyIcon'
 import { HeaderTitleWithSubtitle, nuxNavigationOptionsOnboarding } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
@@ -28,7 +30,7 @@ import {
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
-import { showToast } from 'src/components/showToast'
+import { Spacing } from 'src/styles/styles'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.OnboardingRecoveryPhrase>
 
@@ -99,16 +101,12 @@ function OnboardingRecoveryPhrase({ navigation, route }: Props) {
         <Text style={styles.recoveryPhraseBody}>{t('recoveryPhrase.bodyV1_90')}</Text>
       </ScrollView>
       <View style={styles.bottomSection}>
-        <TextButton
-          style={styles.copyButtonStyle}
-          onPress={onPressCopy}
-          testID={'protectWalletCopy'}
-        >
-          <View style={styles.copyIconStyle}>
-            <CopyIcon color={colors.accent} />
+        <Touchable borderless onPress={onPressCopy} testID="protectWalletCopy">
+          <View style={styles.copyButton}>
+            <CopyIcon color={colors.accent} size={20} />
+            <Text style={styles.copyText}>{t('recoveryPhrase.copy')}</Text>
           </View>
-          {t('recoveryPhrase.copy')}
-        </TextButton>
+        </Touchable>
         <Button
           onPress={onPressContinue}
           text={t('recoveryPhrase.continue')}
@@ -152,20 +150,23 @@ const styles = StyleSheet.create({
   bottomSection: {
     flexGrow: 1,
     justifyContent: 'flex-end',
-    padding: 24,
+    padding: Spacing.Thick24,
   },
-  copyIconStyle: {
-    paddingRight: 10,
-  },
-  copyButtonStyle: {
+  copyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
     alignSelf: 'center',
-    justifyContent: 'center',
-    paddingBottom: 30,
+    gap: Spacing.Smallest8,
+    paddingVertical: Spacing.Regular16,
+    paddingBottom: Spacing.Large32,
+  },
+  copyText: {
+    ...typeScale.labelSemiBoldMedium,
     color: colors.accent,
   },
   buttonStyle: {
-    marginTop: 37,
-    marginBottom: 9,
+    marginTop: Spacing.Large32,
+    marginBottom: Spacing.Smallest8,
     textAlign: 'center',
     color: colors.gray3,
   },
@@ -174,31 +175,31 @@ const styles = StyleSheet.create({
   },
   bottomSheetBody: {
     ...typeScale.bodyMedium,
-    marginTop: 12,
-    paddingBottom: 10,
+    marginTop: Spacing.Small12,
+    paddingBottom: Spacing.Smallest8,
   },
   backupPhrase: {
     borderWidth: 1,
     borderColor: colors.black,
-    borderRadius: 8,
+    borderRadius: Spacing.Smallest8,
     marginTop: 0,
   },
   contentContainer: {
     flexGrow: 1,
     justifyContent: 'flex-start',
-    padding: 24,
-    paddingTop: 40,
+    padding: Spacing.Thick24,
+    paddingTop: Spacing.Large32,
   },
   container: {
     flex: 1,
   },
   recoveryPhraseBody: {
-    marginTop: 28,
+    marginTop: Spacing.Thick24,
     ...typeScale.labelSmall,
   },
   recoveryPhraseTitle: {
-    marginTop: 36,
-    marginBottom: 18,
+    marginTop: Spacing.Large32,
+    marginBottom: Spacing.Regular16,
     ...typeScale.titleSmall,
   },
 })


### PR DESCRIPTION
## Summary

Surface a \"Copy\" button next to the recovery phrase on every screen that shows it, using the same design-system tokens across the three flows.

- **Onboarding** (\`OnboardingRecoveryPhrase\`): copy button + Spacing scale / typeScale.
- **Settings** (\`BackupIntroduction\`): copy button + adoption of \`SafeAreaView\` + \`StickyCtaBottom\` to align with the standard screen layout.
- **Account removal** (\`BackupPhrase\`): copy button shared with the others.

All three use the same \`Touchable\` + \`CopyIcon\` row pattern and trigger a \`showToast(\"Copied\")\` confirmation.

## Test plan

- [ ] Onboarding: complete a fresh wallet creation, reach the recovery phrase screen, copy → paste → confirm match
- [ ] Settings: Settings → Security → Recovery phrase, copy → toast appears
- [ ] Account removal: Settings → Security → Remove account flow, copy → toast appears
- [ ] All three layouts visually match (same spacing, button placement, font sizes)