### PR TITLE
feat(retry): add generic retry helper with exponential backoff

### DIFF
--- a/src/lib/retry/index.ts
+++ b/src/lib/retry/index.ts
@@ -1,0 +1,2 @@
+export type { RetryOpts } from './retry'
+export { retryWithBackoff } from './retry'

--- a/src/lib/retry/retry.test.ts
+++ b/src/lib/retry/retry.test.ts
@@ -1,0 +1,55 @@
+import { retryWithBackoff } from './retry'
+
+describe('retryWithBackoff', () => {
+  beforeEach(() => {
+    jest.useRealTimers()
+  })
+
+  afterAll(() => {
+    jest.useFakeTimers()
+  })
+
+  it('returns successful result on first attempt', async () => {
+    const fn = jest.fn().mockResolvedValue('ok')
+    const result = await retryWithBackoff(fn, { maxAttempts: 3, baseMs: 1 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on failure and returns success', async () => {
+    let n = 0
+    const fn = jest.fn().mockImplementation(() => {
+      n++
+      if (n < 4) throw new Error('transient')
+      return 'ok'
+    })
+    const result = await retryWithBackoff(fn, { maxAttempts: 5, baseMs: 1 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(4)
+  })
+
+  it('throws after maxAttempts', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('permanent'))
+    await expect(retryWithBackoff(fn, { maxAttempts: 2, baseMs: 1 })).rejects.toThrow('permanent')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors shouldRetry returning false', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('do-not-retry'))
+    await expect(
+      retryWithBackoff(fn, { maxAttempts: 5, baseMs: 1, shouldRetry: () => false })
+    ).rejects.toThrow('do-not-retry')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes attempt number to shouldRetry', async () => {
+    const shouldRetry = jest.fn().mockReturnValue(true)
+    const fn = jest.fn().mockRejectedValue(new Error('err'))
+    try {
+      await retryWithBackoff(fn, { maxAttempts: 3, baseMs: 1, shouldRetry })
+    } catch {
+      // expected
+    }
+    expect(shouldRetry.mock.calls.map((c) => c[1])).toEqual([0, 1])
+  })
+})

--- a/src/lib/retry/retry.ts
+++ b/src/lib/retry/retry.ts
@@ -1,0 +1,21 @@
+export interface RetryOpts {
+  maxAttempts: number
+  baseMs: number
+  shouldRetry?: (err: unknown, attempt: number) => boolean
+}
+
+export async function retryWithBackoff<T>(fn: () => Promise<T>, opts: RetryOpts): Promise<T> {
+  let lastErr: unknown
+  for (let attempt = 0; attempt < opts.maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastErr = err
+      if (attempt === opts.maxAttempts - 1) break
+      if (opts.shouldRetry && !opts.shouldRetry(err, attempt)) throw err
+      const jitter = Math.random() * opts.baseMs
+      await new Promise((r) => setTimeout(r, opts.baseMs * 2 ** attempt + jitter))
+    }
+  }
+  throw lastErr
+}


### PR DESCRIPTION
Plan 01 Track A Task 2.

Generic retry utility for the saga layer and per-feature retry logic.

### API
```ts
retryWithBackoff<T>(fn: () => Promise<T>, opts: { maxAttempts, baseMs, shouldRetry? }): Promise<T>
```
Exponential backoff with jitter: `baseMs * 2^attempt + random(0, baseMs)`.

### Files
- `src/lib/retry/retry.ts` — impl
- `src/lib/retry/index.ts` — barrel
- `src/lib/retry/retry.test.ts` — 5 tests (all pass)

### Notes
- shouldRetry NOT called on final attempt (sensible semantics, matches test fixture)
- Tests use real timers (project jest_setup enables fake timers globally; otherwise setTimeout hangs)

### Verification
- yarn build:ts ✓
- yarn lint ✓
- 5/5 tests pass

Composes with Track A Task 1 error taxonomy via the optional `shouldRetry` callback.