### PR TITLE
feat(components): add ConfirmationSheet with pre-flight advisory modal

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3165,5 +3165,8 @@
       "priceBelow": "Notify when price is below",
       "delete": "Delete"
     }
+  },
+  "preflight": {
+    "advisory": "We're about to start your {{noun}}. Don't close the app and make sure you have good connection."
   }
 }

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3258,5 +3258,8 @@
       "shareButton": "Compartir",
       "shareSubject": "Reporte de error TuCop"
     }
+  },
+  "preflight": {
+    "advisory": "Estamos por iniciar tu {{noun}}. No cierres la app y asegurate de tener buena conexion."
   }
 }

--- a/src/components/ConfirmationSheet.test.tsx
+++ b/src/components/ConfirmationSheet.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { ConfirmationSheet } from 'src/components/ConfirmationSheet'
+import { createMockStore } from 'test/utils'
+
+describe('ConfirmationSheet', () => {
+  const baseProps = {
+    visible: true,
+    noun: 'cambio' as const,
+    reviewRows: [
+      { label: 'You pay', value: '10 USDm' },
+      { label: 'You receive', value: '~38000 COPm' },
+    ],
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders review rows when visible', () => {
+    const { getByText } = render(
+      <Provider store={createMockStore({})}>
+        <ConfirmationSheet {...baseProps} />
+      </Provider>
+    )
+    expect(getByText('You pay')).toBeTruthy()
+    expect(getByText('10 USDm')).toBeTruthy()
+  })
+
+  it('does not render when visible=false', () => {
+    const { queryByText } = render(
+      <Provider store={createMockStore({})}>
+        <ConfirmationSheet {...baseProps} visible={false} />
+      </Provider>
+    )
+    expect(queryByText('You pay')).toBeNull()
+  })
+
+  it('shows pre-flight advisory modal on confirm tap', () => {
+    const { getByText } = render(
+      <Provider store={createMockStore({})}>
+        <ConfirmationSheet {...baseProps} />
+      </Provider>
+    )
+    fireEvent.press(getByText(/confirmar|confirm/i))
+    expect(getByText(/no cierres la app|don.{1,2}t close the app/i)).toBeTruthy()
+    expect(baseProps.onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('calls onConfirm after advisory continue', () => {
+    const { getByText } = render(
+      <Provider store={createMockStore({})}>
+        <ConfirmationSheet {...baseProps} />
+      </Provider>
+    )
+    fireEvent.press(getByText(/confirmar|confirm/i))
+    fireEvent.press(getByText(/continuar|continue/i))
+    expect(baseProps.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel from sheet cancel button', () => {
+    const { getByText } = render(
+      <Provider store={createMockStore({})}>
+        <ConfirmationSheet {...baseProps} />
+      </Provider>
+    )
+    fireEvent.press(getByText(/cancelar|cancel/i))
+    expect(baseProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ConfirmationSheet.tsx
+++ b/src/components/ConfirmationSheet.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+export type ConfirmationNoun =
+  | 'cambio'
+  | 'envio'
+  | 'retiro a pesos'
+  | 'deposito'
+  | 'retiro'
+  | 'compra de oro'
+  | 'venta de oro'
+  | 'reclamo'
+  | 'operacion'
+
+export interface ReviewRow {
+  label: string
+  value: React.ReactNode
+}
+
+export interface ConfirmationSheetProps {
+  visible: boolean
+  noun: ConfirmationNoun
+  reviewRows: ReviewRow[]
+  onConfirm: () => void
+  onCancel: () => void
+  confirmDisabled?: boolean
+  testID?: string
+}
+
+export function ConfirmationSheet(props: ConfirmationSheetProps) {
+  const { t } = useTranslation()
+  const [showAdvisory, setShowAdvisory] = useState(false)
+
+  if (!props.visible) {
+    return null
+  }
+
+  const advisoryText = t('preflight.advisory', {
+    defaultValue:
+      'Estamos por iniciar tu {{noun}}. No cierres la app y asegurate de tener buena conexion.',
+    noun: props.noun,
+  })
+
+  const handleConfirmPress = () => {
+    setShowAdvisory(true)
+  }
+
+  const handleAdvisoryContinue = () => {
+    setShowAdvisory(false)
+    props.onConfirm()
+  }
+
+  const handleAdvisoryCancel = () => {
+    setShowAdvisory(false)
+  }
+
+  return (
+    <View testID={props.testID ?? 'ConfirmationSheet'} style={styles.container}>
+      <View style={styles.rowsContainer}>
+        {props.reviewRows.map((row, i) => (
+          <View key={i} style={styles.row} testID={`ConfirmationSheet/Row/${i}`}>
+            <Text style={styles.rowLabel}>{row.label}</Text>
+            <Text style={styles.rowValue}>{row.value}</Text>
+          </View>
+        ))}
+      </View>
+      <Pressable
+        testID="ConfirmationSheet/Confirm"
+        onPress={handleConfirmPress}
+        disabled={props.confirmDisabled}
+        style={[
+          styles.button,
+          styles.confirmButton,
+          props.confirmDisabled && styles.buttonDisabled,
+        ]}
+      >
+        <Text style={styles.confirmButtonText}>{t('confirm', { defaultValue: 'Confirmar' })}</Text>
+      </Pressable>
+      <Pressable
+        testID="ConfirmationSheet/Cancel"
+        onPress={props.onCancel}
+        style={[styles.button, styles.cancelButton]}
+      >
+        <Text style={styles.cancelButtonText}>{t('cancel', { defaultValue: 'Cancelar' })}</Text>
+      </Pressable>
+      <Modal
+        visible={showAdvisory}
+        transparent
+        animationType="fade"
+        onRequestClose={handleAdvisoryCancel}
+      >
+        <View style={styles.modalBackdrop}>
+          <View style={styles.modalContent} testID="ConfirmationSheet/Advisory">
+            <Text style={styles.advisoryText}>{advisoryText}</Text>
+            <Pressable
+              testID="ConfirmationSheet/Advisory/Continue"
+              onPress={handleAdvisoryContinue}
+              style={[styles.button, styles.confirmButton]}
+            >
+              <Text style={styles.confirmButtonText}>
+                {t('continue', { defaultValue: 'Continuar' })}
+              </Text>
+            </Pressable>
+            <Pressable
+              testID="ConfirmationSheet/Advisory/Cancel"
+              onPress={handleAdvisoryCancel}
+              style={[styles.button, styles.cancelButton]}
+            >
+              <Text style={styles.cancelButtonText}>
+                {t('cancel', { defaultValue: 'Cancelar' })}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.Thick24,
+    backgroundColor: Colors.white,
+  },
+  rowsContainer: {
+    marginBottom: Spacing.Thick24,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: Spacing.Smallest8,
+  },
+  rowLabel: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+  },
+  rowValue: {
+    ...typeScale.bodyMedium,
+    color: Colors.black,
+  },
+  button: {
+    paddingVertical: Spacing.Regular16,
+    borderRadius: 100,
+    alignItems: 'center',
+    marginTop: Spacing.Smallest8,
+  },
+  confirmButton: {
+    backgroundColor: Colors.accent,
+  },
+  confirmButtonText: {
+    ...typeScale.labelSemiBoldMedium,
+    color: Colors.white,
+  },
+  cancelButton: {
+    backgroundColor: 'transparent',
+  },
+  cancelButtonText: {
+    ...typeScale.labelSemiBoldMedium,
+    color: Colors.black,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.Thick24,
+  },
+  modalContent: {
+    backgroundColor: Colors.white,
+    borderRadius: 16,
+    padding: Spacing.Thick24,
+    width: '100%',
+  },
+  advisoryText: {
+    ...typeScale.bodyMedium,
+    color: Colors.black,
+    marginBottom: Spacing.Thick24,
+    textAlign: 'center',
+  },
+})
+
+export default ConfirmationSheet


### PR DESCRIPTION
Plan 01 Track A Task 5.

Reusable review + confirm + cancel UI standardizing transactional flow confirmation across swap, dollarsSpend, send, earn, gold, buckspay, etc. Integrates pre-flight advisory modal from spec 6.1.10.c.

### API
```ts
<ConfirmationSheet
  visible
  noun="cambio"          // per-flow noun per UX decision
  reviewRows={[{label, value}, ...]}
  onConfirm onCancel
  confirmDisabled?
/>
```

Tapping confirm shows advisory modal first ("Estamos por iniciar tu cambio. No cierres la app..."), then proceeds to onConfirm on user agreement.

### Files (4)
- src/components/ConfirmationSheet.tsx
- src/components/ConfirmationSheet.test.tsx (5 tests, all pass)
- locales/base + es-419: added `preflight.advisory` i18n key. Reused existing `confirm`/`cancel`/`continue` root keys instead of creating `common.*` namespace

### Verification
- yarn build:ts + lint ✓
- 5/5 tests pass