### PR TITLE
feat(components): add TransactionProgressSheet with connectivity banner

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3178,5 +3178,14 @@
     "revert": "The network rejected your {{noun}}. Nothing was charged. Try again?",
     "rpcTimeout": "The blockchain network did not respond in time. Try again?",
     "unknown": "Something did not go as expected. Want to try again or contact us?"
+  },
+  "progress": {
+    "preparing": "Preparing your {{noun}}...",
+    "awaitingPin": "Confirm your PIN to continue",
+    "submitting": "Sending your {{noun}} to the network...",
+    "pendingConfirmation": "Waiting for network confirmation...",
+    "multiStep": "Step {{currentStep}} of {{total}}",
+    "succeeded": "Done. Your {{noun}} completed.",
+    "connectivityLost": "We lost connection. Your {{noun}} is still in progress; waiting for connection to come back."
   }
 }

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3271,5 +3271,14 @@
     "revert": "La red rechazo tu {{noun}}. No se cobro nada. Lo intentamos de nuevo?",
     "rpcTimeout": "La red blockchain no respondio a tiempo. Lo intentamos de nuevo?",
     "unknown": "Algo no salio como esperabamos. Lo intentamos de nuevo o nos contactas?"
+  },
+  "progress": {
+    "preparing": "Preparando tu {{noun}}...",
+    "awaitingPin": "Confirma tu PIN para continuar",
+    "submitting": "Enviando tu {{noun}} a la red...",
+    "pendingConfirmation": "Esperando confirmacion de la red...",
+    "multiStep": "Paso {{currentStep}} de {{total}}",
+    "succeeded": "Listo. Tu {{noun}} se completo.",
+    "connectivityLost": "Perdimos la conexion. Tu {{noun}} sigue en curso; esperando que vuelvas a tener conexion."
   }
 }

--- a/src/components/TransactionProgressSheet.test.tsx
+++ b/src/components/TransactionProgressSheet.test.tsx
@@ -1,0 +1,172 @@
+import { configureStore } from '@reduxjs/toolkit'
+import NetInfo from '@react-native-community/netinfo'
+import { act, render } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { TransactionProgressSheet } from 'src/components/TransactionProgressSheet'
+import transactionInFlightReducer, {
+  inFlightAdvance,
+  inFlightStart,
+} from 'src/lib/useTransactionInFlight/slice'
+import type { InFlightDescriptor, InFlightStatus } from 'src/lib/useTransactionInFlight/types'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('@react-native-community/netinfo')
+
+function buildStore() {
+  return configureStore({
+    reducer: { transactionInFlight: transactionInFlightReducer },
+  })
+}
+
+type TestStore = ReturnType<typeof buildStore>
+
+function makeDescriptor(overrides: Partial<InFlightDescriptor> = {}): InFlightDescriptor {
+  return {
+    flowId: 'swap-test-1',
+    flowKind: 'swap',
+    steps: 1,
+    currentStep: 0,
+    status: 'preparing',
+    preparedTransactions: [],
+    networkId: NetworkId['celo-mainnet'],
+    retryCount: 0,
+    startedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+function renderSheet(store: TestStore) {
+  return render(
+    <Provider store={store as any}>
+      <TransactionProgressSheet scopeToFlowKind="swap" noun="cambio" />
+    </Provider>
+  )
+}
+
+describe('TransactionProgressSheet', () => {
+  let listeners: Array<(s: any) => void> = []
+
+  beforeEach(() => {
+    listeners = []
+    ;(NetInfo as any).addEventListener = jest.fn((cb) => {
+      listeners.push(cb)
+      return () => {
+        listeners = listeners.filter((l) => l !== cb)
+      }
+    })
+    ;(NetInfo as any).fetch = jest.fn().mockResolvedValue({ isConnected: true, type: 'wifi' })
+  })
+
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+
+  it('returns null when there is no current in-flight', () => {
+    const store = buildStore()
+    const { queryByTestId } = renderSheet(store)
+    expect(queryByTestId('TransactionProgressSheet')).toBeNull()
+  })
+
+  it('renders preparing message for status preparing', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'preparing' })))
+    const { getByTestId, getByText } = renderSheet(store)
+    await flush()
+    expect(getByTestId('TransactionProgressSheet')).toBeTruthy()
+    expect(getByText(/progress\.preparing/)).toBeTruthy()
+  })
+
+  it('renders multi-step "Paso N de M" for status progress with steps>1', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'progress', steps: 3, currentStep: 1 })))
+    const { getByText } = renderSheet(store)
+    await flush()
+    const node = getByText(/progress\.multiStep/)
+    expect(node).toBeTruthy()
+    // params are serialized by the react-i18next mock as JSON
+    expect(node.props.children).toEqual(expect.stringContaining('"currentStep":2'))
+    expect(node.props.children).toEqual(expect.stringContaining('"total":3'))
+  })
+
+  it('renders submitting message for status submitting', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'submitting' })))
+    const { getByText } = renderSheet(store)
+    await flush()
+    expect(getByText(/progress\.submitting/)).toBeTruthy()
+  })
+
+  it('renders pending-confirmation message for status pending-confirmation', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'pending-confirmation' })))
+    const { getByText } = renderSheet(store)
+    await flush()
+    expect(getByText(/progress\.pendingConfirmation/)).toBeTruthy()
+  })
+
+  it('returns null for partial-failure status (handled by another component)', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'preparing' })))
+    store.dispatch(
+      inFlightAdvance({
+        flowId: 'swap-test-1',
+        toStatus: 'partial-failure' as InFlightStatus,
+      })
+    )
+    const { queryByTestId } = renderSheet(store)
+    await flush()
+    expect(queryByTestId('TransactionProgressSheet')).toBeNull()
+  })
+
+  it('returns null for failed status', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'preparing' })))
+    store.dispatch(inFlightAdvance({ flowId: 'swap-test-1', toStatus: 'failed' as InFlightStatus }))
+    const { queryByTestId } = renderSheet(store)
+    await flush()
+    expect(queryByTestId('TransactionProgressSheet')).toBeNull()
+  })
+
+  it('shows connectivity banner when isConnected becomes false during submitting', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'submitting' })))
+    const { getByTestId, queryByTestId } = renderSheet(store)
+    await flush()
+    expect(queryByTestId('TransactionProgressSheet/ConnectivityBanner')).toBeNull()
+
+    await act(async () => {
+      listeners.forEach((cb) => cb({ isConnected: false, type: 'none' }))
+    })
+    expect(getByTestId('TransactionProgressSheet/ConnectivityBanner')).toBeTruthy()
+  })
+
+  it('hides connectivity banner when connectivity returns', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'submitting' })))
+    const { queryByTestId } = renderSheet(store)
+    await flush()
+    await act(async () => {
+      listeners.forEach((cb) => cb({ isConnected: false, type: 'none' }))
+    })
+    expect(queryByTestId('TransactionProgressSheet/ConnectivityBanner')).toBeTruthy()
+
+    await act(async () => {
+      listeners.forEach((cb) => cb({ isConnected: true, type: 'wifi' }))
+    })
+    expect(queryByTestId('TransactionProgressSheet/ConnectivityBanner')).toBeNull()
+  })
+
+  it('does not show connectivity banner when disconnected during awaiting-pin', async () => {
+    const store = buildStore()
+    store.dispatch(inFlightStart(makeDescriptor({ status: 'awaiting-pin' })))
+    const { queryByTestId } = renderSheet(store)
+    await flush()
+    await act(async () => {
+      listeners.forEach((cb) => cb({ isConnected: false, type: 'none' }))
+    })
+    expect(queryByTestId('TransactionProgressSheet/ConnectivityBanner')).toBeNull()
+  })
+})

--- a/src/components/TransactionProgressSheet.tsx
+++ b/src/components/TransactionProgressSheet.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import type { ConfirmationNoun } from 'src/components/ConfirmationSheet'
+import { useConnectivityState } from 'src/lib/connectivity'
+import { useTransactionInFlight } from 'src/lib/useTransactionInFlight'
+import type { FlowKind, InFlightStatus } from 'src/lib/useTransactionInFlight/types'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+export interface TransactionProgressSheetProps {
+  scopeToFlowKind: FlowKind
+  noun: ConfirmationNoun
+  testID?: string
+}
+
+// Maps the descriptor `status` to the i18n key suffix under `progress.*`.
+// Hyphenated statuses translate to camelCase keys (i18n keys cannot contain
+// dashes when accessed via dotted lookups). `partial-failure` and `failed` are
+// rendered by other components in the flow shell, so they yield `null` here.
+const STATUS_TO_KEY: Record<InFlightStatus, string | null> = {
+  idle: null,
+  preparing: 'preparing',
+  'awaiting-pin': 'awaitingPin',
+  submitting: 'submitting',
+  'pending-confirmation': 'pendingConfirmation',
+  progress: 'multiStep',
+  succeeded: 'succeeded',
+  'partial-failure': null,
+  failed: null,
+}
+
+export function TransactionProgressSheet(props: TransactionProgressSheetProps) {
+  const { t } = useTranslation()
+  const { current } = useTransactionInFlight({ scopeToFlowKind: props.scopeToFlowKind })
+  const { isConnected } = useConnectivityState()
+
+  if (!current) {
+    return null
+  }
+
+  const keySuffix = STATUS_TO_KEY[current.status]
+  if (!keySuffix) {
+    return null
+  }
+
+  const messageKey = `progress.${keySuffix}`
+  const tParams = {
+    noun: props.noun,
+    currentStep: current.currentStep + 1,
+    total: current.steps,
+  }
+
+  const showConnectivityBanner =
+    !isConnected && (current.status === 'submitting' || current.status === 'progress')
+
+  return (
+    <View testID={props.testID ?? 'TransactionProgressSheet'} style={styles.container}>
+      <Text style={styles.message}>{t(messageKey, tParams)}</Text>
+      {showConnectivityBanner && (
+        <View testID="TransactionProgressSheet/ConnectivityBanner" style={styles.banner}>
+          <Text style={styles.bannerText}>
+            {t('progress.connectivityLost', { noun: props.noun })}
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.Thick24,
+    backgroundColor: Colors.white,
+  },
+  message: {
+    ...typeScale.bodyMedium,
+    color: Colors.black,
+    textAlign: 'center',
+  },
+  banner: {
+    marginTop: Spacing.Regular16,
+    padding: Spacing.Regular16,
+    borderRadius: 12,
+    backgroundColor: Colors.warningLight,
+  },
+  bannerText: {
+    ...typeScale.bodySmall,
+    color: Colors.warningDark,
+    textAlign: 'center',
+  },
+})
+
+export default TransactionProgressSheet


### PR DESCRIPTION
Plan 01 Track A Task 6.

Shared in-progress UI consuming `useTransactionInFlight` (PR #177) + `useConnectivityState` (PR #172). Presentation-only — no saga calls.

### Status → message mapping (i18n `progress.*`)
- preparing / awaiting-pin / submitting / pending-confirmation → contextual messages
- progress (multi-step) → 'Paso N de M'
- succeeded → success message
- partial-failure / failed → null (result sheet handles)

### Connectivity banner
Yellow overlay shown when isConnected=false during 'submitting' or 'progress'. Suppressed during 'awaiting-pin' to avoid noise.

### Files
- src/components/TransactionProgressSheet.tsx
- src/components/TransactionProgressSheet.test.tsx (10/10 tests pass)
- locales/base + es-419: progress.* block

### Verification
- yarn build:ts + lint ✓
- 10/10 tests pass with configureStore slice + mocked NetInfo