### PR TITLE
feat(components): add PinRequiredGate composing transactional cache

### DIFF
--- a/src/components/PinRequiredGate.test.tsx
+++ b/src/components/PinRequiredGate.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { Text } from 'react-native'
+import { Provider } from 'react-redux'
+import { createMockStore } from 'test/utils'
+import { PinRequiredGate } from './PinRequiredGate'
+
+const mockPinTransactional = jest.fn()
+const mockEndTransactional = jest.fn()
+jest.mock('src/pincode/PasswordCache', () => ({
+  pinTransactional: (...args: any[]) => mockPinTransactional(...args),
+  endTransactional: (...args: any[]) => mockEndTransactional(...args),
+}))
+
+describe('PinRequiredGate', () => {
+  const address = '0x1111111111111111111111111111111111111111'
+  beforeEach(() => {
+    mockPinTransactional.mockClear()
+    mockEndTransactional.mockClear()
+  })
+
+  it('pins the cache on mount with the current wallet address', () => {
+    render(
+      <Provider store={createMockStore({ web3: { account: address } })}>
+        <PinRequiredGate>
+          <Text>child</Text>
+        </PinRequiredGate>
+      </Provider>
+    )
+    expect(mockPinTransactional).toHaveBeenCalledWith(address)
+    expect(mockEndTransactional).not.toHaveBeenCalled()
+  })
+
+  it('ends the lock on unmount', () => {
+    const { unmount } = render(
+      <Provider store={createMockStore({ web3: { account: address } })}>
+        <PinRequiredGate>
+          <Text>child</Text>
+        </PinRequiredGate>
+      </Provider>
+    )
+    unmount()
+    expect(mockEndTransactional).toHaveBeenCalledWith(address)
+  })
+
+  it('does nothing if address is null', () => {
+    render(
+      <Provider store={createMockStore({ web3: { account: null } })}>
+        <PinRequiredGate>
+          <Text>child</Text>
+        </PinRequiredGate>
+      </Provider>
+    )
+    expect(mockPinTransactional).not.toHaveBeenCalled()
+  })
+
+  it('renders children', () => {
+    const { getByText } = render(
+      <Provider store={createMockStore({ web3: { account: address } })}>
+        <PinRequiredGate>
+          <Text>child</Text>
+        </PinRequiredGate>
+      </Provider>
+    )
+    expect(getByText('child')).toBeTruthy()
+  })
+})

--- a/src/components/PinRequiredGate.tsx
+++ b/src/components/PinRequiredGate.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react'
+import { useSelector } from 'src/redux/hooks'
+import { walletAddressSelector } from 'src/web3/selectors'
+import { pinTransactional, endTransactional } from 'src/pincode/PasswordCache'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function PinRequiredGate({ children }: Props) {
+  const address = useSelector(walletAddressSelector)
+  useEffect(() => {
+    if (!address) return
+    pinTransactional(address)
+    return () => endTransactional(address)
+  }, [address])
+  return <>{children}</>
+}
+
+export default PinRequiredGate


### PR DESCRIPTION
Plan 01 Track A Task 3.

React wrapper that calls `pinTransactional(address)` on mount and `endTransactional(address)` on unmount, gated by non-null `walletAddressSelector`. Composes with B5 PR #171 (transactional cache hold).

### Files
- src/components/PinRequiredGate.tsx
- src/components/PinRequiredGate.test.tsx (4/4 tests pass)

### Verification
- yarn build:ts + lint ✓