### PR TITLE
chore(knip): remove stale husky ignore entry post v9 upgrade

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -37,7 +37,6 @@ const config: KnipConfig = {
     '@sentry/types', // type definitions for sentry
     'react-native-svg-mock', // test mocking
     '@types/jest',
-    'husky',
   ],
   ignore: [
     'src/redux/reducersForSchemaGeneration.ts', // used for root state schema generation


### PR DESCRIPTION
Knip's full report on Development came back clean except for one configuration issue: `husky` was listed in `ignoreDependencies` but is no longer a runtime dep (managed via .husky/ folder per husky v9 upgrade in PR #165).

### Knip baseline
After this PR, `yarn knip --no-gitignore --include dependencies` reports zero issues.

### Closes Track D in-repo work
Last in-repo task of Track D Plan 04. Backend tasks 4-5-6 (CoinMarketCap + Blockscout proxies in api-wallet-tucop) remain.