### PR TITLE
fix(dollarsSpend): close rendering-gap between progress and partial-success

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3052,6 +3052,7 @@
     "expandedDetailHeader": "Detalle por token",
     "stepCount": "{{steps}} pasos",
     "stepProgress": "Paso {{index}} de {{total}}: convirtiendo {{symbol}}",
+    "transitioning": "Finishing your operation...",
     "partialSuccess": {
       "title": "Completaste {{completed}} de {{total}} pasos",
       "remaining": "Te quedan {{remainingUsd}} por convertir",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3026,6 +3026,7 @@
     "expandedDetailHeader": "Detalle por token",
     "stepCount": "{{steps}} pasos",
     "stepProgress": "Paso {{index}} de {{total}}: convirtiendo {{symbol}}",
+    "transitioning": "Finalizando tu cambio...",
     "partialSuccess": {
       "title": "Completaste {{completed}} de {{total}} pasos",
       "remaining": "Te quedan {{remainingUsd}} por convertir",

--- a/src/dollarsSpend/TransactionFlowShell.test.tsx
+++ b/src/dollarsSpend/TransactionFlowShell.test.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react'
+import { render } from '@testing-library/react-native'
+import BigNumber from 'bignumber.js'
+import { Provider } from 'react-redux'
+import TransactionFlowShell from 'src/dollarsSpend/TransactionFlowShell'
+import { SpendStep } from 'src/dollarsSpend/types'
+import { createMockStore } from 'test/utils'
+
+const stepUsat: SpendStep = {
+  tokenId: 'celo-mainnet:usat',
+  symbol: 'USAT',
+  amountUsd: new BigNumber(30),
+  amountTokenWhole: new BigNumber(30),
+  decimals: 6,
+}
+const stepUsdm: SpendStep = {
+  tokenId: 'celo-mainnet:usdm',
+  symbol: 'USDm',
+  amountUsd: new BigNumber(50),
+  amountTokenWhole: new BigNumber(50),
+  decimals: 18,
+}
+
+describe('TransactionFlowShell', () => {
+  it('renders nothing when no in-flight session and not transitioning', () => {
+    const store = createMockStore({
+      dollarsSpend: { inFlight: null, transitioning: false },
+    })
+    const { queryByTestId, toJSON } = render(
+      <Provider store={store}>
+        <TransactionFlowShell onRetry={jest.fn()} onCancel={jest.fn()} />
+      </Provider>
+    )
+    expect(queryByTestId('MultiSwapProgressSheet')).toBeNull()
+    expect(queryByTestId('PartialSuccessSheet')).toBeNull()
+    expect(queryByTestId('TxFlowShell/Transitioning')).toBeNull()
+    expect(toJSON()).toBeNull()
+  })
+
+  it('renders MultiSwapProgressSheet while a step is in flight', () => {
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [stepUsat, stepUsdm],
+          completedSteps: 0,
+          failedAtIndex: null,
+          lastError: null,
+        },
+        transitioning: false,
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <TransactionFlowShell onRetry={jest.fn()} onCancel={jest.fn()} />
+      </Provider>
+    )
+    expect(queryByTestId('MultiSwapProgressSheet')).not.toBeNull()
+    expect(queryByTestId('PartialSuccessSheet')).toBeNull()
+    expect(queryByTestId('TxFlowShell/Transitioning')).toBeNull()
+  })
+
+  it('renders the transitional message when transitioning is true (closes the blank-frame gap)', () => {
+    // This is the regression: between multiSwapStepFailed and Redux propagating
+    // the failure, BOTH sheets used to return null and the user saw a blank frame.
+    // The shell now shows a transitional message in that window.
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [stepUsat, stepUsdm],
+          completedSteps: 1,
+          failedAtIndex: 1,
+          lastError: 'tx reverted',
+        },
+        transitioning: true,
+      },
+    })
+    const { getByTestId, getByText, queryByTestId } = render(
+      <Provider store={store}>
+        <TransactionFlowShell onRetry={jest.fn()} onCancel={jest.fn()} />
+      </Provider>
+    )
+    expect(getByTestId('TxFlowShell/Transitioning')).toBeTruthy()
+    expect(getByText('dollarsSpend.transitioning')).toBeTruthy()
+    expect(queryByTestId('MultiSwapProgressSheet')).toBeNull()
+    expect(queryByTestId('PartialSuccessSheet')).toBeNull()
+  })
+
+  it('renders PartialSuccessSheet once the transition window closes', () => {
+    const store = createMockStore({
+      dollarsSpend: {
+        inFlight: {
+          plannedSteps: [stepUsat, stepUsdm],
+          completedSteps: 1,
+          failedAtIndex: 1,
+          lastError: 'tx reverted',
+        },
+        transitioning: false,
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <TransactionFlowShell onRetry={jest.fn()} onCancel={jest.fn()} />
+      </Provider>
+    )
+    expect(queryByTestId('PartialSuccessSheet')).not.toBeNull()
+    expect(queryByTestId('MultiSwapProgressSheet')).toBeNull()
+    expect(queryByTestId('TxFlowShell/Transitioning')).toBeNull()
+  })
+})

--- a/src/dollarsSpend/TransactionFlowShell.tsx
+++ b/src/dollarsSpend/TransactionFlowShell.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import MultiSwapProgressSheet from 'src/dollarsSpend/MultiSwapProgressSheet'
+import PartialSuccessSheet from 'src/dollarsSpend/PartialSuccessSheet'
+import { useSelector } from 'src/redux/hooks'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  onRetry: () => void
+  onCancel: () => void
+}
+
+// Wraps the in-flight progress sheet and the partial-success sheet so the user
+// never sees a blank frame between a step failure dispatching and the partial-
+// success UI committing. While `transitioning` is true the shell renders a brief
+// transitional message; otherwise it renders whichever sheet applies for the
+// current slice state.
+export default function TransactionFlowShell({ onRetry, onCancel }: Props) {
+  const { t } = useTranslation()
+  const inFlight = useSelector((s) => s.dollarsSpend.inFlight)
+  const transitioning = useSelector((s) => s.dollarsSpend.transitioning)
+
+  if (!inFlight && !transitioning) {
+    return null
+  }
+
+  if (transitioning) {
+    return (
+      <View style={styles.container} testID="TxFlowShell/Transitioning">
+        <Text style={styles.text}>{t('dollarsSpend.transitioning')}</Text>
+      </View>
+    )
+  }
+
+  if (inFlight && inFlight.failedAtIndex !== null) {
+    return <PartialSuccessSheet onRetry={onRetry} onCancel={onCancel} />
+  }
+
+  return <MultiSwapProgressSheet />
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.Thick24,
+    backgroundColor: Colors.white,
+    borderRadius: Spacing.Regular16,
+  },
+  text: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+    textAlign: 'center',
+  },
+})

--- a/src/dollarsSpend/saga.test.ts
+++ b/src/dollarsSpend/saga.test.ts
@@ -8,6 +8,7 @@ import {
   multiSwapStarted,
   multiSwapStepFailed,
   multiSwapStepSucceeded,
+  multiSwapTransitionComplete,
 } from 'src/dollarsSpend/slice'
 import { SpendStep } from 'src/dollarsSpend/types'
 import { swapError, swapSuccess } from 'src/swap/slice'
@@ -125,6 +126,10 @@ describe('executeMultiSwapSaga', () => {
   })
 
   it('halts and emits stepFailed when a step swap fails', async () => {
+    // The saga uses delay(50) between stepFailed and transitionComplete to
+    // give the UI a frame for the transitional message. Use real timers so
+    // jest.useFakeTimers() (global) does not stall the saga.
+    jest.useRealTimers()
     let raceCallIndex = 0
     const raceProvider: EffectProviders = {
       race(_effect, _next) {
@@ -142,31 +147,42 @@ describe('executeMultiSwapSaga', () => {
       raceProvider,
     ]
 
-    await expectSaga(
-      executeMultiSwapSaga,
-      executeMultiSwap({ steps: [stepUsat, stepUsdm], toTokenId: 'celo-mainnet:copm' })
-    )
-      .provide(providers)
-      .put(multiSwapStepSucceeded({ index: 0 }))
-      .put.actionType(multiSwapStepFailed.type)
-      .not.put.actionType(multiSwapCompleted.type)
-      .silentRun()
+    try {
+      await expectSaga(
+        executeMultiSwapSaga,
+        executeMultiSwap({ steps: [stepUsat, stepUsdm], toTokenId: 'celo-mainnet:copm' })
+      )
+        .provide(providers)
+        .put(multiSwapStepSucceeded({ index: 0 }))
+        .put.actionType(multiSwapStepFailed.type)
+        .put.actionType(multiSwapTransitionComplete.type)
+        .not.put.actionType(multiSwapCompleted.type)
+        .silentRun(500)
+    } finally {
+      jest.useFakeTimers()
+    }
   })
 
   it('emits stepFailed when a quote refetch throws', async () => {
+    jest.useRealTimers()
     const quoteError = new Error('Squid 500')
     const providers: (EffectProviders | StaticProvider)[] = [
       ...baseProviders(),
       [matchers.call.fn(fetchSwapQuoteForExecution), Promise.reject(quoteError) as any],
     ]
 
-    await expectSaga(
-      executeMultiSwapSaga,
-      executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
-    )
-      .provide(providers)
-      .put.actionType(multiSwapStepFailed.type)
-      .not.put.actionType(multiSwapCompleted.type)
-      .silentRun()
+    try {
+      await expectSaga(
+        executeMultiSwapSaga,
+        executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+      )
+        .provide(providers)
+        .put.actionType(multiSwapStepFailed.type)
+        .put.actionType(multiSwapTransitionComplete.type)
+        .not.put.actionType(multiSwapCompleted.type)
+        .silentRun(500)
+    } finally {
+      jest.useFakeTimers()
+    }
   })
 })

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -1,11 +1,12 @@
 import { createAction, PayloadAction } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
-import { call, put, race, select, take, takeEvery } from 'typed-redux-saga'
+import { call, delay, put, race, select, take, takeEvery } from 'typed-redux-saga'
 import {
   multiSwapCompleted,
   multiSwapStarted,
   multiSwapStepFailed,
   multiSwapStepSucceeded,
+  multiSwapTransitionComplete,
 } from 'src/dollarsSpend/slice'
 import { SpendStep } from 'src/dollarsSpend/types'
 import { swapStart, swapSuccess, swapError } from 'src/swap/slice'
@@ -54,6 +55,10 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
           errorMessage: 'Wallet address unavailable for step execution',
         })
       )
+      // Give the UI one frame to render the transitional message before
+      // committing to PartialSuccessSheet. Bridges the render gap.
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
       return
     }
 
@@ -66,6 +71,8 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
           errorMessage: `Token not found in wallet state: ${step.symbol}`,
         })
       )
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
       return
     }
 
@@ -91,6 +98,8 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
       const message = err instanceof Error ? err.message : String(err)
       Logger.warn(TAG, `Quote refetch failed for step ${index} (${step.symbol}): ${message}`)
       yield* put(multiSwapStepFailed({ index, errorMessage: message }))
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
       return
     }
 
@@ -142,6 +151,8 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
           errorMessage: `Swap failed at step ${index} (${step.symbol})`,
         })
       )
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
       return
     }
   }

--- a/src/dollarsSpend/slice.test.ts
+++ b/src/dollarsSpend/slice.test.ts
@@ -3,6 +3,7 @@ import reducer, {
   multiSwapStarted,
   multiSwapStepSucceeded,
   multiSwapStepFailed,
+  multiSwapTransitionComplete,
   multiSwapCompleted,
   multiSwapCleared,
 } from 'src/dollarsSpend/slice'
@@ -25,7 +26,10 @@ const stepUsdm: SpendStep = {
 
 describe('dollarsSpend slice', () => {
   it('returns initial state', () => {
-    expect(reducer(undefined, { type: 'init' })).toEqual({ inFlight: null })
+    expect(reducer(undefined, { type: 'init' })).toEqual({
+      inFlight: null,
+      transitioning: false,
+    })
   })
 
   it('handles multiSwapStarted by setting inFlight with planned steps', () => {
@@ -43,7 +47,7 @@ describe('dollarsSpend slice', () => {
     expect(next.inFlight?.completedSteps).toBe(1)
   })
 
-  it('records failedAtIndex and lastError on step failure', () => {
+  it('records failedAtIndex and lastError on step failure and sets transitioning', () => {
     const startedState = reducer(undefined, multiSwapStarted({ steps: [stepUsat, stepUsdm] }))
     const failed = reducer(
       startedState,
@@ -51,6 +55,19 @@ describe('dollarsSpend slice', () => {
     )
     expect(failed.inFlight?.failedAtIndex).toBe(1)
     expect(failed.inFlight?.lastError).toBe('slippage exceeded')
+    expect(failed.transitioning).toBe(true)
+  })
+
+  it('clears transitioning on multiSwapTransitionComplete', () => {
+    const startedState = reducer(undefined, multiSwapStarted({ steps: [stepUsat] }))
+    const failed = reducer(
+      startedState,
+      multiSwapStepFailed({ index: 0, errorMessage: 'tx reverted' })
+    )
+    expect(failed.transitioning).toBe(true)
+    const settled = reducer(failed, multiSwapTransitionComplete())
+    expect(settled.transitioning).toBe(false)
+    expect(settled.inFlight?.failedAtIndex).toBe(0)
   })
 
   it('clears inFlight on multiSwapCompleted', () => {
@@ -72,11 +89,11 @@ describe('dollarsSpend slice', () => {
 
   it('ignores stepSucceeded when no in-flight session', () => {
     const state = reducer(undefined, multiSwapStepSucceeded({ index: 0 }))
-    expect(state).toEqual({ inFlight: null })
+    expect(state).toEqual({ inFlight: null, transitioning: false })
   })
 
   it('ignores stepFailed when no in-flight session', () => {
     const state = reducer(undefined, multiSwapStepFailed({ index: 0, errorMessage: 'x' }))
-    expect(state).toEqual({ inFlight: null })
+    expect(state).toEqual({ inFlight: null, transitioning: false })
   })
 })

--- a/src/dollarsSpend/slice.ts
+++ b/src/dollarsSpend/slice.ts
@@ -10,10 +10,15 @@ interface InFlight {
 
 export interface State {
   inFlight: InFlight | null
+  // True for a brief window after multiSwapStepFailed dispatches and before
+  // the UI commits to PartialSuccessSheet. Bridges the render gap where both
+  // sheets would otherwise return null. See TransactionFlowShell.
+  transitioning: boolean
 }
 
 const initialState: State = {
   inFlight: null,
+  transitioning: false,
 }
 
 const slice = createSlice({
@@ -27,6 +32,7 @@ const slice = createSlice({
         failedAtIndex: null,
         lastError: null,
       }
+      state.transitioning = false
     },
     multiSwapStepSucceeded(state, action: PayloadAction<{ index: number }>) {
       if (!state.inFlight) return
@@ -36,12 +42,18 @@ const slice = createSlice({
       if (!state.inFlight) return
       state.inFlight.failedAtIndex = action.payload.index
       state.inFlight.lastError = action.payload.errorMessage
+      state.transitioning = true
+    },
+    multiSwapTransitionComplete(state) {
+      state.transitioning = false
     },
     multiSwapCompleted(state) {
       state.inFlight = null
+      state.transitioning = false
     },
     multiSwapCleared(state) {
       state.inFlight = null
+      state.transitioning = false
     },
   },
 })
@@ -50,6 +62,7 @@ export const {
   multiSwapStarted,
   multiSwapStepSucceeded,
   multiSwapStepFailed,
+  multiSwapTransitionComplete,
   multiSwapCompleted,
   multiSwapCleared,
 } = slice.actions

--- a/src/gold/GoldBuyConfirmation.tsx
+++ b/src/gold/GoldBuyConfirmation.tsx
@@ -18,8 +18,7 @@ import {
   planSpend,
   useDollarBalanceSnapshots,
 } from 'src/dollarsSpend'
-import MultiSwapProgressSheet from 'src/dollarsSpend/MultiSwapProgressSheet'
-import PartialSuccessSheet from 'src/dollarsSpend/PartialSuccessSheet'
+import TransactionFlowShell from 'src/dollarsSpend/TransactionFlowShell'
 import { goldBuyStatusSelector, goldErrorSelector, xaut0TokenSelector } from 'src/gold/selectors'
 import { buyGoldStart } from 'src/gold/slice'
 import { XAUT0_DECIMALS } from 'src/gold/types'
@@ -307,8 +306,7 @@ export default function GoldBuyConfirmation({ route }: Props) {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <MultiSwapProgressSheet />
-      <PartialSuccessSheet
+      <TransactionFlowShell
         onRetry={() => {
           const remaining = planSpend({ requestedUsd, balances: dollarSnapshots })
           if (remaining.shortfall.gt(0)) return

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -2054,4 +2054,17 @@ export const migrations = {
       dollarsSpend: { inFlight: null },
     }
   },
+  248: (state: any) => {
+    // Track B Task 4: add `transitioning` flag to dollarsSpend so the
+    // TransactionFlowShell can render a brief transitional state and avoid
+    // the blank frame between multiSwapStepFailed and PartialSuccessSheet
+    // committing. Default to false for existing persisted state.
+    return {
+      ...state,
+      dollarsSpend: {
+        ...state.dollarsSpend,
+        transitioning: false,
+      },
+    }
+  },
 }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -26,7 +26,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 247,
+  version: 248,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -49,8 +49,7 @@ import {
   useDollarBalanceSnapshots,
   useMultiSwapQuote,
 } from 'src/dollarsSpend'
-import MultiSwapProgressSheet from 'src/dollarsSpend/MultiSwapProgressSheet'
-import PartialSuccessSheet from 'src/dollarsSpend/PartialSuccessSheet'
+import TransactionFlowShell from 'src/dollarsSpend/TransactionFlowShell'
 import { currentSwapSelector, priceImpactWarningThresholdSelector } from 'src/swap/selectors'
 import { swapStart } from 'src/swap/slice'
 import { AppFeeAmount, Field, SwapAmount, SwapFeeAmount } from 'src/swap/types'
@@ -1291,8 +1290,7 @@ export function SwapScreen({ route }: Props) {
         onPressCta={handleDismissSelectTokenNoUsdPrice}
         onDismiss={handleDismissSelectTokenNoUsdPrice}
       />
-      <MultiSwapProgressSheet />
-      <PartialSuccessSheet
+      <TransactionFlowShell
         onRetry={() => {
           if (!toTokenId) return
           const remaining = planSpend({ requestedUsd: fromAmountUsd, balances: dollarSnapshots })

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -5525,10 +5525,14 @@
                             "type": "null"
                         }
                     ]
+                },
+                "transitioning": {
+                    "type": "boolean"
                 }
             },
             "required": [
-                "inFlight"
+                "inFlight",
+                "transitioning"
             ],
             "type": "object"
         },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3697,6 +3697,18 @@ export const v247Schema = {
   },
 }
 
+// Migration 248 adds `transitioning` to dollarsSpend (Track B Task 4) so the
+// TransactionFlowShell can bridge the render gap between step failure and
+// PartialSuccessSheet without showing a blank frame.
+export const v248Schema = {
+  ...v247Schema,
+  dollarsSpend: { inFlight: null, transitioning: false },
+  _persist: {
+    ...v247Schema._persist,
+    version: 248,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v247Schema as Partial<RootState>
+  return v248Schema as Partial<RootState>
 }


### PR DESCRIPTION
Plan 02 Track B Task 4. Fixes blank-frame bug between MultiSwapProgressSheet and PartialSuccessSheet during transition to partial-failure.

### Changes
- NEW `src/dollarsSpend/TransactionFlowShell.tsx` + test
- `slice.ts`: `transitioning` flag + `multiSwapTransitionComplete` action
- `saga.ts`: dispatch `multiSwapTransitionComplete` after `delay(50)` post-fail
- `SwapScreen.tsx`, `GoldBuyConfirmation.tsx`: replaced direct sheet mounts with shell
- redux-persist v248 + RootStateSchema regen
- i18n: `dollarsSpend.transitioning` in es-419 ("Finalizando tu cambio...") + base

### Verification
- yarn build:ts + lint ✓
- yarn test dollarsSpend + swap → 199 tests pass