### PR TITLE
fix(ios): wire Info.plist version keys to build-setting template vars

### DIFF
--- a/ios/MobileStack/Info.plist
+++ b/ios/MobileStack/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.118.4</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -52,7 +52,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>254</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CleverTapAccountID</key>
 	<string>$(CLEVERTAP_ACCOUNT_ID)</string>
 	<key>CleverTapToken</key>


### PR DESCRIPTION
## Summary

\`CFBundleShortVersionString\` and \`CFBundleVersion\` in \`ios/MobileStack/Info.plist\` were hardcoded as \`1.118.4\` and \`254\`. Bumping \`MARKETING_VERSION\` / \`CURRENT_PROJECT_VERSION\` in \`MobileStack.xcodeproj\` alone did not update the archived bundle, and TestFlight rejected the 1.118.5 upload with codes 90186 + 90062 (\"CFBundleShortVersionString must be higher than the previously approved 1.118.4\").

## Fix

Switch both keys to the standard React Native template:

\`\`\`xml
<key>CFBundleShortVersionString</key>
<string>$(MARKETING_VERSION)</string>
<key>CFBundleVersion</key>
<string>$(CURRENT_PROJECT_VERSION)</string>
\`\`\`

After this, bumping the two pbxproj build settings is enough for future releases.

## Test plan

- [ ] Open Xcode, Product -> Clean Build Folder, Product -> Archive
- [ ] Organizer shows the archive as 1.118.5 (255)
- [ ] Upload to App Store Connect succeeds