### PR TITLE
test: update fixtures to mainnet chain IDs after testnet removal

### DIFF
--- a/src/analytics/AppAnalytics.test.ts
+++ b/src/analytics/AppAnalytics.test.ts
@@ -172,7 +172,7 @@ describe('AppAnalytics', () => {
       'statsig-key',
       { userID: 'someUserId' },
       // Segment client is disabled, so overrideStableID uses device uniqueID as fallback
-      { environment: { tier: 'development' }, overrideStableID: mockDeviceId, localMode: false }
+      { environment: { tier: 'production' }, overrideStableID: mockDeviceId, localMode: false }
     )
   })
 

--- a/src/earn/hooks.test.tsx
+++ b/src/earn/hooks.test.tsx
@@ -111,7 +111,7 @@ const mockSwapDepositResponseBody = {
     ],
     dataProps: {
       swapTransaction: {
-        chainId: 11142220,
+        chainId: 42220,
         buyAmount: '994820',
         sellAmount: '1785876928077378476',
         buyTokenAddress: mockArbArbAddress,
@@ -184,7 +184,7 @@ const expectedSwapDepositPrepareTransactionsResult = {
     appFeePercentageIncludedInPrice: '0.6',
     buyAmount: '994820',
     buyTokenAddress: mockArbArbAddress,
-    chainId: 11142220,
+    chainId: 42220,
     data: '0x0',
     estimatedGasUse: '971972',
     estimatedPriceImpact: '0.0',

--- a/src/keylessBackup/index.test.ts
+++ b/src/keylessBackup/index.test.ts
@@ -96,7 +96,7 @@ describe(getEncryptedMnemonic, () => {
     expect(jest.mocked(SiweClient)).toHaveBeenCalledWith(
       {
         accountAddress: expect.any(String),
-        chainId: 11142220,
+        chainId: 42220,
         clockUrl: networkConfig.cabClockUrl,
         loginUrl: networkConfig.cabLoginUrl,
         sessionDurationMs: 300000,
@@ -134,7 +134,7 @@ describe(getEncryptedMnemonic, () => {
     expect(jest.mocked(SiweClient)).toHaveBeenCalledWith(
       {
         accountAddress: expect.any(String),
-        chainId: 11142220,
+        chainId: 42220,
         clockUrl: networkConfig.cabClockUrl,
         loginUrl: networkConfig.cabLoginUrl,
         sessionDurationMs: 300000,
@@ -169,7 +169,7 @@ describe(getEncryptedMnemonic, () => {
     expect(jest.mocked(SiweClient)).toHaveBeenCalledWith(
       {
         accountAddress: expect.any(String),
-        chainId: 11142220,
+        chainId: 42220,
         clockUrl: networkConfig.cabClockUrl,
         loginUrl: networkConfig.cabLoginUrl,
         sessionDurationMs: 300000,
@@ -202,7 +202,7 @@ describe(deleteEncryptedMnemonic, () => {
     expect(jest.mocked(SiweClient)).toHaveBeenCalledWith(
       {
         accountAddress: expect.any(String),
-        chainId: 11142220,
+        chainId: 42220,
         clockUrl: networkConfig.cabClockUrl,
         loginUrl: networkConfig.cabLoginUrl,
         sessionDurationMs: 300000,
@@ -232,7 +232,7 @@ describe(deleteEncryptedMnemonic, () => {
     expect(jest.mocked(SiweClient)).toHaveBeenCalledWith(
       {
         accountAddress: expect.any(String),
-        chainId: 11142220,
+        chainId: 42220,
         clockUrl: networkConfig.cabClockUrl,
         loginUrl: networkConfig.cabLoginUrl,
         sessionDurationMs: 300000,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -385,6 +385,7 @@ describe('store state', () => {
           "inviteRewardsVersion": "none",
           "isEncryptingComment": false,
           "isSending": false,
+          "lastUsedTokenId": undefined,
           "recentPayments": [],
           "recentRecipients": [],
         },

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -203,7 +203,7 @@ const renderScreen = ({
 const defaultQuote: FetchQuoteResponse = {
   unvalidatedSwapTransaction: {
     swapType: 'same-chain',
-    chainId: 11142220,
+    chainId: 42220,
     price: '1.2345678',
     guaranteedPrice: '1.1234567',
     appFeePercentageIncludedInPrice: undefined,
@@ -1924,12 +1924,12 @@ describe('SwapScreen', () => {
 
   describe('SwapScreen virtual Dolares flow', () => {
     // Fixture token IDs used by useDollarBalanceSnapshots.
-    const usdcStagingTokenId = 'celo-mainnet:0x01c5c0122039549ad1493b8220cabedd739bc44e'
-    const usdtStagingTokenId = 'celo-mainnet:0xd077a400968890eacc75cdc901f0356c943e4fdb'
+    const usdcMainnetTokenId = 'celo-mainnet:0xceba9300f2b948710d2653dd7b07f33a8b32118c'
+    const usdtMainnetTokenId = 'celo-mainnet:0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e'
 
     const dollarBalanceTokens = {
-      [usdcStagingTokenId]: {
-        tokenId: usdcStagingTokenId,
+      [usdcMainnetTokenId]: {
+        tokenId: usdcMainnetTokenId,
         networkId: NetworkId['celo-mainnet'],
         symbol: 'USDC',
         name: 'USDC',
@@ -1939,8 +1939,8 @@ describe('SwapScreen', () => {
         priceUsd: '1',
         imageUrl: undefined,
       },
-      [usdtStagingTokenId]: {
-        tokenId: usdtStagingTokenId,
+      [usdtMainnetTokenId]: {
+        tokenId: usdtMainnetTokenId,
         networkId: NetworkId['celo-mainnet'],
         symbol: 'USDT',
         name: 'USDT',

--- a/src/tokens/hooks.test.tsx
+++ b/src/tokens/hooks.test.tsx
@@ -314,10 +314,10 @@ describe('useSwappableTokens', () => {
     })
 
     const expectedToTokens1 = [mockCeloTokenId, ethTokenId]
-    const expectedFromTokens1 = [mockCrealTokenId, mockPoofTokenId, mockCeloTokenId, ethTokenId]
+    const expectedFromTokens1 = [mockCeloTokenId, ethTokenId, mockCrealTokenId, mockPoofTokenId]
 
-    const expectedToTokens2 = [mockCeloTokenId, ethTokenId]
-    const expectedFromTokens2 = [mockCrealTokenId, mockCeloTokenId, ethTokenId, mockPoofTokenId]
+    const expectedToTokens2 = [ethTokenId, mockCeloTokenId]
+    const expectedFromTokens2 = [ethTokenId, mockCeloTokenId, mockPoofTokenId, mockCrealTokenId]
 
     const { result: result1 } = renderHook(() => useSwappableTokens(), {
       wrapper: (component) => (

--- a/src/viem/getLockableWallet.test.ts
+++ b/src/viem/getLockableWallet.test.ts
@@ -78,7 +78,7 @@ describe('getLockableWallet', () => {
     const mockRequest = jest.fn(async ({ method }) => {
       switch (method) {
         case 'eth_chainId':
-          return toHex(BigInt(11142220))
+          return toHex(BigInt(42220))
         case 'eth_getTransactionCount':
           return toHex(BigInt(1))
         case 'eth_getBlockByNumber':

--- a/src/walletConnect/request.test.ts
+++ b/src/walletConnect/request.test.ts
@@ -38,7 +38,7 @@ const signTransactionRequest = {
     method: SupportedActions.eth_signTransaction,
     params: [{ from: '0xTEST', to: '0xTEST', data: '0x', nonce: 7, gas: '0x5208', value: '0x01' }],
   },
-  chainId: 'eip155:11142220',
+  chainId: 'eip155:42220',
 }
 const serializableTransactionRequest = signTransactionRequest.request
   .params[0] as SerializableTransactionRequest
@@ -47,7 +47,7 @@ const sendTransactionRequest = {
     method: SupportedActions.eth_sendTransaction,
     params: [{ from: '0xTEST', to: '0xTEST', data: '0x', nonce: 7, gas: '0x5208', value: '0x01' }],
   },
-  chainId: 'eip155:11142220',
+  chainId: 'eip155:42220',
 }
 const serializableSendTransactionRequest = sendTransactionRequest.request
   .params[0] as SerializableTransactionRequest
@@ -56,21 +56,21 @@ const personalSignRequest = {
     method: SupportedActions.personal_sign,
     params: ['Some message', '0xdeadbeef'],
   },
-  chainId: 'eip155:11142220',
+  chainId: 'eip155:42220',
 }
 const signTypedDataRequest = {
   request: {
     method: SupportedActions.eth_signTypedData,
     params: ['0xdeadbeef', JSON.stringify(mockTypedData)],
   },
-  chainId: 'eip155:11142220',
+  chainId: 'eip155:42220',
 }
 const signTypedDataV4Request = {
   request: {
     method: SupportedActions.eth_signTypedData_v4,
     params: ['0xdeadbeef', JSON.stringify(mockTypedData)],
   },
-  chainId: 'eip155:11142220',
+  chainId: 'eip155:42220',
 }
 
 const state = createMockStore({
@@ -123,13 +123,13 @@ describe(handleRequest, () => {
   })
 
   it('chooses the correct wallet for the request', async () => {
-    await expectSaga(handleRequest, { ...personalSignRequest, chainId: 'eip155:11155111' })
+    await expectSaga(handleRequest, { ...personalSignRequest, chainId: 'eip155:1' })
       .withState(state)
       .call(getViemWallet, ethereumMainnet)
       .not.call(getViemWallet, celo)
       .run()
 
-    await expectSaga(handleRequest, { ...personalSignRequest, chainId: 'eip155:11142220' })
+    await expectSaga(handleRequest, { ...personalSignRequest, chainId: 'eip155:42220' })
       .withState(state)
       .call(getViemWallet, celo)
       .not.call(getViemWallet, ethereumMainnet)

--- a/src/walletConnect/saga.test.ts
+++ b/src/walletConnect/saga.test.ts
@@ -57,7 +57,7 @@ function createSessionProposal(
       requiredNamespaces: {
         eip155: {
           events: ['chainChanged', 'accountsChanged'],
-          chains: ['eip155:11142220'],
+          chains: ['eip155:42220'],
           methods: ['eth_sendTransaction', 'eth_signTypedData'],
         },
       },
@@ -101,7 +101,7 @@ function createSession(proposerMetadata: CoreTypes.Metadata): SessionTypes.Struc
     },
     namespaces: {
       eip155: {
-        accounts: ['eip155:11142220:0x6131a6d616a4be3737b38988847270a64bc10caa'],
+        accounts: ['eip155:42220:0x6131a6d616a4be3737b38988847270a64bc10caa'],
         events: ['chainChanged', 'accountsChanged'],
         methods: ['eth_sendTransaction', 'eth_signTypedData'],
       },
@@ -112,7 +112,7 @@ function createSession(proposerMetadata: CoreTypes.Metadata): SessionTypes.Struc
     requiredNamespaces: {
       eip155: {
         events: ['chainChanged', 'accountsChanged'],
-        chains: ['eip155:11142220'],
+        chains: ['eip155:42220'],
         methods: ['eth_sendTransaction', 'eth_signTypedData'],
       },
     },
@@ -153,7 +153,7 @@ describe('getDefaultSessionTrackedProperties', () => {
         dappIcon: 'someIcon',
         relayProtocol: 'irn',
         eip155Events: ['chainChanged', 'accountsChanged'],
-        eip155Chains: ['eip155:11142220'],
+        eip155Chains: ['eip155:42220'],
         eip155Methods: ['eth_sendTransaction', 'eth_signTypedData'],
       })
       .run()
@@ -231,7 +231,7 @@ describe(walletConnectSaga, () => {
       type: WalletConnectRequestType.Session,
       pendingSession: sessionProposal,
       namespacesToApprove: expect.anything(),
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
     })
   })
@@ -257,7 +257,7 @@ describe('showSessionRequest', () => {
       type: WalletConnectRequestType.Session,
       pendingSession: sessionProposal,
       namespacesToApprove: expect.anything(),
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
     })
 
@@ -266,10 +266,10 @@ describe('showSessionRequest', () => {
       {
         "eip155": {
           "accounts": [
-            "eip155:11142220:0x0000000000000000000000000000000000007e57",
+            "eip155:42220:0x0000000000000000000000000000000000007e57",
           ],
           "chains": [
-            "eip155:11142220",
+            "eip155:42220",
           ],
           "events": [
             "accountsChanged",
@@ -301,11 +301,11 @@ describe('showSessionRequest', () => {
       namespacesToApprove: expect.objectContaining({
         eip155: expect.objectContaining({
           // matches the chains requested by the dapp
-          chains: ['eip155:11142220'],
-          accounts: ['eip155:11142220:0x0000000000000000000000000000000000007e57'],
+          chains: ['eip155:42220'],
+          accounts: ['eip155:42220:0x0000000000000000000000000000000000007e57'],
         }),
       }),
-      supportedChains: ['eip155:11142220', 'eip155:11155111'], // matches the chains supported by the wallet
+      supportedChains: ['eip155:42220', 'eip155:1'], // matches the chains supported by the wallet
       version: 2,
     })
   })
@@ -327,7 +327,7 @@ describe('showSessionRequest', () => {
         },
         optionalNamespaces: {
           eip155: {
-            chains: ['eip155:11142220'], // this optional chain is supported and will be added to the approved namespaces
+            chains: ['eip155:42220'], // this optional chain is supported and will be added to the approved namespaces
             methods: ['eth_signTransaction', 'some_optional_unsupported_method'],
             events: ['accountsChanged', 'some_optional_unsupported_event'],
           },
@@ -344,7 +344,7 @@ describe('showSessionRequest', () => {
       type: WalletConnectRequestType.Session,
       pendingSession: session,
       namespacesToApprove: expect.anything(),
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
     })
 
@@ -356,11 +356,11 @@ describe('showSessionRequest', () => {
         "eip155": {
           "accounts": [
             "eip155:1:0x0000000000000000000000000000000000007e57",
-            "eip155:11142220:0x0000000000000000000000000000000000007e57",
+            "eip155:42220:0x0000000000000000000000000000000000007e57",
           ],
           "chains": [
             "eip155:1",
-            "eip155:11142220",
+            "eip155:42220",
           ],
           "events": [
             "accountsChanged",
@@ -400,7 +400,7 @@ describe('showSessionRequest', () => {
       type: WalletConnectRequestType.Session,
       pendingSession: session,
       namespacesToApprove: null,
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
     })
   })
@@ -436,10 +436,10 @@ describe('acceptSession', () => {
       proposal: sessionProposal.params,
       supportedNamespaces: {
         eip155: {
-          chains: ['eip155:11142220'],
+          chains: ['eip155:42220'],
           methods: Object.values(SupportedActions) as string[],
           events: Object.values(SupportedEvents) as string[],
-          accounts: [`eip155:11142220:${mockAccount}`],
+          accounts: [`eip155:42220:${mockAccount}`],
         },
       },
     })
@@ -459,10 +459,10 @@ describe('acceptSession', () => {
           "namespaces": {
             "eip155": {
               "accounts": [
-                "eip155:11142220:0x0000000000000000000000000000000000007E57",
+                "eip155:42220:0x0000000000000000000000000000000000007E57",
               ],
               "chains": [
-                "eip155:11142220",
+                "eip155:42220",
               ],
               "events": [
                 "accountsChanged",
@@ -563,10 +563,10 @@ describe('showActionRequest', () => {
     expect(navigate).toHaveBeenNthCalledWith(2, Screens.WalletConnectRequest, {
       type: WalletConnectRequestType.Action,
       pendingAction: actionRequest,
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
       hasInsufficientGasFunds: false,
-      feeCurrenciesSymbols: [],
+      feeCurrenciesSymbols: ['CELO', 'cUSD', 'cEUR'],
       preparedTransaction: mockPreparedTransactions.transactions[0],
       prepareTransactionErrorMessage: undefined,
     })
@@ -598,10 +598,10 @@ describe('showActionRequest', () => {
     expect(navigate).toHaveBeenNthCalledWith(2, Screens.WalletConnectRequest, {
       type: WalletConnectRequestType.Action,
       pendingAction: actionRequest,
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
       hasInsufficientGasFunds: false,
-      feeCurrenciesSymbols: [],
+      feeCurrenciesSymbols: ['CELO', 'cUSD', 'cEUR'],
       preparedTransaction: undefined,
       prepareTransactionErrorMessage: 'Some error',
     })
@@ -633,10 +633,10 @@ describe('showActionRequest', () => {
     expect(navigate).toHaveBeenNthCalledWith(2, Screens.WalletConnectRequest, {
       type: WalletConnectRequestType.Action,
       pendingAction: actionRequest,
-      supportedChains: ['eip155:11142220'],
+      supportedChains: ['eip155:42220'],
       version: 2,
       hasInsufficientGasFunds: false,
-      feeCurrenciesSymbols: [],
+      feeCurrenciesSymbols: ['CELO', 'cUSD', 'cEUR'],
       preparedTransaction: undefined,
       prepareTransactionErrorMessage: 'viem short message',
     })

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -43,7 +43,7 @@ describe('ActionRequest with WalletConnect V2', () => {
     controller: 'b991206845c62280479fd1f24087e9c6f0df3921b5f9d94f4619fbf995a81149',
     namespaces: {
       eip155: {
-        accounts: ['eip155:11142220:0x047154ac4d7e01b1dc9ddeea9e8996b57895a747'],
+        accounts: ['eip155:42220:0x047154ac4d7e01b1dc9ddeea9e8996b57895a747'],
         methods: [
           'eth_sendTransaction',
           'eth_signTransaction',
@@ -66,7 +66,7 @@ describe('ActionRequest with WalletConnect V2', () => {
           'personal_sign',
           'eth_signTypedData',
         ],
-        chains: ['eip155:11142220'],
+        chains: ['eip155:42220'],
         events: ['chainChanged', 'accountsChanged'],
       },
     },
@@ -78,7 +78,7 @@ describe('ActionRequest with WalletConnect V2', () => {
     id: 1669810746892321,
     topic: 'd8afe1f5c3efa38bbb62c68005f572a7218afcd48703e4b02bdc5df2549ac5b5',
     params: {
-      chainId: 'eip155:11142220',
+      chainId: 'eip155:42220',
       request: {
         method: 'personal_sign',
         params: [
@@ -118,7 +118,7 @@ describe('ActionRequest with WalletConnect V2', () => {
     _baseFeePerGas: '5000000000',
   }
 
-  const supportedChains = ['eip155:11142220']
+  const supportedChains = ['eip155:42220']
 
   describe('eth_sendTransaction', () => {
     const store = createMockStore({

--- a/src/walletConnect/screens/SessionRequest.test.tsx
+++ b/src/walletConnect/screens/SessionRequest.test.tsx
@@ -20,7 +20,7 @@ describe(SessionRequest, () => {
       requiredNamespaces: {
         eip155: {
           methods: ['eth_sendTransaction', 'personal_sign'],
-          chains: ['eip155:11155111', 'eip155:11142220'],
+          chains: ['eip155:1', 'eip155:42220'],
           events: ['chainChanged', 'accountsChanged'],
         },
       },
@@ -54,15 +54,15 @@ describe(SessionRequest, () => {
     proposal: pendingSession.params,
     supportedNamespaces: {
       eip155: {
-        chains: ['eip155:11155111', 'eip155:11142220'],
+        chains: ['eip155:1', 'eip155:42220'],
         methods: Object.values(SupportedActions) as string[],
         events: Object.values(SupportedEvents) as string[],
-        accounts: [`eip155:11155111:${mockAccount}`, `eip155:11142220:${mockAccount}`],
+        accounts: [`eip155:1:${mockAccount}`, `eip155:42220:${mockAccount}`],
       },
     },
   })
 
-  const supportedChains = ['eip155:11142220']
+  const supportedChains = ['eip155:42220']
 
   const store = createMockStore({})
 
@@ -78,7 +78,7 @@ describe(SessionRequest, () => {
             version={2}
             pendingSession={pendingSession}
             namespacesToApprove={namespacesToApprove}
-            supportedChains={['eip155:11155111', 'eip155:11142220']}
+            supportedChains={['eip155:1', 'eip155:42220']}
           />
         </Provider>
       )


### PR DESCRIPTION
Follow-up to PR #162 (Sepolia removal). Updates 11 test files that still referenced testnet chain IDs (11142220 Celo Sepolia, 11155111 Ethereum Sepolia, etc).

### Files updated
- src/walletConnect/saga.test.ts, request.test.ts, screens/ActionRequest.test.tsx, screens/SessionRequest.test.tsx
- src/swap/SwapScreen.test.tsx (also fixed virtual Dolares fixtures using sepolia USDT/USDC addresses)
- src/tokens/hooks.test.tsx (recomputed deterministic shuffle expectations)
- src/redux/store.test.ts (snapshot update)
- src/keylessBackup/index.test.ts (5 chain ID occurrences)
- src/analytics/AppAnalytics.test.ts (Statsig env tier production)
- src/viem/getLockableWallet.test.ts (mock eth_chainId)
- src/earn/hooks.test.tsx (proactive cleanup of stale refs)

### Verification
`yarn test` 377/378 suites pass, 4045 tests pass. One pre-existing timezone flake unrelated.
`grep -rin 'sepolia|alfajores|testnet'` over src/ and test/ returns empty.
`grep -rin '11142220|11155111|421614|11155420|80002|84532'` returns empty.

No new testnet references introduced.