### PR TITLE
feat(pincode): per-session transactional cache hold

### DIFF
--- a/src/pincode/PasswordCache.test.ts
+++ b/src/pincode/PasswordCache.test.ts
@@ -1,0 +1,46 @@
+import {
+  clearPasswordCaches,
+  endTransactional,
+  getCachedPassword,
+  pinTransactional,
+  setCachedPassword,
+} from 'src/pincode/PasswordCache'
+
+describe('PasswordCache transactional hold', () => {
+  beforeEach(() => clearPasswordCaches())
+  afterEach(() => {
+    clearPasswordCaches()
+    jest.useRealTimers()
+  })
+
+  it('does not expire during a transactional session even if 601s pass', () => {
+    jest.useFakeTimers()
+    const acct = '0xabc'
+    setCachedPassword(acct, 'pw')
+    pinTransactional(acct)
+    jest.advanceTimersByTime(601 * 1000)
+    expect(getCachedPassword(acct)).toBe('pw')
+    endTransactional(acct)
+    jest.advanceTimersByTime(601 * 1000)
+    expect(getCachedPassword(acct)).toBeNull()
+  })
+
+  it('endTransactional is idempotent if called multiple times', () => {
+    pinTransactional('0xa')
+    endTransactional('0xa')
+    expect(() => endTransactional('0xa')).not.toThrow()
+  })
+
+  it('multiple pinTransactional calls keep the cache pinned until all are released', () => {
+    jest.useFakeTimers()
+    setCachedPassword('0xa', 'pw')
+    pinTransactional('0xa')
+    pinTransactional('0xa') // refcount = 2
+    endTransactional('0xa') // refcount = 1
+    jest.advanceTimersByTime(601 * 1000)
+    expect(getCachedPassword('0xa')).toBe('pw')
+    endTransactional('0xa') // refcount = 0
+    jest.advanceTimersByTime(601 * 1000)
+    expect(getCachedPassword('0xa')).toBeNull()
+  })
+})

--- a/src/pincode/PasswordCache.ts
+++ b/src/pincode/PasswordCache.ts
@@ -11,10 +11,32 @@ let pepperCache: SecretCache = {}
 let passwordHashCache: SecretCache = {}
 let passwordCache: SecretCache = {}
 
+// Refcounted per-account lock that prevents inactivity-based eviction while a
+// long-running transactional flow (e.g. sendPreparedTransactions) is in flight.
+// Each pinTransactional must be paired with an endTransactional in a finally block.
+const transactionalLocks = new Map<string, number>()
+
+export function pinTransactional(account: string): void {
+  transactionalLocks.set(account, (transactionalLocks.get(account) ?? 0) + 1)
+}
+
+export function endTransactional(account: string): void {
+  const current = transactionalLocks.get(account) ?? 0
+  if (current <= 1) {
+    transactionalLocks.delete(account)
+  } else {
+    transactionalLocks.set(account, current - 1)
+  }
+}
+
 function getCachedValue(cache: SecretCache, account: string) {
   // TODO(Rossy) use a monotonic clock here?
   const value = cache[account]
   if (value && value.secret && value.timestamp && Date.now() - value.timestamp < CACHE_TIMEOUT) {
+    return value.secret
+  } else if (value && value.secret && transactionalLocks.has(account)) {
+    // Pinned by an in-flight transactional saga: hold the value past the
+    // inactivity TTL so multi-step flows don't re-prompt for PIN mid-flow.
     return value.secret
   } else {
     // Clear values in cache when they're expired
@@ -68,4 +90,5 @@ export function clearPasswordCaches() {
   pepperCache = {}
   passwordHashCache = {}
   passwordCache = {}
+  transactionalLocks.clear()
 }

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -1,3 +1,4 @@
+import { endTransactional, pinTransactional } from 'src/pincode/PasswordCache'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { BaseStandbyTransaction, addStandbyTransaction } from 'src/transactions/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -59,41 +60,54 @@ export function* sendPreparedTransactions(
   // Unlock account before executing tx
   yield* call(getConnectedUnlockedAccount)
 
-  // @ts-ignore typed-redux-saga erases the parameterized types causing error, we can address this separately
-  let nonce: number = yield* call(getTransactionCount, wallet, {
-    address: wallet.account.address,
-    blockTag: 'pending',
-  })
-
-  const preparedTransactions = getPreparedTransactions(serializablePreparedTransactions)
-  const txHashes: Hash[] = []
-  for (let i = 0; i < preparedTransactions.length; i++) {
-    const preparedTransaction = preparedTransactions[i]
-    const createBaseStandbyTransaction = createBaseStandbyTransactions[i]
-
-    const signedTx = yield* call([wallet, 'signTransaction'], {
-      ...preparedTransaction,
-      nonce: nonce++,
-    } as any)
-    const hash = yield* call([wallet, 'sendRawTransaction'], {
-      serializedTransaction: signedTx,
+  // Hold the PIN cache for the duration of this multi-step transactional saga
+  // so the inactivity TTL cannot expire between signing iterations and force
+  // a mid-flow PIN re-prompt. Released on success, failure, or abort.
+  const account = wallet.account.address
+  pinTransactional(account)
+  try {
+    // @ts-ignore typed-redux-saga erases the parameterized types causing error, we can address this separately
+    let nonce: number = yield* call(getTransactionCount, wallet, {
+      address: wallet.account.address,
+      blockTag: 'pending',
     })
 
-    Logger.debug(
-      `${TAG}/sendTransactionsSaga`,
-      'Successfully sent transaction to the network',
-      hash
-    )
+    const preparedTransactions = getPreparedTransactions(serializablePreparedTransactions)
+    const txHashes: Hash[] = []
+    for (let i = 0; i < preparedTransactions.length; i++) {
+      const preparedTransaction = preparedTransactions[i]
+      const createBaseStandbyTransaction = createBaseStandbyTransactions[i]
 
-    const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
-    const feeCurrencyId = getFeeCurrencyToken([preparedTransaction], networkId, tokensById)?.tokenId
+      const signedTx = yield* call([wallet, 'signTransaction'], {
+        ...preparedTransaction,
+        nonce: nonce++,
+      } as any)
+      const hash = yield* call([wallet, 'sendRawTransaction'], {
+        serializedTransaction: signedTx,
+      })
 
-    const standByTx = createBaseStandbyTransaction(hash, feeCurrencyId)
-    if (standByTx) {
-      yield* put(addStandbyTransaction(standByTx))
+      Logger.debug(
+        `${TAG}/sendTransactionsSaga`,
+        'Successfully sent transaction to the network',
+        hash
+      )
+
+      const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
+      const feeCurrencyId = getFeeCurrencyToken(
+        [preparedTransaction],
+        networkId,
+        tokensById
+      )?.tokenId
+
+      const standByTx = createBaseStandbyTransaction(hash, feeCurrencyId)
+      if (standByTx) {
+        yield* put(addStandbyTransaction(standByTx))
+      }
+      txHashes.push(hash)
     }
-    txHashes.push(hash)
-  }
 
-  return txHashes
+    return txHashes
+  } finally {
+    endTransactional(account)
+  }
 }


### PR DESCRIPTION
Plan 02 Track B Task 5 (locked decision #4).

Per locked decision #4: instead of raising global PIN cache TTL, hold the cache for the duration of a transactional saga. Released on success/failure/abort.

### Changes
- `PasswordCache.ts`: refcounted `transactionalLocks` Map + `pinTransactional/endTransactional` exports. `getCachedValue` bypasses TTL when lock is held.
- `viem/saga.ts` `sendPreparedTransactions`: wraps body in `try { pinTransactional(account) } finally { endTransactional(account) }`.
- New `PasswordCache.test.ts`: 3 tests (pinned past TTL, idempotent end, refcount semantics).

### Verification
- 162/162 tests passing in src/pincode + src/viem suites
- yarn build:ts + lint ✓
- Default inactivity TTL unchanged (security posture preserved)