### PR TITLE
feat(components): add TransactionResultSheet with root-cause messaging

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3168,5 +3168,15 @@
   },
   "preflight": {
     "advisory": "We're about to start your {{noun}}. Don't close the app and make sure you have good connection."
+  },
+  "result": {
+    "succeeded": "Your {{noun}} completed successfully.",
+    "connectivity": "You lost connection in the middle of your {{noun}}, so it did not go through. Try again?",
+    "appBackgrounded": "You closed the app while your {{noun}} was in progress. Want to resume it?",
+    "gasInsufficient": "Your balance was not enough to cover the network fee. Top up a little and we will try again.",
+    "slippage": "The price moved more than allowed, so we canceled your {{noun}} to protect you. Try again?",
+    "revert": "The network rejected your {{noun}}. Nothing was charged. Try again?",
+    "rpcTimeout": "The blockchain network did not respond in time. Try again?",
+    "unknown": "Something did not go as expected. Want to try again or contact us?"
   }
 }

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3261,5 +3261,15 @@
   },
   "preflight": {
     "advisory": "Estamos por iniciar tu {{noun}}. No cierres la app y asegurate de tener buena conexion."
+  },
+  "result": {
+    "succeeded": "Tu {{noun}} se completo correctamente.",
+    "connectivity": "Se te fue la conexion a mitad de tu {{noun}} y por eso no se completo. Lo intentamos de nuevo?",
+    "appBackgrounded": "Cerraste la app mientras tu {{noun}} estaba en curso. Quieres retomarlo?",
+    "gasInsufficient": "No alcanzo el saldo para pagar la comision de red. Recarga un poquito mas y volvemos a intentar.",
+    "slippage": "El precio se movio mas de lo permitido y cancelamos tu {{noun}} para protegerte. Lo intentamos de nuevo?",
+    "revert": "La red rechazo tu {{noun}}. No se cobro nada. Lo intentamos de nuevo?",
+    "rpcTimeout": "La red blockchain no respondio a tiempo. Lo intentamos de nuevo?",
+    "unknown": "Algo no salio como esperabamos. Lo intentamos de nuevo o nos contactas?"
   }
 }

--- a/src/components/TransactionResultSheet.test.tsx
+++ b/src/components/TransactionResultSheet.test.tsx
@@ -1,0 +1,196 @@
+import { render } from '@testing-library/react-native'
+import * as React from 'react'
+import TransactionResultSheet from 'src/components/TransactionResultSheet'
+import type { ErrorClass } from 'src/lib/errors'
+import type { ConnectivityTransition } from 'src/lib/connectivity'
+
+const makeError = (kind: ErrorClass['kind']): ErrorClass => ({
+  kind,
+  message: `mock ${kind}`,
+  retryable: true,
+})
+
+describe('TransactionResultSheet', () => {
+  it('renders nothing when not visible', () => {
+    const { queryByTestId } = render(
+      <TransactionResultSheet visible={false} status="succeeded" noun="envio" />
+    )
+    expect(queryByTestId('TransactionResultSheet')).toBeNull()
+  })
+
+  it('renders success message on succeeded status', () => {
+    const { getByText, getByTestId } = render(
+      <TransactionResultSheet visible={true} status="succeeded" noun="envio" />
+    )
+    expect(getByTestId('TransactionResultSheet')).toBeTruthy()
+    expect(getByText(/result\.succeeded/)).toBeTruthy()
+  })
+
+  it('renders connectivity message when history shows a disconnect (regardless of errorClass)', () => {
+    const history: ConnectivityTransition[] = [
+      { at: 1, isConnected: true },
+      { at: 2, isConnected: false },
+    ]
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="cambio"
+        errorClass={makeError('revert')}
+        connectivityHistory={history}
+      />
+    )
+    expect(getByText(/result\.connectivity/)).toBeTruthy()
+  })
+
+  it('renders connectivity message when errorClass kind is connectivity (no history needed)', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('connectivity')}
+      />
+    )
+    expect(getByText(/result\.connectivity/)).toBeTruthy()
+  })
+
+  it('renders app-backgrounded message', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('app-backgrounded')}
+      />
+    )
+    expect(getByText(/result\.appBackgrounded/)).toBeTruthy()
+  })
+
+  it('renders gas-insufficient message', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('gas-insufficient')}
+      />
+    )
+    expect(getByText(/result\.gasInsufficient/)).toBeTruthy()
+  })
+
+  it('renders slippage message', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="cambio"
+        errorClass={makeError('slippage')}
+      />
+    )
+    expect(getByText(/result\.slippage/)).toBeTruthy()
+  })
+
+  it('renders revert message', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('revert')}
+      />
+    )
+    expect(getByText(/result\.revert/)).toBeTruthy()
+  })
+
+  it('renders rpc-timeout message', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('rpc-timeout')}
+      />
+    )
+    expect(getByText(/result\.rpcTimeout/)).toBeTruthy()
+  })
+
+  it('renders unknown message when no errorClass is provided on failure', () => {
+    const { getByText } = render(
+      <TransactionResultSheet visible={true} status="failed" noun="envio" />
+    )
+    expect(getByText(/result\.unknown/)).toBeTruthy()
+  })
+
+  it('renders unknown message for unmapped error kinds (e.g. user-rejected)', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('user-rejected')}
+      />
+    )
+    expect(getByText(/result\.unknown/)).toBeTruthy()
+  })
+
+  it('includes the noun in the translation params', () => {
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="retiro a pesos"
+        errorClass={makeError('revert')}
+      />
+    )
+    // mock for i18n appends JSON-serialised options after the key
+    expect(getByText(/"noun":"retiro a pesos"/)).toBeTruthy()
+  })
+
+  it('connectivity history with only connected transitions does NOT trigger connectivity branch', () => {
+    const history: ConnectivityTransition[] = [
+      { at: 1, isConnected: true },
+      { at: 2, isConnected: true },
+    ]
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('revert')}
+        connectivityHistory={history}
+      />
+    )
+    expect(getByText(/result\.revert/)).toBeTruthy()
+  })
+
+  it('shows retry button on non-success states when onRetry is supplied', () => {
+    const onRetry = jest.fn()
+    const { getByText } = render(
+      <TransactionResultSheet
+        visible={true}
+        status="failed"
+        noun="envio"
+        errorClass={makeError('revert')}
+        onRetry={onRetry}
+      />
+    )
+    expect(getByText(/common\.retry/)).toBeTruthy()
+  })
+
+  it('does NOT show retry button on success state even if onRetry is supplied', () => {
+    const onRetry = jest.fn()
+    const { queryByText } = render(
+      <TransactionResultSheet visible={true} status="succeeded" noun="envio" onRetry={onRetry} />
+    )
+    expect(queryByText(/common\.retry/)).toBeNull()
+  })
+
+  it('shows close button when onClose is supplied', () => {
+    const onClose = jest.fn()
+    const { getByText } = render(
+      <TransactionResultSheet visible={true} status="failed" noun="envio" onClose={onClose} />
+    )
+    expect(getByText(/common\.close/)).toBeTruthy()
+  })
+})

--- a/src/components/TransactionResultSheet.tsx
+++ b/src/components/TransactionResultSheet.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { View, Text, Pressable } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import type { ErrorClass } from 'src/lib/errors'
+import type { ConnectivityTransition } from 'src/lib/connectivity'
+
+// Local copy of the noun union. ConfirmationSheet (Track A Task 5) will export
+// the canonical `ConfirmationNoun`; once it lands, swap this for an import.
+export type ConfirmationNoun =
+  | 'cambio'
+  | 'envio'
+  | 'retiro a pesos'
+  | 'deposito'
+  | 'retiro'
+  | 'compra de oro'
+  | 'venta de oro'
+  | 'reclamo'
+  | 'operacion'
+
+export type ResultStatus = 'succeeded' | 'failed' | 'partial-failure'
+
+export interface TransactionResultSheetProps {
+  visible: boolean
+  status: ResultStatus
+  noun: ConfirmationNoun
+  errorClass?: ErrorClass
+  connectivityHistory?: ConnectivityTransition[]
+  onRetry?: () => void
+  onClose?: () => void
+}
+
+function disconnectDuringFlow(history?: ConnectivityTransition[]): boolean {
+  if (!history || history.length === 0) return false
+  return history.some((t) => !t.isConnected)
+}
+
+export function TransactionResultSheet(props: TransactionResultSheetProps) {
+  const { t } = useTranslation()
+  if (!props.visible) return null
+
+  let messageKey = 'result.unknown'
+  if (props.status === 'succeeded') {
+    messageKey = 'result.succeeded'
+  } else if (disconnectDuringFlow(props.connectivityHistory)) {
+    messageKey = 'result.connectivity'
+  } else if (props.errorClass) {
+    switch (props.errorClass.kind) {
+      case 'gas-insufficient':
+        messageKey = 'result.gasInsufficient'
+        break
+      case 'slippage':
+        messageKey = 'result.slippage'
+        break
+      case 'revert':
+        messageKey = 'result.revert'
+        break
+      case 'rpc-timeout':
+        messageKey = 'result.rpcTimeout'
+        break
+      case 'connectivity':
+        messageKey = 'result.connectivity'
+        break
+      case 'app-backgrounded':
+        messageKey = 'result.appBackgrounded'
+        break
+      default:
+        messageKey = 'result.unknown'
+    }
+  }
+
+  return (
+    <View testID="TransactionResultSheet">
+      <Text>{t(messageKey, { noun: props.noun })}</Text>
+      {props.status !== 'succeeded' && props.onRetry && (
+        <Pressable onPress={props.onRetry}>
+          <Text>{t('common.retry', { defaultValue: 'Intentar de nuevo' })}</Text>
+        </Pressable>
+      )}
+      {props.onClose && (
+        <Pressable onPress={props.onClose}>
+          <Text>{t('common.close', { defaultValue: 'Cerrar' })}</Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}
+
+export default TransactionResultSheet


### PR DESCRIPTION
Plan 01 Track A Task 7.

Shared end-state UI per spec section 6.1.10.e. Maps `ErrorClass.kind` + `connectivityHistory` to warm, empathetic messages.

### Mapping
- connectivity disconnect during flow → 'Se te fue la conexion a mitad de tu {{noun}}...'
- app-backgrounded → 'Cerraste la app mientras tu {{noun}} estaba en curso...'
- gas-insufficient → 'No alcanzo el saldo para pagar la comision de red...'
- slippage → 'El precio se movio mas de lo permitido...'
- revert → 'La red rechazo tu {{noun}}. No se cobro nada...'
- rpc-timeout → 'La red blockchain no respondio a tiempo...'
- unknown / unmapped → 'Algo no salio como esperabamos...'

### Files
- src/components/TransactionResultSheet.tsx
- src/components/TransactionResultSheet.test.tsx (16/16 tests pass)
- locales/es-419 + base: result.* keys

### Verification
- yarn build:ts + lint ✓
- 16/16 tests pass