### PR TITLE
feat(errors): add blockchain error taxonomy

### DIFF
--- a/src/lib/errors/classify.test.ts
+++ b/src/lib/errors/classify.test.ts
@@ -1,0 +1,51 @@
+import { classifyError } from './classify'
+
+describe('classifyError', () => {
+  it('classifies "insufficient funds" as gas-insufficient', () => {
+    const c = classifyError(new Error('insufficient funds for gas'))
+    expect(c.kind).toBe('gas-insufficient')
+    expect(c.retryable).toBe(false)
+  })
+
+  it('classifies "execution reverted: slippage" as slippage', () => {
+    const c = classifyError(new Error('execution reverted: slippage'))
+    expect(c.kind).toBe('slippage')
+    expect(c.retryable).toBe(true)
+  })
+
+  it('classifies network errors as rpc-timeout retryable', () => {
+    const c = classifyError(new Error('Network request failed'))
+    expect(c.kind).toBe('rpc-timeout')
+    expect(c.retryable).toBe(true)
+  })
+
+  it('classifies user-rejected pin as user-rejected non-retryable', () => {
+    const c = classifyError(new Error('user rejected the request'))
+    expect(c.kind).toBe('user-rejected')
+    expect(c.retryable).toBe(false)
+  })
+
+  it('classifies nonce conflicts as retryable', () => {
+    const c = classifyError(new Error('nonce too low'))
+    expect(c.kind).toBe('nonce-conflict')
+    expect(c.retryable).toBe(true)
+  })
+
+  it('falls back to unknown for unrecognized errors', () => {
+    const c = classifyError(new Error('something weird'))
+    expect(c.kind).toBe('unknown')
+    expect(c.retryable).toBe(true)
+  })
+
+  it('preserves the raw error', () => {
+    const raw = new Error('original')
+    const c = classifyError(raw)
+    expect(c.raw).toBe(raw)
+  })
+
+  it('handles non-Error inputs', () => {
+    const c = classifyError('a string error')
+    expect(c.message).toBe('a string error')
+    expect(c.kind).toBe('unknown')
+  })
+})

--- a/src/lib/errors/classify.ts
+++ b/src/lib/errors/classify.ts
@@ -1,0 +1,21 @@
+import type { ErrorClass, ErrorKind } from './types'
+
+const PATTERNS: Array<[RegExp, ErrorKind, boolean]> = [
+  [/insufficient funds/i, 'gas-insufficient', false],
+  [/slippage|price moved|min.{0,3}received/i, 'slippage', true],
+  [/user rejected|user denied|user cancel/i, 'user-rejected', false],
+  [/nonce.{0,15}(low|conflict|too low)/i, 'nonce-conflict', true],
+  [/timeout|deadline|timed out/i, 'rpc-timeout', true],
+  [/network request failed|fetch failed/i, 'rpc-timeout', true],
+  [/execution reverted/i, 'revert', false],
+]
+
+export function classifyError(err: unknown): ErrorClass {
+  const message = err instanceof Error ? err.message : String(err)
+  for (const [pattern, kind, retryable] of PATTERNS) {
+    if (pattern.test(message)) {
+      return { kind, message, retryable, raw: err }
+    }
+  }
+  return { kind: 'unknown', message, retryable: true, raw: err }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,0 +1,2 @@
+export type { ErrorClass, ErrorKind } from './types'
+export { classifyError } from './classify'

--- a/src/lib/errors/types.ts
+++ b/src/lib/errors/types.ts
@@ -1,0 +1,17 @@
+export type ErrorKind =
+  | 'gas-insufficient'
+  | 'slippage'
+  | 'revert'
+  | 'rpc-timeout'
+  | 'user-rejected'
+  | 'connectivity'
+  | 'app-backgrounded'
+  | 'nonce-conflict'
+  | 'unknown'
+
+export interface ErrorClass {
+  kind: ErrorKind
+  message: string
+  retryable: boolean
+  raw?: unknown
+}


### PR DESCRIPTION
Plan 01 Track A Task 1.

Single source of truth for blockchain-transaction error classification. Consumed by useTransactionInFlight, TransactionResultSheet, retry logic.

### Files
- `src/lib/errors/types.ts` — `ErrorKind` union + `ErrorClass` interface
- `src/lib/errors/classify.ts` — `classifyError()` with regex pattern table
- `src/lib/errors/index.ts` — public barrel
- `src/lib/errors/classify.test.ts` — 8 unit tests (all passing)

### Tests
8/8 PASS: gas-insufficient, slippage, rpc-timeout x2, user-rejected, nonce-conflict, unknown fallback, raw preservation, non-Error input.

### Verification
- yarn build:ts ✓
- yarn lint ✓
- 8/8 tests pass

Foundation for Track A Tasks 4 (useTransactionInFlight), 7 (TransactionResultSheet), and Track B Tasks 1, 4.