### PR TITLE
feat(connectivity): add useConnectivityState hook

### DIFF
--- a/src/lib/connectivity/index.ts
+++ b/src/lib/connectivity/index.ts
@@ -1,0 +1,2 @@
+export type { ConnectivityState, ConnectivityType, ConnectivityTransition } from './types'
+export { useConnectivityState } from './useConnectivityState'

--- a/src/lib/connectivity/types.ts
+++ b/src/lib/connectivity/types.ts
@@ -1,0 +1,12 @@
+export type ConnectivityType = 'wifi' | 'cellular' | 'unknown' | 'none'
+
+export interface ConnectivityTransition {
+  at: number
+  isConnected: boolean
+}
+
+export interface ConnectivityState {
+  isConnected: boolean
+  type: ConnectivityType
+  history: ConnectivityTransition[]
+}

--- a/src/lib/connectivity/useConnectivityState.test.tsx
+++ b/src/lib/connectivity/useConnectivityState.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook, act } from '@testing-library/react-native'
+import NetInfo from '@react-native-community/netinfo'
+import { useConnectivityState } from './useConnectivityState'
+
+jest.mock('@react-native-community/netinfo')
+
+describe('useConnectivityState', () => {
+  let listeners: Array<(s: any) => void> = []
+
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+
+  beforeEach(() => {
+    listeners = []
+    ;(NetInfo as any).addEventListener = jest.fn((cb) => {
+      listeners.push(cb)
+      return () => {
+        listeners = listeners.filter((l) => l !== cb)
+      }
+    })
+    ;(NetInfo as any).fetch = jest.fn().mockResolvedValue({ isConnected: true, type: 'wifi' })
+  })
+
+  it('returns initial connected state', async () => {
+    const { result } = renderHook(() => useConnectivityState())
+    await flush()
+    expect(result.current.isConnected).toBe(true)
+    expect(result.current.type).toBe('wifi')
+  })
+
+  it('updates when NetInfo emits a disconnect', async () => {
+    const { result } = renderHook(() => useConnectivityState())
+    await flush()
+    void act(() => {
+      listeners.forEach((cb) => cb({ isConnected: false, type: 'none' }))
+    })
+    expect(result.current.isConnected).toBe(false)
+  })
+
+  it('records last 5 transitions in history', async () => {
+    const { result } = renderHook(() => useConnectivityState())
+    await flush()
+    void act(() => {
+      listeners.forEach((cb) => cb({ isConnected: false, type: 'none' }))
+    })
+    void act(() => {
+      listeners.forEach((cb) => cb({ isConnected: true, type: 'cellular' }))
+    })
+    expect(result.current.history.length).toBeGreaterThanOrEqual(2)
+    expect(result.current.history.slice(-1)[0].isConnected).toBe(true)
+  })
+
+  it('caps history at 5 entries', async () => {
+    const { result } = renderHook(() => useConnectivityState())
+    await flush()
+    for (let i = 0; i < 10; i++) {
+      void act(() => {
+        listeners.forEach((cb) => cb({ isConnected: i % 2 === 0, type: 'wifi' }))
+      })
+    }
+    expect(result.current.history.length).toBeLessThanOrEqual(5)
+  })
+})

--- a/src/lib/connectivity/useConnectivityState.ts
+++ b/src/lib/connectivity/useConnectivityState.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react'
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo'
+import type { ConnectivityState, ConnectivityTransition, ConnectivityType } from './types'
+
+const HISTORY_CAP = 5
+
+function mapType(t: NetInfoState['type']): ConnectivityType {
+  if (t === 'wifi') return 'wifi'
+  if (t === 'cellular') return 'cellular'
+  if (t === 'none') return 'none'
+  return 'unknown'
+}
+
+export function useConnectivityState(): ConnectivityState {
+  const [state, setState] = useState<ConnectivityState>({
+    isConnected: true,
+    type: 'unknown',
+    history: [],
+  })
+  const historyRef = useRef<ConnectivityTransition[]>([])
+
+  useEffect(() => {
+    let mounted = true
+    void NetInfo.fetch().then((s) => {
+      if (!mounted) return
+      setState({
+        isConnected: Boolean(s.isConnected),
+        type: mapType(s.type),
+        history: historyRef.current,
+      })
+    })
+    const unsubscribe = NetInfo.addEventListener((s) => {
+      if (!mounted) return
+      const isConnected = Boolean(s.isConnected)
+      historyRef.current = [...historyRef.current, { at: Date.now(), isConnected }].slice(
+        -HISTORY_CAP
+      )
+      setState({ isConnected, type: mapType(s.type), history: historyRef.current })
+    })
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [])
+
+  return state
+}


### PR DESCRIPTION
Plan 02 Track B Task 7 (first sub-PR — connectivity hook).

Per spec section 6.1.10.a: wraps `@react-native-community/netinfo` and exposes a stable shape for the connectivity banner + post-flow root-cause messaging (later sub-PRs).

### Files
- `src/lib/connectivity/types.ts`: ConnectivityState/Type/Transition
- `src/lib/connectivity/useConnectivityState.ts`: hook with NetInfo.fetch + addEventListener, history capped at 5 transitions
- `src/lib/connectivity/index.ts`: barrel
- `src/lib/connectivity/useConnectivityState.test.tsx`: 4 tests (initial, disconnect, history records, history cap)

### Verification
- 4/4 tests passing
- yarn build:ts + lint ✓
- No new dependencies