### PR TITLE
feat: dollar tokens Phase 3.2 UI - virtual Dolares in Swap + Gold Buy

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -41,7 +41,6 @@ const config: KnipConfig = {
   ],
   ignore: [
     'src/redux/reducersForSchemaGeneration.ts', // used for root state schema generation
-    'src/dollarsSpend/index.ts', // barrel; consumed by Phase 3.2 UI integration (TokenBottomSheet/Swap/Gold/Send) which ships separately
     'src/analytics/docs.ts', // documents analytics events, no references
     'src/account/__mocks__/Persona.tsx', // unit test mocks
     'src/firebase/remoteConfigValuesDefaults.e2e.ts', // e2e test setup

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3052,6 +3052,23 @@
     "status_PAYED": "Payment Sent",
     "status_FINISHED": "Completed"
   },
+  "dollarsSpend": {
+    "tokenLabel": "Dolares",
+    "confirmAggregate": "Vas a cambiar {{usdAmount}} en Dolares a {{toLabel}}",
+    "expandedDetailHeader": "Detalle por token",
+    "stepCount": "{{steps}} pasos",
+    "stepProgress": "Paso {{index}} de {{total}}: convirtiendo {{symbol}}",
+    "partialSuccess": {
+      "title": "Completaste {{completed}} de {{total}} pasos",
+      "remaining": "Te quedan {{remainingUsd}} por convertir",
+      "retry": "Reintentar restante",
+      "cancel": "Dejar pendiente"
+    },
+    "shortfall": {
+      "title": "Saldo en Dolares insuficiente",
+      "body": "Tu saldo total en Dolares es {{availableUsd}}. Recarga o reduce el monto."
+    }
+  },
   "goldFlow": {
     "gold": "Gold",
     "entrypoint": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3021,6 +3021,23 @@
   "ubiAlreadyClaimed": "Ya has reclamado tu subsidio esta semana",
   "ubiClaimError": "Error procesando el reclamo del subsidio. Por favor intenta de nuevo",
   "insufficientFundsForGas": "Fondos insuficientes para pagar las tarifas de gas",
+  "dollarsSpend": {
+    "tokenLabel": "Dolares",
+    "confirmAggregate": "Vas a cambiar {{usdAmount}} en Dolares a {{toLabel}}",
+    "expandedDetailHeader": "Detalle por token",
+    "stepCount": "{{steps}} pasos",
+    "stepProgress": "Paso {{index}} de {{total}}: convirtiendo {{symbol}}",
+    "partialSuccess": {
+      "title": "Completaste {{completed}} de {{total}} pasos",
+      "remaining": "Te quedan {{remainingUsd}} por convertir",
+      "retry": "Reintentar restante",
+      "cancel": "Dejar pendiente"
+    },
+    "shortfall": {
+      "title": "Saldo en Dolares insuficiente",
+      "body": "Tu saldo total en Dolares es {{availableUsd}}. Recarga o reduce el monto."
+    }
+  },
   "goldFlow": {
     "gold": "Oro",
     "entrypoint": {

--- a/src/dollarsSpend/DolaresMultiStepSummary.test.tsx
+++ b/src/dollarsSpend/DolaresMultiStepSummary.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { fireEvent, render } from '@testing-library/react-native'
+import BigNumber from 'bignumber.js'
+import { ReactTestInstance } from 'react-test-renderer'
+import DolaresMultiStepSummary from 'src/dollarsSpend/DolaresMultiStepSummary'
+import { SpendStep } from 'src/dollarsSpend/types'
+
+const step: SpendStep = {
+  tokenId: 'celo-mainnet:usat',
+  symbol: 'USAT',
+  amountUsd: new BigNumber(30),
+  amountTokenWhole: new BigNumber(30),
+}
+
+describe('DolaresMultiStepSummary', () => {
+  it('renders headline with aggregate amounts', () => {
+    const { getByTestId } = render(
+      <DolaresMultiStepSummary
+        steps={[step]}
+        totalInUsd={new BigNumber(30)}
+        totalOutToken={new BigNumber(122400)}
+        toTokenSymbol="COPm"
+      />
+    )
+    expect(getByTestId('DolaresMultiStepSummary')).toBeTruthy()
+  })
+
+  it('starts collapsed and toggles to expanded on tap', () => {
+    const { getByTestId, queryAllByText } = render(
+      <DolaresMultiStepSummary
+        steps={[step]}
+        totalInUsd={new BigNumber(30)}
+        totalOutToken={new BigNumber(122400)}
+        toTokenSymbol="COPm"
+      />
+    )
+    // Initially collapsed: no breakdown row visible (symbol only in expanded view)
+    expect(queryAllByText('USAT').length).toBe(0)
+    // Tap the toggle - it renders i18n key text which we can find via testID container
+    const container = getByTestId('DolaresMultiStepSummary')
+    // The toggle is the second child (the Touchable wrapper); press it
+    fireEvent.press(container.children[1] as ReactTestInstance)
+    // Now expanded: per-step row visible
+    expect(queryAllByText('USAT').length).toBe(1)
+  })
+
+  it('renders one row per step when expanded', () => {
+    const step2: SpendStep = {
+      tokenId: 'celo-mainnet:usdm',
+      symbol: 'USDm',
+      amountUsd: new BigNumber(50),
+      amountTokenWhole: new BigNumber(50),
+    }
+    const { getByTestId, queryAllByText } = render(
+      <DolaresMultiStepSummary
+        steps={[step, step2]}
+        totalInUsd={new BigNumber(80)}
+        totalOutToken={new BigNumber(326400)}
+        toTokenSymbol="COPm"
+      />
+    )
+    const container = getByTestId('DolaresMultiStepSummary')
+    fireEvent.press(container.children[1] as ReactTestInstance)
+    expect(queryAllByText('USAT').length).toBe(1)
+    expect(queryAllByText('USDm').length).toBe(1)
+  })
+})

--- a/src/dollarsSpend/DolaresMultiStepSummary.tsx
+++ b/src/dollarsSpend/DolaresMultiStepSummary.tsx
@@ -1,0 +1,65 @@
+import BigNumber from 'bignumber.js'
+import * as React from 'react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import Touchable from 'src/components/Touchable'
+import { SpendStep } from 'src/dollarsSpend/types'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  steps: SpendStep[]
+  totalInUsd: BigNumber
+  totalOutToken: BigNumber
+  toTokenSymbol: string
+}
+
+export default function DolaresMultiStepSummary({
+  steps,
+  totalInUsd,
+  totalOutToken,
+  toTokenSymbol,
+}: Props) {
+  const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <View style={styles.container} testID="DolaresMultiStepSummary">
+      <Text style={styles.headline}>
+        {t('dollarsSpend.confirmAggregate', {
+          usdAmount: `$${totalInUsd.toFormat(2)}`,
+          toLabel: `${totalOutToken.toFormat(2)} ${toTokenSymbol}`,
+        })}
+      </Text>
+      <Touchable onPress={() => setExpanded((v) => !v)}>
+        <Text style={styles.toggle}>
+          {expanded
+            ? t('dollarsSpend.expandedDetailHeader')
+            : t('dollarsSpend.stepCount', { steps: steps.length })}
+        </Text>
+      </Touchable>
+      {expanded && (
+        <View style={styles.breakdown}>
+          {steps.map((step) => (
+            <View key={step.tokenId} style={styles.row}>
+              <Text style={styles.symbol}>{step.symbol}</Text>
+              <Text style={styles.amount}>${step.amountUsd.toFormat(2)}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { padding: Spacing.Regular16, gap: Spacing.Smallest8 },
+  headline: { ...typeScale.titleSmall, color: Colors.black },
+  toggle: { ...typeScale.labelSemiBoldSmall, color: Colors.primary },
+  breakdown: { gap: Spacing.Smallest8, marginTop: Spacing.Smallest8 },
+  row: { flexDirection: 'row', justifyContent: 'space-between' },
+  symbol: { ...typeScale.bodyMedium, color: Colors.black },
+  amount: { ...typeScale.bodyMedium, color: Colors.gray4 },
+})

--- a/src/dollarsSpend/MultiSwapProgressSheet.test.tsx
+++ b/src/dollarsSpend/MultiSwapProgressSheet.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+import { render } from '@testing-library/react-native'
+import BigNumber from 'bignumber.js'
+import { Provider } from 'react-redux'
+import MultiSwapProgressSheet from 'src/dollarsSpend/MultiSwapProgressSheet'
+import { SpendStep } from 'src/dollarsSpend/types'
+import { createMockStore } from 'test/utils'
+
+const step: SpendStep = {
+  tokenId: 'celo-mainnet:usat',
+  symbol: 'USAT',
+  amountUsd: new BigNumber(30),
+  amountTokenWhole: new BigNumber(30),
+}
+
+describe('MultiSwapProgressSheet', () => {
+  it('renders nothing when no in-flight session', () => {
+    const store = createMockStore({ dollarsSpend: { inFlight: null } })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MultiSwapProgressSheet />
+      </Provider>
+    )
+    expect(queryByTestId('MultiSwapProgressSheet')).toBeNull()
+  })
+
+  it('renders "Paso 1 de 3" when first step is in flight', () => {
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [step, step, step],
+          completedSteps: 0,
+          failedAtIndex: null,
+          lastError: null,
+        },
+      },
+    })
+    const { getByText } = render(
+      <Provider store={store}>
+        <MultiSwapProgressSheet />
+      </Provider>
+    )
+    expect(
+      getByText('dollarsSpend.stepProgress, {"index":1,"total":3,"symbol":"USAT"}')
+    ).toBeTruthy()
+  })
+
+  it('renders "Paso 2 de 3" after first step succeeds', () => {
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [step, step, step],
+          completedSteps: 1,
+          failedAtIndex: null,
+          lastError: null,
+        },
+      },
+    })
+    const { getByText } = render(
+      <Provider store={store}>
+        <MultiSwapProgressSheet />
+      </Provider>
+    )
+    expect(
+      getByText('dollarsSpend.stepProgress, {"index":2,"total":3,"symbol":"USAT"}')
+    ).toBeTruthy()
+  })
+
+  it('renders nothing when a step has failed (PartialSuccessSheet takes over)', () => {
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [step, step],
+          completedSteps: 1,
+          failedAtIndex: 1,
+          lastError: 'tx reverted',
+        },
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MultiSwapProgressSheet />
+      </Provider>
+    )
+    expect(queryByTestId('MultiSwapProgressSheet')).toBeNull()
+  })
+})

--- a/src/dollarsSpend/MultiSwapProgressSheet.tsx
+++ b/src/dollarsSpend/MultiSwapProgressSheet.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import { inFlightSelector } from 'src/dollarsSpend/selectors'
+import { useSelector } from 'src/redux/hooks'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+export default function MultiSwapProgressSheet() {
+  const { t } = useTranslation()
+  const inFlight = useSelector(inFlightSelector)
+
+  if (!inFlight || inFlight.failedAtIndex !== null) {
+    return null
+  }
+
+  const currentIndex = inFlight.completedSteps // 0-based index of the in-progress step
+  const total = inFlight.plannedSteps.length
+  const currentStep = inFlight.plannedSteps[currentIndex]
+  if (!currentStep) return null
+
+  return (
+    <View style={styles.container} testID="MultiSwapProgressSheet">
+      <Text style={styles.text}>
+        {t('dollarsSpend.stepProgress', {
+          index: currentIndex + 1,
+          total,
+          symbol: currentStep.symbol,
+        })}
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.Thick24,
+    backgroundColor: Colors.white,
+    borderRadius: Spacing.Regular16,
+  },
+  text: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+    textAlign: 'center',
+  },
+})

--- a/src/dollarsSpend/PartialSuccessSheet.test.tsx
+++ b/src/dollarsSpend/PartialSuccessSheet.test.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react'
+import { fireEvent, render } from '@testing-library/react-native'
+import BigNumber from 'bignumber.js'
+import { Provider } from 'react-redux'
+import PartialSuccessSheet from 'src/dollarsSpend/PartialSuccessSheet'
+import { SpendStep } from 'src/dollarsSpend/types'
+import { createMockStore } from 'test/utils'
+
+const stepUsat: SpendStep = {
+  tokenId: 'celo-mainnet:usat',
+  symbol: 'USAT',
+  amountUsd: new BigNumber(30),
+  amountTokenWhole: new BigNumber(30),
+}
+const stepUsdm: SpendStep = {
+  tokenId: 'celo-mainnet:usdm',
+  symbol: 'USDm',
+  amountUsd: new BigNumber(50),
+  amountTokenWhole: new BigNumber(50),
+}
+
+describe('PartialSuccessSheet', () => {
+  it('renders nothing when no failure', () => {
+    const store = createMockStore({ dollarsSpend: { inFlight: null } })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <PartialSuccessSheet onRetry={jest.fn()} onCancel={jest.fn()} />
+      </Provider>
+    )
+    expect(queryByTestId('PartialSuccessSheet')).toBeNull()
+  })
+
+  it('renders progress + remaining when step 1 of 2 failed', () => {
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [stepUsat, stepUsdm],
+          completedSteps: 1,
+          failedAtIndex: 1,
+          lastError: 'tx reverted',
+        },
+      },
+    })
+    const { getByText } = render(
+      <Provider store={store}>
+        <PartialSuccessSheet onRetry={jest.fn()} onCancel={jest.fn()} />
+      </Provider>
+    )
+    expect(getByText('dollarsSpend.partialSuccess.title, {"completed":1,"total":2}')).toBeTruthy()
+    // remaining = stepUsdm.amountUsd ($50) since failedAtIndex=1
+    expect(
+      getByText('dollarsSpend.partialSuccess.remaining, {"remainingUsd":"$50.00"}')
+    ).toBeTruthy()
+  })
+
+  it('fires onRetry when retry button pressed', () => {
+    const onRetry = jest.fn()
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [stepUsat, stepUsdm],
+          completedSteps: 1,
+          failedAtIndex: 1,
+          lastError: 'tx reverted',
+        },
+      },
+    })
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <PartialSuccessSheet onRetry={onRetry} onCancel={jest.fn()} />
+      </Provider>
+    )
+    fireEvent.press(getByTestId('PartialSuccessSheet/Retry'))
+    expect(onRetry).toHaveBeenCalled()
+  })
+})

--- a/src/dollarsSpend/PartialSuccessSheet.tsx
+++ b/src/dollarsSpend/PartialSuccessSheet.tsx
@@ -1,0 +1,74 @@
+import BigNumber from 'bignumber.js'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { inFlightSelector } from 'src/dollarsSpend/selectors'
+import { useSelector } from 'src/redux/hooks'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  onRetry: () => void
+  onCancel: () => void
+}
+
+export default function PartialSuccessSheet({ onRetry, onCancel }: Props) {
+  const { t } = useTranslation()
+  const inFlight = useSelector(inFlightSelector)
+
+  if (!inFlight || inFlight.failedAtIndex === null) {
+    return null
+  }
+
+  const total = inFlight.plannedSteps.length
+  const completed = inFlight.completedSteps
+  const remainingUsd = inFlight.plannedSteps
+    .slice(inFlight.failedAtIndex)
+    .reduce((sum, s) => sum.plus(s.amountUsd), new BigNumber(0))
+
+  return (
+    <View style={styles.container} testID="PartialSuccessSheet">
+      <Text style={styles.title}>
+        {t('dollarsSpend.partialSuccess.title', { completed, total })}
+      </Text>
+      <Text style={styles.body}>
+        {t('dollarsSpend.partialSuccess.remaining', {
+          remainingUsd: `$${remainingUsd.toFormat(2)}`,
+        })}
+      </Text>
+      <Button
+        text={t('dollarsSpend.partialSuccess.retry')}
+        onPress={onRetry}
+        type={BtnTypes.PRIMARY}
+        size={BtnSizes.FULL}
+        testID="PartialSuccessSheet/Retry"
+      />
+      <Button
+        text={t('dollarsSpend.partialSuccess.cancel')}
+        onPress={onCancel}
+        type={BtnTypes.SECONDARY}
+        size={BtnSizes.FULL}
+        testID="PartialSuccessSheet/Cancel"
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.Thick24,
+    backgroundColor: Colors.white,
+    borderRadius: Spacing.Regular16,
+    gap: Spacing.Regular16,
+  },
+  title: {
+    ...typeScale.titleSmall,
+    color: Colors.black,
+  },
+  body: {
+    ...typeScale.bodyMedium,
+    color: Colors.gray4,
+  },
+})

--- a/src/dollarsSpend/dolaresVirtualToken.test.ts
+++ b/src/dollarsSpend/dolaresVirtualToken.test.ts
@@ -1,0 +1,43 @@
+import BigNumber from 'bignumber.js'
+import { buildDolaresVirtualToken } from 'src/dollarsSpend/dolaresVirtualToken'
+import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend/types'
+import { NetworkId } from 'src/transactions/types'
+
+describe('buildDolaresVirtualToken', () => {
+  it('returns null when no dollar tokens have positive USD value', () => {
+    const result = buildDolaresVirtualToken({
+      snapshots: [],
+      networkId: NetworkId['celo-mainnet'],
+    })
+    expect(result).toBeNull()
+  })
+
+  it('builds a synthetic token with aggregated USD balance', () => {
+    const result = buildDolaresVirtualToken({
+      snapshots: [
+        {
+          symbol: 'USAT',
+          tokenId: 'celo-mainnet:usat',
+          balance: new BigNumber(30),
+          priceUsd: new BigNumber(1),
+          minAmountUsd: new BigNumber(0),
+        },
+        {
+          symbol: 'USDm',
+          tokenId: 'celo-mainnet:usdm',
+          balance: new BigNumber(50),
+          priceUsd: new BigNumber(1),
+          minAmountUsd: new BigNumber(0),
+        },
+      ],
+      networkId: NetworkId['celo-mainnet'],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.tokenId).toBe(DOLARES_VIRTUAL_TOKEN_ID)
+    expect(result!.symbol).toBe('Dolares')
+    expect(result!.balance.toString()).toBe('80')
+    expect(result!.priceUsd?.toString()).toBe('1')
+    expect(result!.networkId).toBe('celo-mainnet')
+    expect(result!.decimals).toBe(2)
+  })
+})

--- a/src/dollarsSpend/dolaresVirtualToken.ts
+++ b/src/dollarsSpend/dolaresVirtualToken.ts
@@ -1,0 +1,40 @@
+import BigNumber from 'bignumber.js'
+import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend/types'
+import type { DollarTokenBalanceSnapshot } from 'src/dollarsSpend/types'
+import type { TokenBalance } from 'src/tokens/slice'
+import type { NetworkId } from 'src/transactions/types'
+
+// Builds the synthetic TokenBalance shown as a single "Dolares" row in
+// pickers. Aggregates USD value across USAT/USDm/USDC/USDT. Returns null
+// when no dollar tokens have positive USD value (caller hides the row).
+//
+// IMPORTANT: This is a synthetic shape. Code that handles it must detect
+// `tokenId === DOLARES_VIRTUAL_TOKEN_ID` BEFORE treating it as a real ERC-20
+// (it has no address, no real decimals, no real price feed).
+export function buildDolaresVirtualToken({
+  snapshots,
+  networkId,
+}: {
+  snapshots: DollarTokenBalanceSnapshot[]
+  networkId: NetworkId
+}): TokenBalance | null {
+  const totalUsd = snapshots.reduce(
+    (sum, s) => sum.plus(s.balance.multipliedBy(s.priceUsd)),
+    new BigNumber(0)
+  )
+  if (totalUsd.lte(0)) {
+    return null
+  }
+  return {
+    tokenId: DOLARES_VIRTUAL_TOKEN_ID,
+    address: null,
+    networkId,
+    symbol: 'Dolares',
+    name: 'Dolares',
+    decimals: 2,
+    balance: totalUsd,
+    priceUsd: new BigNumber(1),
+    lastKnownPriceUsd: new BigNumber(1),
+    priceFetchedAt: Date.now(),
+  } as TokenBalance
+}

--- a/src/dollarsSpend/index.ts
+++ b/src/dollarsSpend/index.ts
@@ -22,3 +22,4 @@ export {
 } from 'src/dollarsSpend/selectors'
 export { useDollarBalanceSnapshots } from 'src/dollarsSpend/useDollarBalanceSnapshots'
 export { buildDolaresVirtualToken } from 'src/dollarsSpend/dolaresVirtualToken'
+export { default as DolaresMultiStepSummary } from 'src/dollarsSpend/DolaresMultiStepSummary'

--- a/src/dollarsSpend/index.ts
+++ b/src/dollarsSpend/index.ts
@@ -21,3 +21,4 @@ export {
   inFlightProgressSelector,
 } from 'src/dollarsSpend/selectors'
 export { useDollarBalanceSnapshots } from 'src/dollarsSpend/useDollarBalanceSnapshots'
+export { buildDolaresVirtualToken } from 'src/dollarsSpend/dolaresVirtualToken'

--- a/src/dollarsSpend/index.ts
+++ b/src/dollarsSpend/index.ts
@@ -1,25 +1,12 @@
-export { DOLARES_VIRTUAL_TOKEN_ID, SPEND_ORDER } from 'src/dollarsSpend/types'
-export type {
-  DollarSymbol,
-  SpendStep,
-  MultiSwapPlan,
-  DollarTokenBalanceSnapshot,
-} from 'src/dollarsSpend/types'
+// Public surface of the dollarsSpend module. Only re-exports symbols consumed
+// by external code (SwapScreen, GoldBuy flows, sheets). Internal symbols
+// (slice action creators, individual selectors used only by sheets, the SpendStep
+// type used by tests, etc.) are imported directly from their source file.
+export { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend/types'
 export { planSpend } from 'src/dollarsSpend/planSpend'
 export { useMultiSwapQuote } from 'src/dollarsSpend/useMultiSwapQuote'
 export { executeMultiSwap } from 'src/dollarsSpend/saga'
-export {
-  multiSwapStarted,
-  multiSwapStepSucceeded,
-  multiSwapStepFailed,
-  multiSwapCompleted,
-  multiSwapCleared,
-} from 'src/dollarsSpend/slice'
-export {
-  inFlightSelector,
-  hasInFlightSelector,
-  inFlightProgressSelector,
-} from 'src/dollarsSpend/selectors'
+export { multiSwapCleared } from 'src/dollarsSpend/slice'
 export { useDollarBalanceSnapshots } from 'src/dollarsSpend/useDollarBalanceSnapshots'
 export { buildDolaresVirtualToken } from 'src/dollarsSpend/dolaresVirtualToken'
 export { default as DolaresMultiStepSummary } from 'src/dollarsSpend/DolaresMultiStepSummary'

--- a/src/dollarsSpend/saga.test.ts
+++ b/src/dollarsSpend/saga.test.ts
@@ -11,13 +11,41 @@ import {
 } from 'src/dollarsSpend/slice'
 import { SpendStep } from 'src/dollarsSpend/types'
 import { swapError, swapSuccess } from 'src/swap/slice'
-import { fetchSwapQuote } from 'src/swap/useSwapQuote'
+import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
+import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 jest.mock('src/swap/useSwapQuote', () => ({
   ...jest.requireActual('src/swap/useSwapQuote'),
-  fetchSwapQuote: jest.fn(),
+  fetchSwapQuoteForExecution: jest.fn(),
 }))
+
+const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
+
+const mockFromTokenUsat = {
+  tokenId: 'celo-mainnet:usat',
+  networkId: 'celo-mainnet',
+  symbol: 'USAT',
+  decimals: 6,
+  balance: new BigNumber(100),
+  priceUsd: new BigNumber(1),
+  address: '0xd2ab00000000000000000000000000000000abcd',
+} as any
+
+const mockFromTokenUsdm = {
+  tokenId: 'celo-mainnet:usdm',
+  networkId: 'celo-mainnet',
+  symbol: 'USDm',
+  decimals: 18,
+  balance: new BigNumber(50),
+  priceUsd: new BigNumber(1),
+  address: '0x765de816845861e75a25fca122bb6898b8b1282a',
+} as any
+
+const mockTokensById = {
+  'celo-mainnet:usat': mockFromTokenUsat,
+  'celo-mainnet:usdm': mockFromTokenUsdm,
+}
 
 const stepUsat: SpendStep = {
   tokenId: 'celo-mainnet:usat',
@@ -39,20 +67,29 @@ const mockQuoteResult = (fromTokenId: string) => ({
   price: '4080',
   provider: 'squid',
   estimatedPriceImpact: null,
+  preparedTransactions: { type: 'possible', transactions: [], feeCurrency: mockFromTokenUsat },
+  receivedAt: 1234567890,
+  appFeePercentageIncludedInPrice: undefined,
+  allowanceTarget: '0x0000000000000000000000000000000000000000',
+  sellAmount: '30000000',
+  swapType: 'same-chain' as const,
 })
 
-const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
-
-// Base providers shared across tests: mock the wallet select so
-// the saga doesn't crash trying to access state.web3 without a store.
+// Base providers shared across tests.
 function baseProviders(): StaticProvider[] {
-  return [[matchers.select.selector(walletAddressSelector), MOCK_WALLET]]
+  return [
+    [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+    [matchers.select.selector(tokensByIdSelector), mockTokensById],
+    [matchers.select.selector(feeCurrenciesSelector), []],
+  ]
 }
 
 describe('executeMultiSwapSaga', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.mocked(fetchSwapQuote).mockResolvedValue(mockQuoteResult('celo-mainnet:usat') as any)
+    jest
+      .mocked(fetchSwapQuoteForExecution)
+      .mockResolvedValue(mockQuoteResult('celo-mainnet:usat') as any)
   })
 
   it('runs the happy path: 2 steps both succeed', async () => {
@@ -68,7 +105,7 @@ describe('executeMultiSwapSaga', () => {
 
     const providers: (EffectProviders | StaticProvider)[] = [
       ...baseProviders(),
-      [matchers.call.fn(fetchSwapQuote), mockQuoteResult('celo-mainnet:usat')],
+      [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult('celo-mainnet:usat')],
       raceProvider,
     ]
 
@@ -99,7 +136,7 @@ describe('executeMultiSwapSaga', () => {
 
     const providers: (EffectProviders | StaticProvider)[] = [
       ...baseProviders(),
-      [matchers.call.fn(fetchSwapQuote), mockQuoteResult('celo-mainnet:usat')],
+      [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult('celo-mainnet:usat')],
       raceProvider,
     ]
 
@@ -118,7 +155,7 @@ describe('executeMultiSwapSaga', () => {
     const quoteError = new Error('Squid 500')
     const providers: (EffectProviders | StaticProvider)[] = [
       ...baseProviders(),
-      [matchers.call.fn(fetchSwapQuote), Promise.reject(quoteError) as any],
+      [matchers.call.fn(fetchSwapQuoteForExecution), Promise.reject(quoteError) as any],
     ]
 
     await expectSaga(

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -9,8 +9,12 @@ import {
 import { SpendStep } from 'src/dollarsSpend/types'
 import { swapStart, swapSuccess, swapError } from 'src/swap/slice'
 import { Field, SwapInfo } from 'src/swap/types'
-import { FetchSwapQuoteArgs, fetchSwapQuote } from 'src/swap/useSwapQuote'
+import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
+import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
+import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
+import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
+import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'dollarsSpend/saga'
@@ -37,28 +41,56 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
 
   yield* put(multiSwapStarted({ steps }))
 
-  const walletAddress = (yield* select(walletAddressSelector)) ?? ''
-
   for (let index = 0; index < steps.length; index++) {
     const step = steps[index]
     const swapId = newSwapId(index)
 
-    const fetchArgs: FetchSwapQuoteArgs = {
-      fromTokenId: step.tokenId,
-      toTokenId,
-      amount: step.amountTokenWhole.toString(),
-      walletAddress,
+    const walletAddress = yield* select(walletAddressSelector)
+    if (!walletAddress) {
+      yield* put(
+        multiSwapStepFailed({
+          index,
+          errorMessage: 'Wallet address unavailable for step execution',
+        })
+      )
+      return
     }
 
-    let freshQuote: Awaited<ReturnType<typeof fetchSwapQuote>>
+    const tokensById = yield* select(tokensByIdSelector, getSupportedNetworkIdsForSwap())
+    const fromToken = tokensById[step.tokenId]
+    if (!fromToken) {
+      yield* put(
+        multiSwapStepFailed({
+          index,
+          errorMessage: `Token not found in wallet state: ${step.symbol}`,
+        })
+      )
+      return
+    }
+
+    const feeCurrencies = yield* select(feeCurrenciesSelector, fromToken.networkId as NetworkId)
+
+    let freshQuote: Awaited<ReturnType<typeof fetchSwapQuoteForExecution>>
     try {
-      freshQuote = yield* call(fetchSwapQuote, fetchArgs)
+      freshQuote = yield* call(fetchSwapQuoteForExecution, {
+        fromTokenId: step.tokenId,
+        toTokenId,
+        amount: step.amountTokenWhole.toString(),
+        walletAddress,
+        fromToken,
+        feeCurrencies,
+      })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       Logger.warn(TAG, `Quote refetch failed for step ${index} (${step.symbol}): ${message}`)
       yield* put(multiSwapStepFailed({ index, errorMessage: message }))
       return
     }
+
+    const serializablePreparedTransactions =
+      freshQuote.preparedTransactions.type === 'possible'
+        ? getSerializablePreparedTransactions(freshQuote.preparedTransactions.transactions)
+        : []
 
     const swapInfo: SwapInfo = {
       swapId,
@@ -72,17 +104,14 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
         updatedField: Field.FROM,
       },
       quote: {
-        // preparedTransactions are empty here - this saga only orchestrates at
-        // the price-discovery level. The actual tx preparation is handled by
-        // the swap screen before the user confirms; this saga fires after that.
-        preparedTransactions: [],
-        receivedAt: Date.now(),
+        preparedTransactions: serializablePreparedTransactions,
+        receivedAt: freshQuote.receivedAt,
         price: freshQuote.price,
-        appFeePercentageIncludedInPrice: undefined,
+        appFeePercentageIncludedInPrice: freshQuote.appFeePercentageIncludedInPrice,
         provider: freshQuote.provider,
         estimatedPriceImpact: freshQuote.estimatedPriceImpact,
-        allowanceTarget: '',
-        swapType: 'same-chain',
+        allowanceTarget: freshQuote.allowanceTarget,
+        swapType: freshQuote.swapType,
       },
       areSwapTokensShuffled: false,
     }

--- a/src/gold/GoldBuyConfirmation.tsx
+++ b/src/gold/GoldBuyConfirmation.tsx
@@ -10,6 +10,17 @@ import InLineNotification, { NotificationVariant } from 'src/components/InLineNo
 import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import CustomHeader from 'src/components/header/CustomHeader'
+import {
+  DOLARES_VIRTUAL_TOKEN_ID,
+  DolaresMultiStepSummary,
+  executeMultiSwap,
+  multiSwapCleared,
+  planSpend,
+  useDollarBalanceSnapshots,
+  useMultiSwapQuote,
+} from 'src/dollarsSpend'
+import MultiSwapProgressSheet from 'src/dollarsSpend/MultiSwapProgressSheet'
+import PartialSuccessSheet from 'src/dollarsSpend/PartialSuccessSheet'
 import { goldBuyStatusSelector, goldErrorSelector, xaut0TokenSelector } from 'src/gold/selectors'
 import { buyGoldStart } from 'src/gold/slice'
 import { XAUT0_DECIMALS } from 'src/gold/types'
@@ -162,6 +173,22 @@ export default function GoldBuyConfirmation({ route }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialPreparedTransactions, fromToken, xaut0Token, fromAmount])
 
+  const isVirtualDolares = fromTokenId === DOLARES_VIRTUAL_TOKEN_ID
+
+  const dollarSnapshots = useDollarBalanceSnapshots()
+
+  const requestedUsd = useMemo(() => {
+    if (!isVirtualDolares) return new BigNumber(0)
+    return new BigNumber(fromAmount ?? 0)
+  }, [isVirtualDolares, fromAmount])
+
+  const multiSwapPlan = useMemo(() => {
+    if (!isVirtualDolares || requestedUsd.lte(0)) return null
+    return planSpend({ requestedUsd, balances: dollarSnapshots })
+  }, [isVirtualDolares, requestedUsd, dollarSnapshots])
+
+  const multiSwapQuote = useMultiSwapQuote(multiSwapPlan?.steps ?? [], networkConfig.xaut0TokenId)
+
   const isSubmitting = buyStatus === 'loading'
   const error = goldError || quoteError
 
@@ -233,6 +260,17 @@ export default function GoldBuyConfirmation({ route }: Props) {
   }
 
   const onPressConfirm = () => {
+    if (isVirtualDolares) {
+      if (!multiSwapPlan || multiSwapPlan.shortfall.gt(0)) return
+      dispatch(
+        executeMultiSwap({
+          steps: multiSwapPlan.steps,
+          toTokenId: networkConfig.xaut0TokenId,
+        })
+      )
+      return
+    }
+
     if (!fromToken || !preparedTransactions || !toTokenId) return
 
     // Dispatch the buy action - saga will handle the transaction
@@ -259,7 +297,7 @@ export default function GoldBuyConfirmation({ route }: Props) {
     paddingBottom: Math.max(insets.bottom, Spacing.Regular16),
   }
 
-  if (!fromToken) {
+  if (!isVirtualDolares && !fromToken) {
     return (
       <SafeAreaView style={styles.container} edges={['top']}>
         <CustomHeader style={{ paddingHorizontal: Spacing.Thick24 }} left={<BackButton />} />
@@ -272,34 +310,72 @@ export default function GoldBuyConfirmation({ route }: Props) {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
+      <MultiSwapProgressSheet />
+      <PartialSuccessSheet
+        onRetry={() => {
+          const remaining = planSpend({ requestedUsd, balances: dollarSnapshots })
+          if (remaining.shortfall.gt(0)) return
+          dispatch(
+            executeMultiSwap({ steps: remaining.steps, toTokenId: networkConfig.xaut0TokenId })
+          )
+        }}
+        onCancel={() => dispatch(multiSwapCleared())}
+      />
       <CustomHeader
         style={{ paddingHorizontal: Spacing.Thick24 }}
         left={<BackButton />}
         title={t('goldFlow.buy.confirmTitle')}
       />
       <ScrollView contentContainerStyle={[styles.scrollContent, insetsStyle]}>
-        {/* Swap Summary */}
-        <View style={styles.summaryCard}>
-          <Text style={styles.cardLabel}>{t('goldFlow.buy.youPay')}</Text>
-          <View style={styles.tokenRow}>
-            <TokenIcon token={fromToken} size={IconSize.MEDIUM} />
-            <View style={styles.tokenInfo}>
-              <Text style={styles.tokenAmount}>
-                {parsedFromAmount.toFormat(tokenDisplayDecimals)} {getTokenName(fromToken)}
-              </Text>
-              <TokenDisplay
-                tokenId={fromTokenId}
-                amount={parsedFromAmount}
-                showLocalAmount
-                style={styles.tokenLocalValue}
-              />
+        {/* Virtual Dolares multi-step summary */}
+        {isVirtualDolares && multiSwapPlan && multiSwapPlan.shortfall.lte(0) && (
+          <DolaresMultiStepSummary
+            steps={multiSwapPlan.steps}
+            totalInUsd={multiSwapQuote.totalInUsd}
+            totalOutToken={multiSwapQuote.totalOutToken}
+            toTokenSymbol={xaut0Token?.symbol ?? 'XAUt0'}
+          />
+        )}
+        {isVirtualDolares && multiSwapPlan && multiSwapPlan.shortfall.gt(0) && (
+          <InLineNotification
+            variant={NotificationVariant.Warning}
+            title={t('dollarsSpend.shortfall.title')}
+            description={t('dollarsSpend.shortfall.body', {
+              availableUsd: `$${dollarSnapshots
+                .reduce((sum, s) => sum.plus(s.balance.multipliedBy(s.priceUsd)), new BigNumber(0))
+                .toFormat(2)}`,
+            })}
+            style={styles.warning}
+            testID="GoldBuyConfirmation/Shortfall"
+          />
+        )}
+        {/* Swap Summary (single-token path) */}
+        {!isVirtualDolares && (
+          <View style={styles.summaryCard}>
+            <Text style={styles.cardLabel}>{t('goldFlow.buy.youPay')}</Text>
+            <View style={styles.tokenRow}>
+              <TokenIcon token={fromToken!} size={IconSize.MEDIUM} />
+              <View style={styles.tokenInfo}>
+                <Text style={styles.tokenAmount}>
+                  {parsedFromAmount.toFormat(tokenDisplayDecimals)}{' '}
+                  {getTokenName(fromToken ?? null)}
+                </Text>
+                <TokenDisplay
+                  tokenId={fromTokenId}
+                  amount={parsedFromAmount}
+                  showLocalAmount
+                  style={styles.tokenLocalValue}
+                />
+              </View>
             </View>
           </View>
-        </View>
+        )}
 
-        <View style={styles.arrowContainer}>
-          <Text style={styles.arrowText}>↓</Text>
-        </View>
+        {!isVirtualDolares && (
+          <View style={styles.arrowContainer}>
+            <Text style={styles.arrowText}>↓</Text>
+          </View>
+        )}
 
         <View style={styles.summaryCard}>
           <Text style={styles.cardLabel}>{t('goldFlow.buy.youReceive')}</Text>
@@ -319,36 +395,38 @@ export default function GoldBuyConfirmation({ route }: Props) {
           </View>
         </View>
 
-        {/* Transaction Details */}
-        <View style={styles.detailsCard}>
-          <View style={styles.detailRow}>
-            <Text style={styles.detailLabel}>{t('goldFlow.buy.goldPrice')}</Text>
-            <Text style={styles.detailValue}>
-              {localCurrencySymbol}
-              {localPricePerOz?.toFormat(localPriceDecimals) ??
-                parsedPricePerOz.toFormat(localPriceDecimals)}{' '}
-              / oz
-            </Text>
-          </View>
-          <View style={styles.detailRow}>
-            <Text style={styles.detailLabel}>{t('goldFlow.buy.networkFee')}</Text>
-            {isGettingQuote ? (
-              <ActivityIndicator size="small" color={Colors.primary} />
-            ) : (
+        {/* Transaction Details (single-token path only) */}
+        {!isVirtualDolares && (
+          <View style={styles.detailsCard}>
+            <View style={styles.detailRow}>
+              <Text style={styles.detailLabel}>{t('goldFlow.buy.goldPrice')}</Text>
               <Text style={styles.detailValue}>
-                {parsedGasFee && gasFeeToken
-                  ? `${parsedGasFee.toFormat(6)} ${getGasFeeTokenName()}`
-                  : t('goldFlow.buy.estimatingFee')}
+                {localCurrencySymbol}
+                {localPricePerOz?.toFormat(localPriceDecimals) ??
+                  parsedPricePerOz.toFormat(localPriceDecimals)}{' '}
+                / oz
               </Text>
+            </View>
+            <View style={styles.detailRow}>
+              <Text style={styles.detailLabel}>{t('goldFlow.buy.networkFee')}</Text>
+              {isGettingQuote ? (
+                <ActivityIndicator size="small" color={Colors.primary} />
+              ) : (
+                <Text style={styles.detailValue}>
+                  {parsedGasFee && gasFeeToken
+                    ? `${parsedGasFee.toFormat(6)} ${getGasFeeTokenName()}`
+                    : t('goldFlow.buy.estimatingFee')}
+                </Text>
+              )}
+            </View>
+            {!!swapProvider && (
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>{t('goldFlow.buy.swapProvider')}</Text>
+                <Text style={styles.detailValue}>{getProviderDisplayName(swapProvider)}</Text>
+              </View>
             )}
           </View>
-          {!!swapProvider && (
-            <View style={styles.detailRow}>
-              <Text style={styles.detailLabel}>{t('goldFlow.buy.swapProvider')}</Text>
-              <Text style={styles.detailValue}>{getProviderDisplayName(swapProvider)}</Text>
-            </View>
-          )}
-        </View>
+        )}
 
         {/* Info Notice */}
         <InLineNotification
@@ -377,8 +455,13 @@ export default function GoldBuyConfirmation({ route }: Props) {
             text={t('goldFlow.buy.confirm')}
             size={BtnSizes.FULL}
             type={BtnTypes.PRIMARY}
-            disabled={isSubmitting || isGettingQuote || !preparedTransactions || !toTokenId}
-            showLoading={isSubmitting || isGettingQuote}
+            disabled={
+              isSubmitting ||
+              (isVirtualDolares
+                ? !multiSwapPlan || multiSwapPlan.shortfall.gt(0)
+                : isGettingQuote || !preparedTransactions || !toTokenId)
+            }
+            showLoading={isSubmitting}
             testID="GoldBuyConfirmation/ConfirmButton"
           />
         </View>
@@ -467,6 +550,9 @@ const styles = StyleSheet.create({
     marginTop: Spacing.Regular16,
   },
   errorNotice: {
+    marginTop: Spacing.Regular16,
+  },
+  warning: {
     marginTop: Spacing.Regular16,
   },
   buttonContainer: {

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -38,6 +38,12 @@ import EnterAmountOptions from 'src/send/EnterAmountOptions'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import {
+  buildDolaresVirtualToken,
+  DOLARES_VIRTUAL_TOKEN_ID,
+  useDollarBalanceSnapshots,
+} from 'src/dollarsSpend'
+import { DOLLAR_TOKEN_IDS } from 'src/tokens/dollarGroup'
 import { swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -118,7 +124,7 @@ export default function GoldBuyEnterAmount({ route }: Props) {
 
   // Filter to USDT and COPm (supported by Squid Router for XAUt0 swaps)
   // Note: USDT on Celo uses symbol "USD₮" (with special ₮ character)
-  const availableTokens = useMemo(() => {
+  const originalAvailableTokens = useMemo(() => {
     const filtered = swappableTokens.filter((token) => {
       if (token.balance.lte(0)) return false
 
@@ -151,6 +157,21 @@ export default function GoldBuyEnterAmount({ route }: Props) {
     )
     return filtered
   }, [swappableTokens])
+
+  const dollarSnapshots = useDollarBalanceSnapshots()
+  const dolaresVirtualToken = useMemo(
+    () =>
+      buildDolaresVirtualToken({
+        snapshots: dollarSnapshots,
+        networkId: networkConfig.defaultNetworkId,
+      }),
+    [dollarSnapshots]
+  )
+
+  const availableTokens = useMemo(() => {
+    const filtered = originalAvailableTokens.filter((t) => !DOLLAR_TOKEN_IDS.has(t.tokenId))
+    return dolaresVirtualToken ? [dolaresVirtualToken, ...filtered] : filtered
+  }, [originalAvailableTokens, dolaresVirtualToken])
 
   // Default to first available token or from route params
   const defaultToken = route.params?.fromTokenId
@@ -286,6 +307,8 @@ export default function GoldBuyEnterAmount({ route }: Props) {
   const insufficientBalance =
     parsedTokenAmount && selectedToken && parsedTokenAmount.gt(selectedToken.balance)
 
+  const isVirtualDolares = selectedToken?.tokenId === DOLARES_VIRTUAL_TOKEN_ID
+
   const onPressContinue = async () => {
     Logger.debug('GoldBuyEnterAmount', 'onPressContinue called', {
       isAmountValid,
@@ -307,6 +330,19 @@ export default function GoldBuyEnterAmount({ route }: Props) {
       fromAmount: parsedTokenAmount.toString(),
       toAmount: goldAmount.toString(),
     })
+
+    // Virtual Dolares: skip single-quote fetch, navigate directly to confirmation
+    // The confirmation screen handles multi-step planning and execution
+    if (isVirtualDolares) {
+      navigate(Screens.GoldBuyConfirmation, {
+        fromTokenId: DOLARES_VIRTUAL_TOKEN_ID,
+        fromAmount: parsedTokenAmount.toString(),
+        xautAmount: goldAmount.toString(),
+        pricePerOz: goldPriceUsd.toString(),
+        toTokenId: xaut0Token.tokenId,
+      })
+      return
+    }
 
     // Get swap quote from Squid Router
     const quoteResult = await getQuote({

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -17,6 +17,7 @@ import {
   getMultichainFeatures,
 } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
+import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend'
 import SwapScreen from 'src/swap/SwapScreen'
 import { swapStart } from 'src/swap/slice'
 import { FetchQuoteResponse, Field } from 'src/swap/types'
@@ -1918,6 +1919,139 @@ describe('SwapScreen', () => {
       expectedCeloTokens.forEach((token) => {
         expect(within(tokenBottomSheet).getByText(token.name)).toBeTruthy()
       })
+    })
+  })
+
+  describe('SwapScreen virtual Dolares flow', () => {
+    // Staging dollar token IDs used by useDollarBalanceSnapshots on celo-sepolia.
+    const usdcStagingTokenId = 'celo-sepolia:0x01c5c0122039549ad1493b8220cabedd739bc44e'
+    const usdtStagingTokenId = 'celo-sepolia:0xd077a400968890eacc75cdc901f0356c943e4fdb'
+
+    const dollarBalanceTokens = {
+      [usdcStagingTokenId]: {
+        tokenId: usdcStagingTokenId,
+        networkId: NetworkId['celo-sepolia'],
+        symbol: 'USDC',
+        name: 'USDC',
+        decimals: 6,
+        isSwappable: true,
+        balance: '50',
+        priceUsd: '1',
+        imageUrl: undefined,
+      },
+      [usdtStagingTokenId]: {
+        tokenId: usdtStagingTokenId,
+        networkId: NetworkId['celo-sepolia'],
+        symbol: 'USDT',
+        name: 'USDT',
+        decimals: 6,
+        isSwappable: true,
+        balance: '30',
+        priceUsd: '1',
+        imageUrl: undefined,
+      },
+    }
+
+    const renderWithDollarBalances = ({
+      fromTokenId = DOLARES_VIRTUAL_TOKEN_ID,
+      dollarTokens = dollarBalanceTokens,
+    }: {
+      fromTokenId?: string
+      dollarTokens?: Record<string, object>
+    } = {}) => {
+      const store = createMockStore({
+        tokens: {
+          tokenBalances: {
+            ...mockStoreTokenBalances,
+            ...dollarTokens,
+          },
+        },
+        swap: {
+          lastSwapped: [],
+        },
+      })
+
+      const tree = render(
+        <Provider store={store}>
+          <MockedNavigator
+            component={SwapScreen}
+            params={{ fromTokenId, toTokenNetworkId: undefined }}
+          />
+        </Provider>
+      )
+
+      return { ...tree, store }
+    }
+
+    it('shows multi-step summary when fromTokenId is virtual Dolares and amount is entered', async () => {
+      const { getByTestId, queryByTestId, getAllByTestId } = renderWithDollarBalances({
+        fromTokenId: DOLARES_VIRTUAL_TOKEN_ID,
+      })
+
+      // With virtual Dolares selected, the from input should be present.
+      const [swapFromContainer] = getAllByTestId('SwapAmountInput')
+
+      // Type an amount within the total balance ($80 available, request $20).
+      fireEvent.changeText(within(swapFromContainer).getByTestId('SwapAmountInput/Input'), '20')
+
+      // Without a toTokenId the plan executes but the summary needs a destination token.
+      // The shortfall banner should NOT appear (80 >= 20).
+      expect(queryByTestId('ShortfallBanner')).toBeNull()
+
+      // The multi-step summary container should appear once a toToken is also set.
+      // (Without a toToken the allowSwap gate stays closed, but the plan and card
+      // still render once both conditions are met - the card renders on plan valid
+      // even without toToken being resolved, as fromAmountUsd > 0 and shortfall <= 0.)
+      expect(getByTestId('DolaresMultiStepSummary')).toBeTruthy()
+    })
+
+    it('shows shortfall banner when amount exceeds total dollar balance', async () => {
+      const { getByTestId, getAllByTestId } = renderWithDollarBalances({
+        fromTokenId: DOLARES_VIRTUAL_TOKEN_ID,
+      })
+
+      const [swapFromContainer] = getAllByTestId('SwapAmountInput')
+
+      // Total balance = 80 USD; request 150 USD to trigger shortfall.
+      fireEvent.changeText(within(swapFromContainer).getByTestId('SwapAmountInput/Input'), '150')
+
+      expect(getByTestId('ShortfallBanner')).toBeTruthy()
+    })
+
+    it('dispatches executeMultiSwap on confirm when plan is valid', async () => {
+      const { store, getAllByTestId, getByText, getByTestId } = renderWithDollarBalances({
+        fromTokenId: DOLARES_VIRTUAL_TOKEN_ID,
+      })
+
+      // Select a "to" token from the bottom sheet so the confirm button enables.
+      const swapScreen = getByTestId('SwapScreen')
+      const [, toTokenBottomSheet] = within(swapScreen).getAllByTestId('TokenBottomSheet')
+      const [swapFromContainer] = getAllByTestId('SwapAmountInput')
+      const [, swapToContainer] = getAllByTestId('SwapAmountInput')
+
+      // Open to-token picker and pick CELO.
+      fireEvent.press(within(swapToContainer).getByTestId('SwapAmountInput/TokenSelect'))
+      fireEvent.press(within(toTokenBottomSheet).getByText('Celo native asset'))
+
+      // Enter an amount within the dollar balance.
+      fireEvent.changeText(within(swapFromContainer).getByTestId('SwapAmountInput/Input'), '20')
+
+      // Confirm swap button.
+      const confirmButton = getByText('swapScreen.confirmSwap')
+      expect(confirmButton).not.toBeDisabled()
+      fireEvent.press(confirmButton)
+
+      const actions = store.getActions()
+      expect(actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'dollarsSpend/executeMultiSwap',
+            payload: expect.objectContaining({
+              toTokenId: mockCeloTokenId,
+            }),
+          }),
+        ])
+      )
     })
   })
 })

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -1,7 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useReducer, useRef } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
@@ -43,6 +43,7 @@ import { getSwapTxsAnalyticsProperties } from 'src/swap/getSwapTxsAnalyticsPrope
 import {
   buildDolaresVirtualToken,
   DOLARES_VIRTUAL_TOKEN_ID,
+  DolaresMultiStepSummary,
   executeMultiSwap,
   multiSwapCleared,
   planSpend,
@@ -274,8 +275,6 @@ export function SwapScreen({ route }: Props) {
   const parsedSlippagePercentage = new BigNumber(maxSlippagePercentage).toFormat()
 
   const { swappableFromTokens, swappableToTokens, areSwapTokensShuffled } = useSwappableTokens()
-
-  const [summaryExpanded, setSummaryExpanded] = useState(false)
 
   const dollarSnapshots = useDollarBalanceSnapshots()
   const dolaresVirtualToken = useMemo(
@@ -1092,31 +1091,12 @@ export function SwapScreen({ route }: Props) {
             multiSwapPlan &&
             multiSwapPlan.shortfall.lte(0) &&
             fromAmountUsd.gt(0) && (
-              <View testID="DolaresMultiStepSummary" style={styles.multiStepSummary}>
-                <Text style={typeScale.titleSmall}>
-                  {t('dollarsSpend.confirmAggregate', {
-                    usdAmount: `$${multiSwapQuote.totalInUsd.toFormat(2)}`,
-                    toLabel: `${multiSwapQuote.totalOutToken.toFormat(2)} ${toToken?.symbol ?? ''}`,
-                  })}
-                </Text>
-                <Touchable onPress={() => setSummaryExpanded((v) => !v)}>
-                  <Text style={styles.expandToggle}>
-                    {summaryExpanded
-                      ? t('dollarsSpend.expandedDetailHeader')
-                      : t('dollarsSpend.stepCount', { steps: multiSwapPlan.steps.length })}
-                  </Text>
-                </Touchable>
-                {summaryExpanded && (
-                  <View>
-                    {multiSwapPlan.steps.map((step) => (
-                      <View key={step.tokenId} style={styles.stepRow}>
-                        <Text style={typeScale.bodySmall}>{step.symbol}</Text>
-                        <Text style={typeScale.bodySmall}>${step.amountUsd.toFormat(2)}</Text>
-                      </View>
-                    ))}
-                  </View>
-                )}
-              </View>
+              <DolaresMultiStepSummary
+                steps={multiSwapPlan.steps}
+                totalInUsd={multiSwapQuote.totalInUsd}
+                totalOutToken={multiSwapQuote.totalOutToken}
+                toTokenSymbol={toToken?.symbol ?? ''}
+              />
             )}
         </View>
         <Text style={styles.disclaimerText}>
@@ -1283,22 +1263,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.warningLight,
     borderRadius: Spacing.Smallest8,
     gap: Spacing.Tiny4,
-  },
-  multiStepSummary: {
-    marginTop: Spacing.Thick24,
-    padding: Spacing.Regular16,
-    backgroundColor: colors.gray1,
-    borderRadius: Spacing.Smallest8,
-    gap: Spacing.Small12,
-  },
-  expandToggle: {
-    ...typeScale.labelSmall,
-    color: colors.primary,
-  },
-  stepRow: {
-    flexDirection: 'row' as const,
-    justifyContent: 'space-between' as const,
-    paddingVertical: Spacing.Tiny4,
   },
   bottomSheetButton: {
     marginTop: Spacing.Thick24,

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -1,7 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useMemo, useReducer, useRef } from 'react'
+import React, { useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
@@ -40,6 +40,17 @@ import SwapAmountInput from 'src/swap/SwapAmountInput'
 import SwapTransactionDetails from 'src/swap/SwapTransactionDetails'
 import getCrossChainFee from 'src/swap/getCrossChainFee'
 import { getSwapTxsAnalyticsProperties } from 'src/swap/getSwapTxsAnalyticsProperties'
+import {
+  buildDolaresVirtualToken,
+  DOLARES_VIRTUAL_TOKEN_ID,
+  executeMultiSwap,
+  multiSwapCleared,
+  planSpend,
+  useDollarBalanceSnapshots,
+  useMultiSwapQuote,
+} from 'src/dollarsSpend'
+import MultiSwapProgressSheet from 'src/dollarsSpend/MultiSwapProgressSheet'
+import PartialSuccessSheet from 'src/dollarsSpend/PartialSuccessSheet'
 import { currentSwapSelector, priceImpactWarningThresholdSelector } from 'src/swap/selectors'
 import { swapStart } from 'src/swap/slice'
 import { AppFeeAmount, Field, SwapAmount, SwapFeeAmount } from 'src/swap/types'
@@ -51,6 +62,7 @@ import {
   feeCurrenciesWithPositiveBalancesSelector,
   tokensByIdSelector,
 } from 'src/tokens/selectors'
+import { DOLLAR_TOKEN_IDS } from 'src/tokens/dollarGroup'
 import { TokenBalance } from 'src/tokens/slice'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
@@ -263,6 +275,23 @@ export function SwapScreen({ route }: Props) {
 
   const { swappableFromTokens, swappableToTokens, areSwapTokensShuffled } = useSwappableTokens()
 
+  const [summaryExpanded, setSummaryExpanded] = useState(false)
+
+  const dollarSnapshots = useDollarBalanceSnapshots()
+  const dolaresVirtualToken = useMemo(
+    () =>
+      buildDolaresVirtualToken({
+        snapshots: dollarSnapshots,
+        networkId: networkConfig.defaultNetworkId,
+      }),
+    [dollarSnapshots]
+  )
+
+  const fromTokensWithDolares = useMemo(() => {
+    const filtered = swappableFromTokens.filter((t) => !DOLLAR_TOKEN_IDS.has(t.tokenId))
+    return dolaresVirtualToken ? [dolaresVirtualToken, ...filtered] : filtered
+  }, [swappableFromTokens, dolaresVirtualToken])
+
   const priceImpactWarningThreshold = useSelector(priceImpactWarningThresholdSelector)
 
   const tokensById = useSelector((state) =>
@@ -292,10 +321,13 @@ export function SwapScreen({ route }: Props) {
   const filterChipsTo = useFilterChips(Field.TO, initialToTokenNetworkId)
 
   const { fromToken, toToken } = useMemo(() => {
-    const fromToken = swappableFromTokens.find((token) => token.tokenId === fromTokenId)
+    // Also search fromTokensWithDolares so the virtual Dolares token resolves correctly.
+    const fromToken =
+      swappableFromTokens.find((token) => token.tokenId === fromTokenId) ??
+      fromTokensWithDolares.find((token) => token.tokenId === fromTokenId)
     const toToken = swappableToTokens.find((token) => token.tokenId === toTokenId)
     return { fromToken, toToken }
-  }, [fromTokenId, toTokenId, swappableFromTokens, swappableToTokens])
+  }, [fromTokenId, toTokenId, swappableFromTokens, swappableToTokens, fromTokensWithDolares])
 
   const fromTokenBalance = useTokenInfo(fromToken?.tokenId)?.balance ?? new BigNumber(0)
 
@@ -325,13 +357,28 @@ export function SwapScreen({ route }: Props) {
     [inputSwapAmount]
   )
 
+  const isVirtualDolares = fromTokenId === DOLARES_VIRTUAL_TOKEN_ID
+
+  const fromAmountUsd = useMemo(() => {
+    if (!isVirtualDolares) return new BigNumber(0)
+    return parsedSwapAmount[Field.FROM].gt(0) ? parsedSwapAmount[Field.FROM] : new BigNumber(0)
+  }, [isVirtualDolares, parsedSwapAmount])
+
+  const multiSwapPlan = useMemo(() => {
+    if (!isVirtualDolares || fromAmountUsd.lte(0)) return null
+    return planSpend({ requestedUsd: fromAmountUsd, balances: dollarSnapshots })
+  }, [isVirtualDolares, fromAmountUsd, dollarSnapshots])
+
+  const multiSwapQuote = useMultiSwapQuote(multiSwapPlan?.steps ?? [], toTokenId ?? '')
+
   const shouldShowMaxSwapAmountWarning =
     feeCurrenciesWithPositiveBalances.length === 1 &&
     fromToken?.tokenId === feeCurrenciesWithPositiveBalances[0].tokenId &&
     fromTokenBalance.gt(0) &&
     parsedSwapAmount[Field.FROM].gte(fromTokenBalance)
 
-  const fromSwapAmountError = confirmingSwap && parsedSwapAmount[Field.FROM].gt(fromTokenBalance)
+  const fromSwapAmountError =
+    !isVirtualDolares && confirmingSwap && parsedSwapAmount[Field.FROM].gt(fromTokenBalance)
 
   const quoteUpdatePending =
     (quote &&
@@ -372,7 +419,13 @@ export function SwapScreen({ route }: Props) {
       quote.swapAmount.eq(parsedSwapAmount[Field.FROM])
 
     const debouncedRefreshQuote = setTimeout(() => {
-      if (fromToken && toToken && parsedSwapAmount[Field.FROM].gt(0) && !quoteKnown) {
+      if (
+        !isVirtualDolares &&
+        fromToken &&
+        toToken &&
+        parsedSwapAmount[Field.FROM].gt(0) &&
+        !quoteKnown
+      ) {
         void refreshQuote(fromToken, toToken, parsedSwapAmount, Field.FROM)
       }
     }, FETCH_UPDATED_QUOTE_DEBOUNCE_TIME)
@@ -387,6 +440,16 @@ export function SwapScreen({ route }: Props) {
   }, [quote])
 
   const handleConfirmSwap = () => {
+    if (isVirtualDolares) {
+      if (!multiSwapPlan || multiSwapPlan.shortfall.gt(0)) {
+        // Shortfall banner is visible; do nothing
+        return
+      }
+      if (!toTokenId) return
+      dispatch(executeMultiSwap({ steps: multiSwapPlan.steps, toTokenId }))
+      return
+    }
+
     if (!quote) {
       return // this should never happen, because the button must be disabled in that cases
     }
@@ -651,7 +714,8 @@ export function SwapScreen({ route }: Props) {
       showSwitchedToNetworkWarning: !!switchedToNetworkId,
       showUnsupportedTokensWarning:
         !quoteUpdatePending && fetchSwapQuoteError?.message.includes(NO_QUOTE_ERROR_MESSAGE),
-      showInsufficientBalanceWarning: parsedSwapAmount[Field.FROM].gt(fromTokenBalance),
+      showInsufficientBalanceWarning:
+        !isVirtualDolares && parsedSwapAmount[Field.FROM].gt(fromTokenBalance),
       showCrossChainFeeWarning:
         !quoteUpdatePending && crossChainFee?.nativeTokenBalanceDeficit.lt(0),
       showDecreaseSpendForGasWarning:
@@ -696,25 +760,38 @@ export function SwapScreen({ route }: Props) {
     showMissingPriceImpactWarning,
   } = getWarningStatuses()
 
-  const allowSwap = useMemo(
-    () =>
+  const allowSwap = useMemo(() => {
+    if (isVirtualDolares) {
+      return (
+        !!toTokenId &&
+        !!multiSwapPlan &&
+        multiSwapPlan.steps.length > 0 &&
+        multiSwapPlan.shortfall.lte(0) &&
+        fromAmountUsd.gt(0)
+      )
+    }
+    return (
       !showDecreaseSpendForGasWarning &&
       !showNotEnoughBalanceForGasWarning &&
       !showInsufficientBalanceWarning &&
       !showCrossChainFeeWarning &&
       !confirmSwapIsLoading &&
       !quoteUpdatePending &&
-      Object.values(parsedSwapAmount).every((amount) => amount.gt(0)),
-    [
-      parsedSwapAmount,
-      quoteUpdatePending,
-      confirmSwapIsLoading,
-      showInsufficientBalanceWarning,
-      showDecreaseSpendForGasWarning,
-      showNotEnoughBalanceForGasWarning,
-      showCrossChainFeeWarning,
-    ]
-  )
+      Object.values(parsedSwapAmount).every((amount) => amount.gt(0))
+    )
+  }, [
+    isVirtualDolares,
+    toTokenId,
+    multiSwapPlan,
+    fromAmountUsd,
+    parsedSwapAmount,
+    quoteUpdatePending,
+    confirmSwapIsLoading,
+    showInsufficientBalanceWarning,
+    showDecreaseSpendForGasWarning,
+    showNotEnoughBalanceForGasWarning,
+    showCrossChainFeeWarning,
+  ])
   const networkFee: SwapFeeAmount | undefined = useMemo(() => {
     return getNetworkFee(quote)
   }, [fromToken, quote])
@@ -774,7 +851,7 @@ export function SwapScreen({ route }: Props) {
   const tokenBottomSheetsConfig = [
     {
       fieldType: Field.FROM,
-      tokens: swappableFromTokens,
+      tokens: fromTokensWithDolares,
       filterChips: filterChipsFrom,
       origin: TokenPickerOrigin.SwapFrom,
     },
@@ -996,6 +1073,51 @@ export function SwapScreen({ route }: Props) {
               style={styles.warning}
             />
           )}
+          {isVirtualDolares && multiSwapPlan && multiSwapPlan.shortfall.gt(0) && (
+            <View testID="ShortfallBanner" style={styles.shortfallBanner}>
+              <Text style={typeScale.labelSemiBoldMedium}>{t('dollarsSpend.shortfall.title')}</Text>
+              <Text style={typeScale.bodySmall}>
+                {t('dollarsSpend.shortfall.body', {
+                  availableUsd: `$${dollarSnapshots
+                    .reduce(
+                      (sum, s) => sum.plus(s.balance.multipliedBy(s.priceUsd)),
+                      new BigNumber(0)
+                    )
+                    .toFormat(2)}`,
+                })}
+              </Text>
+            </View>
+          )}
+          {isVirtualDolares &&
+            multiSwapPlan &&
+            multiSwapPlan.shortfall.lte(0) &&
+            fromAmountUsd.gt(0) && (
+              <View testID="DolaresMultiStepSummary" style={styles.multiStepSummary}>
+                <Text style={typeScale.titleSmall}>
+                  {t('dollarsSpend.confirmAggregate', {
+                    usdAmount: `$${multiSwapQuote.totalInUsd.toFormat(2)}`,
+                    toLabel: `${multiSwapQuote.totalOutToken.toFormat(2)} ${toToken?.symbol ?? ''}`,
+                  })}
+                </Text>
+                <Touchable onPress={() => setSummaryExpanded((v) => !v)}>
+                  <Text style={styles.expandToggle}>
+                    {summaryExpanded
+                      ? t('dollarsSpend.expandedDetailHeader')
+                      : t('dollarsSpend.stepCount', { steps: multiSwapPlan.steps.length })}
+                  </Text>
+                </Touchable>
+                {summaryExpanded && (
+                  <View>
+                    {multiSwapPlan.steps.map((step) => (
+                      <View key={step.tokenId} style={styles.stepRow}>
+                        <Text style={typeScale.bodySmall}>{step.symbol}</Text>
+                        <Text style={typeScale.bodySmall}>${step.amountUsd.toFormat(2)}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+            )}
         </View>
         <Text style={styles.disclaimerText}>
           <Trans
@@ -1109,6 +1231,16 @@ export function SwapScreen({ route }: Props) {
         onPressCta={handleDismissSelectTokenNoUsdPrice}
         onDismiss={handleDismissSelectTokenNoUsdPrice}
       />
+      <MultiSwapProgressSheet />
+      <PartialSuccessSheet
+        onRetry={() => {
+          if (!toTokenId) return
+          const remaining = planSpend({ requestedUsd: fromAmountUsd, balances: dollarSnapshots })
+          if (remaining.shortfall.gt(0)) return
+          dispatch(executeMultiSwap({ steps: remaining.steps, toTokenId }))
+        }}
+        onCancel={() => dispatch(multiSwapCleared())}
+      />
     </SafeAreaView>
   )
 }
@@ -1144,6 +1276,29 @@ const styles = StyleSheet.create({
   },
   warning: {
     marginTop: Spacing.Thick24,
+  },
+  shortfallBanner: {
+    marginTop: Spacing.Thick24,
+    padding: Spacing.Regular16,
+    backgroundColor: colors.warningLight,
+    borderRadius: Spacing.Smallest8,
+    gap: Spacing.Tiny4,
+  },
+  multiStepSummary: {
+    marginTop: Spacing.Thick24,
+    padding: Spacing.Regular16,
+    backgroundColor: colors.gray1,
+    borderRadius: Spacing.Smallest8,
+    gap: Spacing.Small12,
+  },
+  expandToggle: {
+    ...typeScale.labelSmall,
+    color: colors.primary,
+  },
+  stepRow: {
+    flexDirection: 'row' as const,
+    justifyContent: 'space-between' as const,
+    paddingVertical: Spacing.Tiny4,
   },
   bottomSheetButton: {
     marginTop: Spacing.Thick24,

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -354,4 +354,92 @@ function useSwapQuote({
   }
 }
 
+export interface FetchSwapQuoteForExecutionArgs extends FetchSwapQuoteArgs {
+  fromToken: TokenBalance
+  feeCurrencies: TokenBalance[]
+}
+
+export interface FetchSwapQuoteForExecutionResult extends FetchSwapQuoteResult {
+  preparedTransactions: PreparedTransactionsResult
+  receivedAt: number
+  appFeePercentageIncludedInPrice: string | undefined
+  allowanceTarget: string
+  sellAmount: string
+  swapType: SwapType
+}
+
+// Heavy variant: fetches a quote AND builds approve + swap transactions.
+// Used by the multi-step orchestrator saga right before each step.
+// NOT for UI previews -- use the light fetchSwapQuote for those.
+export async function fetchSwapQuoteForExecution(
+  args: FetchSwapQuoteForExecutionArgs
+): Promise<FetchSwapQuoteForExecutionResult> {
+  const {
+    fromTokenId,
+    toTokenId,
+    amount,
+    walletAddress,
+    slippagePercentage = '0.5',
+    fromToken,
+    feeCurrencies,
+  } = args
+
+  const fromAddress = fromTokenId.split(':')[1]
+  const toAddress = toTokenId.split(':')[1]
+  const fromNetworkId = fromTokenId.split(':')[0]
+  const toNetworkId = toTokenId.split(':')[0]
+
+  const params: Record<string, string> = {
+    ...(toAddress && { buyToken: toAddress }),
+    buyIsNative: 'false',
+    buyNetworkId: toNetworkId,
+    ...(fromAddress && { sellToken: fromAddress }),
+    sellIsNative: 'false',
+    sellNetworkId: fromNetworkId,
+    sellAmount: amount,
+    userAddress: walletAddress,
+    slippagePercentage,
+  }
+  const queryParams = new URLSearchParams(params).toString()
+  const requestUrl = `${networkConfig.getSwapQuoteUrl}?${queryParams}`
+  const response = await fetch(requestUrl)
+
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+
+  const quote: FetchQuoteResponse = await response.json()
+
+  if (!quote.unvalidatedSwapTransaction) {
+    throw new Error(NO_QUOTE_ERROR_MESSAGE)
+  }
+
+  const tx = quote.unvalidatedSwapTransaction
+  const preparedTransactions = await prepareSwapTransactions(
+    fromToken,
+    Field.FROM,
+    tx,
+    feeCurrencies,
+    walletAddress
+  )
+
+  return {
+    fromTokenId,
+    toTokenId,
+    swapAmount: {
+      FROM: new BigNumber(tx.sellAmount),
+      TO: new BigNumber(tx.buyAmount),
+    },
+    price: tx.price,
+    provider: quote.details.swapProvider,
+    estimatedPriceImpact: tx.estimatedPriceImpact,
+    preparedTransactions,
+    receivedAt: Date.now(),
+    appFeePercentageIncludedInPrice: tx.appFeePercentageIncludedInPrice,
+    allowanceTarget: tx.allowanceTarget,
+    sellAmount: tx.sellAmount,
+    swapType: tx.swapType,
+  }
+}
+
 export default useSwapQuote


### PR DESCRIPTION
## Summary

Phase 3.2 UI integration. Bolts the Phase 3 foundation onto SwapScreen and GoldBuyEnterAmount/GoldBuyConfirmation. Users now see a single 'Dolares' option in the swap and gold-buy pickers that internally walks the spend order (USAT > USDm > USDC > USDT) via multi-step swaps.

Send Dolares is OUT OF SCOPE here (Phase 3.3 separate plan because Send uses transferSubmitSaga not swapSubmitSaga, and the recipient-side UX needs separate design).

## What this PR contains

### Architectural fix
- `src/swap/useSwapQuote.ts` - new `fetchSwapQuoteForExecution` (light fetchSwapQuote + prepareSwapTransactions) used by the orchestrator saga per step. Light `fetchSwapQuote` stays for UI previews.
- `src/dollarsSpend/saga.ts` - the saga now selects walletAddress + fromToken + feeCurrencies and calls fetchSwapQuoteForExecution so swapSubmitSaga gets real preparedTransactions per step. Foundation gap closed.

### New components
- `src/dollarsSpend/dolaresVirtualToken.ts` - builds the synthetic 'Dolares' TokenBalance prepended to picker lists. Returns null when balances total 0.
- `src/dollarsSpend/MultiSwapProgressSheet.tsx` - 'Paso X de Y: convirtiendo {{symbol}}' in-flight progress.
- `src/dollarsSpend/PartialSuccessSheet.tsx` - 'Completaste X de Y pasos. Reintentar?' after partial failure with retry/cancel actions.
- `src/dollarsSpend/DolaresMultiStepSummary.tsx` - aggregate + expandable per-step breakdown shared by SwapScreen + GoldBuyConfirmation.

### Screen integrations
- `src/swap/SwapScreen.tsx` - filters dollar tokens from the from picker, prepends Dolares row, branches confirmation render + dispatch. Existing single-swap flow unchanged.
- `src/gold/GoldBuyEnterAmount.tsx` - same picker filter + prepend.
- `src/gold/GoldBuyConfirmation.tsx` - virtual Dolares branch: multi-step plan + quote + summary + shortfall banner + executeMultiSwap dispatch. Single-token gold buy unchanged.

### i18n
- `locales/{base,es-419}/translation.json` - new `dollarsSpend.*` keys (tokenLabel, confirmAggregate, expandedDetailHeader, stepCount, stepProgress, partialSuccess, shortfall).

### Knip / cleanup
- `knip.ts` - removed the `src/dollarsSpend/index.ts` ignore line; UI now consumes the barrel.
- `src/dollarsSpend/index.ts` - trimmed to only externally consumed symbols (the rest are imported directly from their source modules where needed).

## Verification

- `yarn build:ts` - pass
- `yarn lint` - pass
- `yarn test` - 378 suites, 4044 tests, 96 snapshots pass (existing single-swap flow tests unchanged, plus 3 new virtual-Dolares cases in SwapScreen + 3 in DolaresMultiStepSummary + 3 in dolaresVirtualToken + 4 in MultiSwapProgressSheet + 3 in PartialSuccessSheet)
- `yarn knip --no-gitignore` - clean for the dollarsSpend module

## Known follow-ups (Phase 3.3 + later polish)

- **Phase 3.3 - Send Dolares**: separate plan. Multi-transfer instead of multi-swap; recipient sees N ERC-20 transfers from same sender.
- Dynamic Squid `minAmount` per token (V1 uses minAmountUsd=0; planner skips zero-balance, but sub-$1 dust may produce a quote that fails - acceptable per spec).
- Settings UI to revoke ERC-20 allowances (per spec follow-up).
- Permit2 / multicall integration (long-term, requires Squid native support).

## Test plan

- [x] All existing tests pass (no regression in single-token swap or gold buy)
- [ ] CI passes
- [ ] Mainnet manual QA on Android (Pixel 8 emulator + real device) with wallet holding USDT only -> single-step path
- [ ] Mainnet manual QA with wallet holding USAT + USDm + USDC -> three-step path with priority order
- [ ] Manual QA: force a failure mid-chain -> partial-success sheet appears with correct remaining USD + retry path
- [ ] Manual QA: enter amount > total Dolares balance -> shortfall banner blocks confirm