### PR TITLE
feat(in-flight): add useTransactionInFlight v4 hook + slice + persist transform

### DIFF
--- a/src/lib/useTransactionInFlight/actions.ts
+++ b/src/lib/useTransactionInFlight/actions.ts
@@ -1,0 +1,3 @@
+// Saga-friendly action creators. Re-exports from the slice so saga callsites
+// have a stable import path independent of the slice's internal layout.
+export { inFlightStart, inFlightAdvance, inFlightFail, inFlightRetry, inFlightAbort } from './slice'

--- a/src/lib/useTransactionInFlight/index.ts
+++ b/src/lib/useTransactionInFlight/index.ts
@@ -1,0 +1,18 @@
+export { useTransactionInFlight } from './useTransactionInFlight'
+export { inFlightStart, inFlightAdvance, inFlightFail, inFlightRetry, inFlightAbort } from './slice'
+export { default as transactionInFlightReducer } from './slice'
+export {
+  allInFlightSelector,
+  inFlightByIdSelector,
+  currentInFlightForKindSelector,
+} from './selectors'
+export type {
+  FlowKind,
+  InFlightStatus,
+  InFlightDescriptor,
+  CustomPoll,
+  RetryClassifier,
+  RetryOptions,
+  UseTransactionInFlightArgs,
+  UseTransactionInFlightResult,
+} from './types'

--- a/src/lib/useTransactionInFlight/selectors.ts
+++ b/src/lib/useTransactionInFlight/selectors.ts
@@ -1,0 +1,22 @@
+import type { RootState } from 'src/redux/reducers'
+import type { FlowKind, InFlightDescriptor } from './types'
+
+export const allInFlightSelector = (state: RootState): Record<string, InFlightDescriptor> =>
+  state.transactionInFlight.byFlow
+
+export const inFlightByIdSelector = (
+  state: RootState,
+  flowId: string
+): InFlightDescriptor | undefined => state.transactionInFlight.byFlow[flowId]
+
+export const currentInFlightForKindSelector = (
+  state: RootState,
+  kind: FlowKind
+): InFlightDescriptor | null => {
+  const all = Object.values(state.transactionInFlight.byFlow)
+  return (
+    all.find(
+      (flow) => flow.flowKind === kind && flow.status !== 'succeeded' && flow.status !== 'failed'
+    ) ?? null
+  )
+}

--- a/src/lib/useTransactionInFlight/slice.ts
+++ b/src/lib/useTransactionInFlight/slice.ts
@@ -1,0 +1,74 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import type { ErrorClass } from 'src/lib/errors'
+import type { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+import type { InFlightDescriptor, InFlightStatus } from './types'
+
+export interface State {
+  byFlow: Record<string, InFlightDescriptor>
+}
+
+const initialState: State = { byFlow: {} }
+
+// viem's TransactionRequest carries readonly fields (e.g. `accessList`) that
+// Immer's WritableDraft refuses to accept. We cast to `any` for assignments
+// into `state.byFlow[...]` since the persisted descriptor is treated as opaque
+// here — the structure is exercised through actions, not direct mutation.
+
+const slice = createSlice({
+  name: 'transactionInFlight',
+  initialState,
+  reducers: {
+    inFlightStart(state, action: PayloadAction<InFlightDescriptor>) {
+      state.byFlow[action.payload.flowId] = action.payload as any
+    },
+    inFlightAdvance(
+      state,
+      action: PayloadAction<{
+        flowId: string
+        toStatus: InFlightStatus
+        patch?: Partial<InFlightDescriptor>
+      }>
+    ) {
+      const flow = state.byFlow[action.payload.flowId]
+      if (!flow) return
+      if (action.payload.patch) {
+        Object.assign(flow, action.payload.patch)
+      }
+      flow.status = action.payload.toStatus
+    },
+    inFlightFail(state, action: PayloadAction<{ flowId: string; errorClass: ErrorClass }>) {
+      const flow = state.byFlow[action.payload.flowId]
+      if (!flow) return
+      flow.status = 'failed'
+      flow.lastErrorClass = action.payload.errorClass
+    },
+    inFlightRetry(
+      state,
+      action: PayloadAction<{
+        flowId: string
+        freshPreparedTransactions?: SerializableTransactionRequest[]
+        pollContextPatch?: Record<string, unknown>
+      }>
+    ) {
+      const flow = state.byFlow[action.payload.flowId]
+      if (!flow) return
+      flow.retryCount += 1
+      flow.status = 'preparing'
+      flow.lastErrorClass = undefined
+      if (action.payload.freshPreparedTransactions) {
+        flow.preparedTransactions = action.payload.freshPreparedTransactions as any
+      }
+      if (action.payload.pollContextPatch) {
+        flow.pollContext = { ...(flow.pollContext ?? {}), ...action.payload.pollContextPatch }
+      }
+    },
+    inFlightAbort(state, action: PayloadAction<{ flowId: string }>) {
+      delete state.byFlow[action.payload.flowId]
+    },
+  },
+})
+
+export const { inFlightStart, inFlightAdvance, inFlightFail, inFlightRetry, inFlightAbort } =
+  slice.actions
+
+export default slice.reducer

--- a/src/lib/useTransactionInFlight/types.ts
+++ b/src/lib/useTransactionInFlight/types.ts
@@ -1,0 +1,73 @@
+import type { ErrorClass } from 'src/lib/errors'
+import type { NetworkId } from 'src/transactions/types'
+import type { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+
+export type FlowKind =
+  | 'swap'
+  | 'dollarsSpend'
+  | 'send'
+  | 'buckspay'
+  | 'earn'
+  | 'gold'
+  | 'jumpstart'
+  | 'subsidy'
+
+export type InFlightStatus =
+  | 'idle'
+  | 'preparing'
+  | 'awaiting-pin'
+  | 'submitting'
+  | 'pending-confirmation'
+  | 'progress'
+  | 'succeeded'
+  | 'partial-failure'
+  | 'failed'
+
+export interface InFlightDescriptor {
+  flowId: string
+  flowKind: FlowKind
+  steps: number
+  currentStep: number
+  status: InFlightStatus
+  preparedTransactions: SerializableTransactionRequest[]
+  networkId: NetworkId
+  lastErrorClass?: ErrorClass
+  retryCount: number
+  startedAt: number
+  // Multi-step: per-step accounting for partial-failure UI.
+  completedStepIndices?: number[]
+  failedStepIndex?: number | null
+  // Optional feature-private blob carried along with the descriptor.
+  // E.g. swap stores maxSlippagePercentage; subsidy stores recipientPhone hash.
+  pollContext?: Record<string, unknown>
+}
+
+export type CustomPoll = (descriptor: InFlightDescriptor) => Promise<InFlightStatus | null>
+
+export type RetryClassifier = (error: unknown) => ErrorClass
+
+export interface RetryOptions {
+  freshPreparedTransactions?: SerializableTransactionRequest[]
+  pollContextPatch?: Record<string, unknown>
+}
+
+export interface UseTransactionInFlightArgs {
+  scopeToFlowKind?: FlowKind
+  customPoll?: CustomPoll
+  retryClassifier?: RetryClassifier
+}
+
+export interface UseTransactionInFlightResult {
+  current: InFlightDescriptor | null
+  start: (
+    descriptor: Omit<
+      InFlightDescriptor,
+      'flowId' | 'currentStep' | 'status' | 'retryCount' | 'startedAt'
+    >
+  ) => string
+  advance: (flowId: string, toStatus: InFlightStatus, patch?: Partial<InFlightDescriptor>) => void
+  fail: (flowId: string, errorClass: ErrorClass) => void
+  retry: (flowId: string, opts?: RetryOptions) => void
+  abort: (flowId: string) => void
+  classifyError: (error: unknown) => ErrorClass
+}

--- a/src/lib/useTransactionInFlight/useTransactionInFlight.test.tsx
+++ b/src/lib/useTransactionInFlight/useTransactionInFlight.test.tsx
@@ -1,0 +1,196 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { act, renderHook } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import type { ErrorClass } from 'src/lib/errors'
+import { useTransactionInFlight } from 'src/lib/useTransactionInFlight'
+import transactionInFlightReducer from 'src/lib/useTransactionInFlight/slice'
+import { NetworkId } from 'src/transactions/types'
+
+// Build a minimal real store with just the transactionInFlight reducer.
+// `createMockStore` from test/utils uses redux-mock-store which does NOT run
+// reducers, so it can't observe state transitions produced by dispatched actions.
+function buildStore() {
+  return configureStore({
+    reducer: { transactionInFlight: transactionInFlightReducer },
+  })
+}
+
+type TestStore = ReturnType<typeof buildStore>
+
+function makeWrapper(store: TestStore) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <Provider store={store as any}>{children}</Provider>
+  }
+}
+
+const baseStartArgs = {
+  flowKind: 'swap' as const,
+  steps: 1,
+  preparedTransactions: [],
+  networkId: NetworkId['celo-mainnet'],
+}
+
+describe('useTransactionInFlight', () => {
+  it('returns no current descriptor when scoped to a kind and store is empty', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight({ scopeToFlowKind: 'swap' }), {
+      wrapper: makeWrapper(store),
+    })
+    expect(result.current.current).toBeNull()
+  })
+
+  it('start() returns a flowId and writes a descriptor in `preparing` status', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight({ scopeToFlowKind: 'swap' }), {
+      wrapper: makeWrapper(store),
+    })
+
+    let flowId = ''
+    void act(() => {
+      flowId = result.current.start(baseStartArgs)
+    })
+
+    expect(flowId).toMatch(/^swap-/)
+    const descriptor = store.getState().transactionInFlight.byFlow[flowId]
+    expect(descriptor).toMatchObject({
+      flowId,
+      flowKind: 'swap',
+      steps: 1,
+      currentStep: 0,
+      status: 'preparing',
+      retryCount: 0,
+      networkId: NetworkId['celo-mainnet'],
+    })
+    expect(typeof descriptor.startedAt).toBe('number')
+  })
+
+  it('advance() transitions status and applies a patch', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight({ scopeToFlowKind: 'swap' }), {
+      wrapper: makeWrapper(store),
+    })
+
+    let flowId = ''
+    void act(() => {
+      flowId = result.current.start(baseStartArgs)
+    })
+    void act(() => {
+      result.current.advance(flowId, 'submitting', { currentStep: 1 })
+    })
+
+    const descriptor = store.getState().transactionInFlight.byFlow[flowId]
+    expect(descriptor.status).toBe('submitting')
+    expect(descriptor.currentStep).toBe(1)
+  })
+
+  it('fail() sets status to `failed` and records the errorClass', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight({ scopeToFlowKind: 'swap' }), {
+      wrapper: makeWrapper(store),
+    })
+
+    let flowId = ''
+    void act(() => {
+      flowId = result.current.start(baseStartArgs)
+    })
+    const errorClass: ErrorClass = {
+      kind: 'slippage',
+      message: 'price moved',
+      retryable: true,
+    }
+    void act(() => {
+      result.current.fail(flowId, errorClass)
+    })
+
+    const descriptor = store.getState().transactionInFlight.byFlow[flowId]
+    expect(descriptor.status).toBe('failed')
+    expect(descriptor.lastErrorClass).toEqual(errorClass)
+  })
+
+  it('retry() increments retryCount and resets status to `preparing`', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight({ scopeToFlowKind: 'swap' }), {
+      wrapper: makeWrapper(store),
+    })
+
+    let flowId = ''
+    void act(() => {
+      flowId = result.current.start(baseStartArgs)
+    })
+    void act(() => {
+      result.current.fail(flowId, { kind: 'rpc-timeout', message: 'oops', retryable: true })
+    })
+    void act(() => {
+      result.current.retry(flowId, { pollContextPatch: { attempt: 2 } })
+    })
+
+    const descriptor = store.getState().transactionInFlight.byFlow[flowId]
+    expect(descriptor.retryCount).toBe(1)
+    expect(descriptor.status).toBe('preparing')
+    expect(descriptor.lastErrorClass).toBeUndefined()
+    expect(descriptor.pollContext).toEqual({ attempt: 2 })
+  })
+
+  it('abort() removes the flow from the store', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight({ scopeToFlowKind: 'swap' }), {
+      wrapper: makeWrapper(store),
+    })
+
+    let flowId = ''
+    void act(() => {
+      flowId = result.current.start(baseStartArgs)
+    })
+    void act(() => {
+      result.current.abort(flowId)
+    })
+
+    expect(store.getState().transactionInFlight.byFlow[flowId]).toBeUndefined()
+  })
+
+  it('classifyError() falls back to the default taxonomy when no retryClassifier is provided', () => {
+    const store = buildStore()
+    const { result } = renderHook(() => useTransactionInFlight(), {
+      wrapper: makeWrapper(store),
+    })
+
+    const cls = result.current.classifyError(new Error('execution reverted: bad path'))
+    expect(cls.kind).toBe('revert')
+    expect(cls.retryable).toBe(false)
+  })
+
+  it('classifyError() uses the provided retryClassifier when given', () => {
+    const store = buildStore()
+    const customClassifier = jest.fn(
+      (): ErrorClass => ({ kind: 'connectivity', message: 'no net', retryable: true })
+    )
+    const { result } = renderHook(
+      () => useTransactionInFlight({ retryClassifier: customClassifier }),
+      { wrapper: makeWrapper(store) }
+    )
+
+    const cls = result.current.classifyError(new Error('whatever'))
+    expect(customClassifier).toHaveBeenCalledTimes(1)
+    expect(cls).toEqual({ kind: 'connectivity', message: 'no net', retryable: true })
+  })
+
+  it('current is scoped to the requested flowKind and ignores other kinds', () => {
+    const store = buildStore()
+    const { result: swapHook } = renderHook(
+      () => useTransactionInFlight({ scopeToFlowKind: 'swap' }),
+      { wrapper: makeWrapper(store) }
+    )
+    const { result: buckspayHook } = renderHook(
+      () => useTransactionInFlight({ scopeToFlowKind: 'buckspay' }),
+      { wrapper: makeWrapper(store) }
+    )
+
+    void act(() => {
+      swapHook.current.start({ ...baseStartArgs, flowKind: 'buckspay' })
+    })
+
+    expect(swapHook.current.current).toBeNull()
+    expect(buckspayHook.current.current?.flowKind).toBe('buckspay')
+  })
+})

--- a/src/lib/useTransactionInFlight/useTransactionInFlight.ts
+++ b/src/lib/useTransactionInFlight/useTransactionInFlight.ts
@@ -1,0 +1,100 @@
+import { useCallback } from 'react'
+import { classifyError as defaultClassifyError } from 'src/lib/errors'
+import type { ErrorClass } from 'src/lib/errors'
+import { useDispatch, useSelector } from 'src/redux/hooks'
+import { currentInFlightForKindSelector } from './selectors'
+import { inFlightAbort, inFlightAdvance, inFlightFail, inFlightRetry, inFlightStart } from './slice'
+import type {
+  InFlightDescriptor,
+  InFlightStatus,
+  RetryOptions,
+  UseTransactionInFlightArgs,
+  UseTransactionInFlightResult,
+} from './types'
+
+function makeFlowId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
+}
+
+export function useTransactionInFlight(
+  args: UseTransactionInFlightArgs = {}
+): UseTransactionInFlightResult {
+  const { scopeToFlowKind, retryClassifier } = args
+  const dispatch = useDispatch()
+
+  const current = useSelector((state) =>
+    scopeToFlowKind ? currentInFlightForKindSelector(state, scopeToFlowKind) : null
+  )
+
+  const start = useCallback(
+    (
+      descriptor: Omit<
+        InFlightDescriptor,
+        'flowId' | 'currentStep' | 'status' | 'retryCount' | 'startedAt'
+      >
+    ): string => {
+      const flowId = makeFlowId(descriptor.flowKind)
+      const full: InFlightDescriptor = {
+        ...descriptor,
+        flowId,
+        currentStep: 0,
+        status: 'preparing',
+        retryCount: 0,
+        startedAt: Date.now(),
+      }
+      dispatch(inFlightStart(full))
+      return flowId
+    },
+    [dispatch]
+  )
+
+  const advance = useCallback(
+    (flowId: string, toStatus: InFlightStatus, patch?: Partial<InFlightDescriptor>) => {
+      dispatch(inFlightAdvance({ flowId, toStatus, patch }))
+    },
+    [dispatch]
+  )
+
+  const fail = useCallback(
+    (flowId: string, errorClass: ErrorClass) => {
+      dispatch(inFlightFail({ flowId, errorClass }))
+    },
+    [dispatch]
+  )
+
+  const retry = useCallback(
+    (flowId: string, opts?: RetryOptions) => {
+      dispatch(
+        inFlightRetry({
+          flowId,
+          freshPreparedTransactions: opts?.freshPreparedTransactions,
+          pollContextPatch: opts?.pollContextPatch,
+        })
+      )
+    },
+    [dispatch]
+  )
+
+  const abort = useCallback(
+    (flowId: string) => {
+      dispatch(inFlightAbort({ flowId }))
+    },
+    [dispatch]
+  )
+
+  const classifyError = useCallback(
+    (error: unknown): ErrorClass =>
+      retryClassifier ? retryClassifier(error) : defaultClassifyError(error),
+    [retryClassifier]
+  )
+
+  return {
+    current,
+    start,
+    advance,
+    fail,
+    retry,
+    abort,
+    classifyError,
+  }
+}

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -2067,4 +2067,15 @@ export const migrations = {
       },
     }
   },
+  249: (state: any) => {
+    // Track A Task 4: seed the new `transactionInFlight` slice that backs the
+    // useTransactionInFlight hook (the keystone abstraction for in-flight
+    // transaction state across feature flows). No prior shape to migrate.
+    return {
+      ...state,
+      transactionInFlight: {
+        byFlow: {},
+      },
+    }
+  },
 }

--- a/src/redux/reducersList.ts
+++ b/src/redux/reducersList.ts
@@ -24,6 +24,7 @@ import { recipientsReducer as recipients } from 'src/recipients/reducer'
 import { sendReducer as send } from 'src/send/reducers'
 import swapReducer from 'src/swap/slice'
 import tokenReducer from 'src/tokens/slice'
+import { transactionInFlightReducer } from 'src/lib/useTransactionInFlight'
 import transactionsReducer from 'src/transactions/slice'
 import { reducer as walletConnect } from 'src/walletConnect/reducer'
 import { reducer as web3 } from 'src/web3/reducer'
@@ -58,4 +59,5 @@ export const reducersList = {
   earn: earnReducer,
   buckspay: bucksPayReducer,
   gold: goldReducer,
+  transactionInFlight: transactionInFlightReducer,
 } as const

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -143,7 +143,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 247,
+          "version": 249,
         },
         "account": {
           "acceptedTerms": false,
@@ -239,6 +239,7 @@ describe('store state', () => {
         },
         "dollarsSpend": {
           "inFlight": null,
+          "transitioning": false,
         },
         "earn": {
           "depositStatus": "idle",
@@ -397,6 +398,9 @@ describe('store state', () => {
         "tokens": {
           "error": false,
           "tokenBalances": {},
+        },
+        "transactionInFlight": {
+          "byFlow": {},
         },
         "transactions": {
           "feedFirstPage": [],

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,10 +1,17 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { configureStore, Middleware } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query'
-import { getStoredState, PersistConfig, persistReducer, persistStore } from 'redux-persist'
+import {
+  createTransform,
+  getStoredState,
+  PersistConfig,
+  persistReducer,
+  persistStore,
+} from 'redux-persist'
 import FSStorage from 'redux-persist-fs-storage'
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2'
 import createSagaMiddleware from 'redux-saga'
+import type { State as TransactionInFlightState } from 'src/lib/useTransactionInFlight/slice'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { PerformanceEvents } from 'src/analytics/Events'
 import { apiMiddlewares } from 'src/redux/apiReducersList'
@@ -22,14 +29,45 @@ export const timeBetweenStoreSizeEvents = ONE_MINUTE_IN_MILLIS
 // the entire state is serialized in a session
 let lastEventTime = 0
 
+// On rehydrate, the `transactionInFlight` slice may have descriptors whose
+// `lastErrorClass.raw` field holds a non-serializable Error captured at runtime.
+// Strip `raw` from every descriptor's `lastErrorClass` before the state is
+// returned to the store so consumers never see an undecodable blob.
+const transactionInFlightTransform = createTransform<
+  TransactionInFlightState,
+  TransactionInFlightState
+>(
+  // inbound: state -> persisted
+  (inboundState) => inboundState,
+  // outbound: persisted -> state
+  (outboundState) => {
+    if (!outboundState?.byFlow) return outboundState
+    const scrubbedByFlow: TransactionInFlightState['byFlow'] = {}
+    for (const [flowId, descriptor] of Object.entries(outboundState.byFlow)) {
+      if (descriptor?.lastErrorClass) {
+        const { raw: _raw, ...restErrorClass } = descriptor.lastErrorClass
+        scrubbedByFlow[flowId] = {
+          ...descriptor,
+          lastErrorClass: restErrorClass,
+        }
+      } else {
+        scrubbedByFlow[flowId] = descriptor
+      }
+    }
+    return { ...outboundState, byFlow: scrubbedByFlow }
+  },
+  { whitelist: ['transactionInFlight'] }
+)
+
 const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 248,
+  version: 249,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],
+  transforms: [transactionInFlightTransform],
   stateReconciler: autoMergeLevel2,
   migrate: async (...args) => {
     const migrate = createMigrate(migrations)

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3863,6 +3863,10 @@
             ],
             "type": "string"
         },
+        "Record<string,InFlightDescriptor>": {
+            "additionalProperties": false,
+            "type": "object"
+        },
         "Record<string,[string,...string[]]>": {
             "additionalProperties": false,
             "type": "object"
@@ -6151,6 +6155,18 @@
             ],
             "type": "object"
         },
+        "State_29": {
+            "additionalProperties": false,
+            "properties": {
+                "byFlow": {
+                    "$ref": "#/definitions/Record<string,InFlightDescriptor>"
+                }
+            },
+            "required": [
+                "byFlow"
+            ],
+            "type": "object"
+        },
         "State_3": {
             "anyOf": [
                 {
@@ -8078,6 +8094,9 @@
         "tokens": {
             "$ref": "#/definitions/State_15"
         },
+        "transactionInFlight": {
+            "$ref": "#/definitions/State_29"
+        },
         "transactions": {
             "$ref": "#/definitions/State_6"
         },
@@ -8116,6 +8135,7 @@
         "send",
         "swap",
         "tokens",
+        "transactionInFlight",
         "transactions",
         "walletConnect",
         "web3"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3709,6 +3709,18 @@ export const v248Schema = {
   },
 }
 
+// Migration 249 seeds the new `transactionInFlight` slice that backs the
+// useTransactionInFlight hook (Track A Task 4 — the keystone in-flight tx
+// state abstraction consumed by all feature flows).
+export const v249Schema = {
+  ...v248Schema,
+  transactionInFlight: { byFlow: {} },
+  _persist: {
+    ...v248Schema._persist,
+    version: 249,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v248Schema as Partial<RootState>
+  return v249Schema as Partial<RootState>
 }


### PR DESCRIPTION
Plan 01 Track A Task 4 — **KEYSTONE abstraction**. v4 API verbatim from S5 spike outcome.

### What this adds
The keystone state-management primitive that subsequent feature migrations consume. Combines:
- Redux Toolkit slice keyed by `flowId` with 5 actions (start/advance/fail/retry/abort)
- TypeScript types verbatim from S5 spec (`FlowKind`, `InFlightStatus`, `InFlightDescriptor`, etc.)
- Hook with 2 pre-agreed extension points: `customPoll`, `retryClassifier`
- Saga-friendly action creators for the saga layer
- Persist transform whitelist-scoped that scrubs non-serializable `lastErrorClass.raw` on rehydrate

### Files (7 new, 6 modified)
NEW:
- src/lib/useTransactionInFlight/{types, slice, selectors, actions, useTransactionInFlight, index}.ts
- src/lib/useTransactionInFlight/useTransactionInFlight.test.tsx (9 tests)

MODIFIED:
- src/redux/reducersList.ts (registered slice as `transactionInFlight`)
- src/redux/migrations.ts (migration **248 → 249** seeding empty byFlow)
- src/redux/store.ts (persist version 249 + `transactionInFlightTransform` scrubbing raw on rehydrate)
- test/schemas.ts + test/RootStateSchema.json (added v249Schema + regenerated schema)
- src/redux/store.test.ts (snapshot updated)

### Verification
- 9/9 hook tests pass
- 107/107 across lib/useTransactionInFlight + redux/store + redux/migrations
- yarn build:ts + lint ✓

### Note on customPoll
Wired into the args signature but not yet exercised by a tick scheduler. Per the S5 doc + plan, the `inFlightSaga.ts` polling-tick scheduler delegating to `customPoll` is intentionally out-of-scope here and lands when BucksPay migrates.

### Unblocks
- Track A Task 6 (TransactionProgressSheet — consumes the descriptor)
- Track B Tasks 1, 3, 6 (use the in-flight state)
- Track C Task 3 (saga7702 uses the slice)