### PR TITLE
feat(revoke7702): add revokeDelegation helper for kill-switch recovery

### DIFF
--- a/src/lib/revoke7702/index.ts
+++ b/src/lib/revoke7702/index.ts
@@ -1,0 +1,2 @@
+export { revokeDelegation } from './revokeDelegation'
+export type { RevokeOpts } from './revokeDelegation'

--- a/src/lib/revoke7702/revokeDelegation.test.ts
+++ b/src/lib/revoke7702/revokeDelegation.test.ts
@@ -1,0 +1,47 @@
+import { revokeDelegation } from './revokeDelegation'
+import { zeroAddress } from 'viem'
+
+describe('revokeDelegation', () => {
+  it('signs authorization pointing at zero address', async () => {
+    const signSpy = jest
+      .fn()
+      .mockResolvedValue({ contractAddress: zeroAddress, signature: '0xsig' })
+    const sendSpy = jest.fn().mockResolvedValue('0xhash')
+    const wallet = {
+      account: { address: '0x4D0d9e458e8a0D0C2c033B1fc2fE5a182837c3D2' as const },
+      signAuthorization: signSpy,
+      sendTransaction: sendSpy,
+    } as any
+
+    const hash = await revokeDelegation(wallet)
+    expect(signSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress: zeroAddress }))
+    expect(sendSpy).toHaveBeenCalled()
+    expect(hash).toBe('0xhash')
+  })
+
+  it('forwards feeCurrency if provided', async () => {
+    const signSpy = jest
+      .fn()
+      .mockResolvedValue({ contractAddress: zeroAddress, signature: '0xsig' })
+    const sendSpy = jest.fn().mockResolvedValue('0xhash2')
+    const wallet = {
+      account: { address: '0x4D0d9e458e8a0D0C2c033B1fc2fE5a182837c3D2' as const },
+      signAuthorization: signSpy,
+      sendTransaction: sendSpy,
+    } as any
+    const FEE = '0x765DE816845861e75A25fCA122bb6898B8B1282a' as const
+
+    await revokeDelegation(wallet, { feeCurrency: FEE })
+    const callArgs = sendSpy.mock.calls[0][0]
+    expect(callArgs.feeCurrency).toBe(FEE)
+  })
+
+  it('throws if wallet has no account', async () => {
+    const wallet = {
+      account: null,
+      signAuthorization: jest.fn(),
+      sendTransaction: jest.fn(),
+    } as any
+    await expect(revokeDelegation(wallet)).rejects.toThrow(/account/i)
+  })
+})

--- a/src/lib/revoke7702/revokeDelegation.ts
+++ b/src/lib/revoke7702/revokeDelegation.ts
@@ -1,0 +1,36 @@
+import type { WalletClient } from 'viem'
+import { zeroAddress } from 'viem'
+
+export interface RevokeOpts {
+  /** Optional Celo CIP-64 fee currency address (USDm, COPm, etc.) */
+  feeCurrency?: `0x${string}`
+}
+
+/**
+ * Signs an EIP-7702 authorization clearing the EOA's delegation by pointing
+ * at the zero address, then submits the tx. After this tx confirms, the user's
+ * EOA is back to a plain EOA with no delegated code.
+ *
+ * This is the kill-switch recovery mechanism per S4 rollback plan.
+ */
+export async function revokeDelegation(
+  wallet: WalletClient,
+  opts: RevokeOpts = {}
+): Promise<`0x${string}`> {
+  if (!wallet.account) throw new Error('revokeDelegation: wallet has no account')
+
+  const authorization = await wallet.signAuthorization({
+    contractAddress: zeroAddress,
+    account: wallet.account,
+  } as any)
+
+  const hash = await wallet.sendTransaction({
+    account: wallet.account,
+    to: wallet.account.address,
+    data: '0x',
+    authorizationList: [authorization],
+    ...(opts.feeCurrency ? { feeCurrency: opts.feeCurrency } : {}),
+  } as any)
+
+  return hash as `0x${string}`
+}


### PR DESCRIPTION
Plan 03 Track C Task 4.

Kill-switch recovery mechanism per S4 rollback plan. Signs an EIP-7702 authorization pointing at zero address (`0x0000000000000000000000000000000000000000`) to clear the EOA's delegation, then submits the tx.

After this tx confirms, the user's EOA is back to a plain EOA with no delegated code.

### API
```ts
revokeDelegation(wallet: WalletClient, opts?: { feeCurrency?: `0x${string}` }): Promise<`0x${string}`>
```

Optional `feeCurrency` forwards CIP-64 fee currency (USDm, COPm, etc.) so a user without CELO can still revoke.

### Files (3 new)
- src/lib/revoke7702/revokeDelegation.ts
- src/lib/revoke7702/revokeDelegation.test.ts (3/3 tests pass)
- src/lib/revoke7702/index.ts

### Verification
- 3/3 tests pass (signs at zeroAddress, forwards feeCurrency, throws on missing account)
- yarn build:ts + lint ✓
- No new dependencies (uses viem 2.x WalletClient + zeroAddress)

### Used by
Future Track C work (Phase 1 internal dogfood, Phase 2 production rollout). The DeepLinkRecovery banner or a Settings option can invoke this when a user reports stuck delegation.