### PR TITLE
chore: drop unused KycStatus and FinclusiveKycStatus enum members

### DIFF
--- a/src/account/reducer.ts
+++ b/src/account/reducer.ts
@@ -55,22 +55,15 @@ interface UserContactDetails {
 export enum KycStatus {
   Created = 'created',
   Completed = 'completed',
-  Failed = 'failed',
-  Pending = 'pending',
-  Expired = 'expired',
   Approved = 'approved',
-  Declined = 'declined',
-  NeedsReview = 'needs-review',
   NotCreated = 'not-created',
 }
 
-// Maintaining this as it's required for migrations
+// Only NotSubmitted is referenced; older numeric values (1..4) may
+// still exist in persisted state, but migrations always overwrite to
+// NotSubmitted so dropping the TS-level mapping is safe.
 export enum FinclusiveKycStatus {
   NotSubmitted = 0,
-  Submitted = 1,
-  Accepted = 2,
-  Rejected = 3,
-  InReview = 4,
 }
 
 export enum RecoveryPhraseInOnboardingStatus {


### PR DESCRIPTION
## Summary

Trim five \`KycStatus\` values (\`Failed\`, \`Pending\`, \`Expired\`, \`Declined\`, \`NeedsReview\`) and four \`FinclusiveKycStatus\` values (\`Submitted\`, \`Accepted\`, \`Rejected\`, \`InReview\`). None are referenced anywhere in \`src/\`; the only KYC values still in use are \`Created\`, \`Completed\`, \`Approved\`, \`NotCreated\` (and \`NotSubmitted\` for the Finclusive flavor).

## Why

Cumulative cleanup work on \`Development\` (toast migration #135-137, etc.) removed the last callers of these enum members. Knip flags them as a regression on the \`Development\` -> \`main\` promote PR (#143). Trimming the dead code here keeps the promote PR clean.

Migrations only ever set \`finclusiveKycStatus\` to \`NotSubmitted\`, so any persisted numeric value (1..4) from older installs gets overwritten on the next migration pass; dropping the TS-level mapping is safe.

## Test plan

- [x] \`yarn build:ts\` passes
- [x] \`yarn test --testPathPattern=\"account|fiatconnect|in-house-liquidity\"\` passes (437 tests)
- [x] Local Knip count: 35 -> 26 unused exported enum members