### PR TITLE
feat(gold,transactions): consume tucop-backend proxies, remove hardcoded API keys

### DIFF
--- a/src/gold/api.test.ts
+++ b/src/gold/api.test.ts
@@ -1,0 +1,106 @@
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+import networkConfig from 'src/web3/networkConfig'
+
+jest.mock('src/utils/fetchWithTimeout', () => ({
+  fetchWithTimeout: jest.fn(),
+}))
+
+const mockFetchWithTimeout = fetchWithTimeout as jest.MockedFunction<typeof fetchWithTimeout>
+
+function jsonResponse(body: object, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+// Re-require the module under test in isolation so the in-memory price cache
+// resets between tests. CommonJS require lets Jest resolve the absolute alias
+// at runtime (without a `.js` suffix that TS' nodenext resolver would reject).
+type ApiModule = typeof import('./api.js')
+
+function loadApi(): ApiModule {
+  let mod!: ApiModule
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mod = require('src/gold/api') as ApiModule
+  })
+  return mod
+}
+
+beforeEach(() => {
+  mockFetchWithTimeout.mockReset()
+})
+
+describe('gold/api', () => {
+  it('fetches XAUt USD price from the TuCop backend proxy', async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      jsonResponse({ symbol: 'XAUT0', vs: 'usd', priceUsd: 3210.5, asOf: '2026-06-16T00:00:00Z' })
+    )
+
+    const { fetchGoldPriceFromApi } = loadApi()
+    const result = await fetchGoldPriceFromApi()
+
+    expect(mockFetchWithTimeout).toHaveBeenCalledWith(
+      networkConfig.getXautPriceUrl,
+      expect.objectContaining({ method: 'GET' })
+    )
+    expect(result.priceUsd).toBe(3210.5)
+    expect(result.price24hChange).toBe(0)
+  })
+
+  it('does not send any API key header to the TuCop backend', async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      jsonResponse({ symbol: 'XAUT0', vs: 'usd', priceUsd: 3000, asOf: '2026-06-16T00:00:00Z' })
+    )
+
+    const { fetchGoldPriceFromApi } = loadApi()
+    await fetchGoldPriceFromApi()
+
+    const [, options] = mockFetchWithTimeout.mock.calls[0]
+    const headers = (options?.headers ?? {}) as Record<string, string>
+    const lowered = Object.keys(headers).map((h) => h.toLowerCase())
+    expect(lowered).not.toContain('x-cmc_pro_api_key')
+    expect(lowered).not.toContain('authorization')
+    expect(lowered).not.toContain('x-api-key')
+  })
+
+  it('falls back to DIA when the TuCop backend errors', async () => {
+    mockFetchWithTimeout
+      .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, false, 502))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          Symbol: 'XAUT',
+          Name: 'Tether Gold',
+          Price: 3100,
+          PriceYesterday: 3000,
+          Time: '2026-06-16T00:00:00Z',
+        })
+      )
+
+    const { fetchGoldPriceFromApi } = loadApi()
+    const result = await fetchGoldPriceFromApi()
+
+    expect(mockFetchWithTimeout).toHaveBeenCalledTimes(2)
+    expect(result.priceUsd).toBe(3100)
+    expect(result.price24hChange).toBeCloseTo(((3100 - 3000) / 3000) * 100)
+  })
+
+  it('returns the hardcoded fallback if all APIs fail', async () => {
+    mockFetchWithTimeout
+      .mockResolvedValueOnce(jsonResponse({}, false, 500))
+      .mockResolvedValueOnce(jsonResponse({}, false, 500))
+
+    const { fetchGoldPriceWithFallback } = loadApi()
+    const result = await fetchGoldPriceWithFallback()
+
+    expect(result.priceUsd).toBeGreaterThan(0)
+  })
+
+  it('uses the URL configured on networkConfig', () => {
+    expect(networkConfig.getXautPriceUrl).toMatch(/^https:\/\/.+\/api\/prices\/xaut\?vs=usd$/)
+    expect(networkConfig.blockscoutProxyBase).toMatch(/^https:\/\/.+\/api\/v2$/)
+  })
+})

--- a/src/gold/api.ts
+++ b/src/gold/api.ts
@@ -1,16 +1,16 @@
 import { GoldPriceData } from 'src/gold/types'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import Logger from 'src/utils/Logger'
+import networkConfig from 'src/web3/networkConfig'
 
 const TAG = 'gold/api'
 
-// Primary API: CoinMarketCap for XAUt (Tether Gold) token price
-// This tracks the actual XAUt token price, not just physical gold
-const CMC_API_URL = 'https://pro-api.coinmarketcap.com/v2/cryptocurrency/quotes/latest'
-const CMC_API_KEY = 'b0118ca69c6a4db5bead46556855df5d'
-const XAUT_CMC_ID = '5176' // XAUt token ID on CoinMarketCap
+// Primary source: TuCop backend price proxy.
+// The backend owns the upstream provider credential; the mobile app never
+// holds a CoinMarketCap (or equivalent) API key. Endpoint contract:
+//   GET /api/prices/xaut?vs=usd  ->  { symbol, vs, priceUsd, asOf }
 
-// Fallback API: DIA Data for XAUt specific pricing
+// Fallback API: DIA Data for XAUt specific pricing (provides 24h change).
 // Documentation: https://www.diadata.org/
 const DIA_XAUT_API_URL =
   'https://api.diadata.org/v1/assetQuotation/Ethereum/0x68749665FF8D2d112Fa859AA293F07A622782F38'
@@ -26,22 +26,12 @@ const FALLBACK_GOLD_PRICE: GoldPriceData = {
   timestamp: Date.now(),
 }
 
-// CoinMarketCap response format for XAUt
-export interface CmcQuoteResponse {
-  data: {
-    [id: string]: {
-      id: number
-      name: string
-      symbol: string
-      quote: {
-        USD: {
-          price: number
-          percent_change_24h: number
-          last_updated: string
-        }
-      }
-    }
-  }
+// TuCop backend price endpoint response format
+export interface TucopXautPriceResponse {
+  symbol: string
+  vs: string
+  priceUsd: number
+  asOf: string
 }
 
 // DIA Data response format
@@ -63,38 +53,35 @@ function isCacheValid(): boolean {
 }
 
 /**
- * Fetch XAUt token price from CoinMarketCap (primary source)
- * This tracks the actual XAUt (Tether Gold) token price
- * Documentation: https://coinmarketcap.com/api/documentation/v1/
+ * Fetch XAUt token price from the TuCop backend price proxy (primary source).
+ * The backend keeps the upstream provider credential; the mobile app does not.
+ * The proxy returns only the current USD price, so price24hChange is filled
+ * by the DIA fallback path when available (here defaulted to 0).
  */
-async function fetchFromCoinMarketCap(): Promise<GoldPriceData> {
-  Logger.debug(TAG, 'Fetching XAUt price from CoinMarketCap')
+async function fetchFromTucopBackend(): Promise<GoldPriceData> {
+  Logger.debug(TAG, 'Fetching XAUt price from TuCop backend')
 
-  const url = `${CMC_API_URL}?id=${XAUT_CMC_ID}`
-
-  const response = await fetchWithTimeout(url, {
+  const response = await fetchWithTimeout(networkConfig.getXautPriceUrl, {
     method: 'GET',
     headers: {
       Accept: 'application/json',
-      'X-CMC_PRO_API_KEY': CMC_API_KEY,
     },
   })
 
   if (!response.ok) {
     const errorText = await response.text()
-    throw new Error(`CoinMarketCap API error: HTTP ${response.status} - ${errorText}`)
+    throw new Error(`TuCop price proxy error: HTTP ${response.status} - ${errorText}`)
   }
 
-  const data: CmcQuoteResponse = await response.json()
-  const xautData = data.data[XAUT_CMC_ID]
+  const data: TucopXautPriceResponse = await response.json()
 
-  if (!xautData) {
-    throw new Error('XAUt data not found in CoinMarketCap response')
+  if (typeof data.priceUsd !== 'number' || !Number.isFinite(data.priceUsd)) {
+    throw new Error('Invalid priceUsd in TuCop price proxy response')
   }
 
   return {
-    priceUsd: xautData.quote.USD.price,
-    price24hChange: xautData.quote.USD.percent_change_24h,
+    priceUsd: data.priceUsd,
+    price24hChange: 0,
     timestamp: Date.now(),
   }
 }
@@ -131,8 +118,8 @@ async function fetchFromDiaApi(): Promise<GoldPriceData> {
 }
 
 /**
- * Fetch XAUt token price from API with caching
- * Uses CoinMarketCap as primary source, DIA as fallback
+ * Fetch XAUt token price from API with caching.
+ * Uses the TuCop backend proxy as primary source, DIA Data as fallback.
  */
 export async function fetchGoldPriceFromApi(): Promise<GoldPriceData> {
   // Return cached price if still valid
@@ -141,14 +128,14 @@ export async function fetchGoldPriceFromApi(): Promise<GoldPriceData> {
     return cachedGoldPrice
   }
 
-  // Try CoinMarketCap first (tracks actual XAUt token price)
+  // Try TuCop backend proxy first
   try {
-    const priceData = await fetchFromCoinMarketCap()
+    const priceData = await fetchFromTucopBackend()
     cachedGoldPrice = priceData
-    Logger.debug(TAG, 'Got XAUt price from CoinMarketCap', { price: priceData.priceUsd })
+    Logger.debug(TAG, 'Got XAUt price from TuCop backend', { price: priceData.priceUsd })
     return priceData
   } catch (primaryError: any) {
-    Logger.warn(TAG, 'CoinMarketCap failed, trying DIA fallback', primaryError.message)
+    Logger.warn(TAG, 'TuCop backend failed, trying DIA fallback', primaryError.message)
   }
 
   // Fallback to DIA Data

--- a/src/transactions/blockscoutApi.ts
+++ b/src/transactions/blockscoutApi.ts
@@ -11,8 +11,8 @@ import networkConfig from 'src/web3/networkConfig'
 
 const TAG = 'transactions/blockscoutApi'
 
-// Blockscout API base URL for Celo mainnet
-const BLOCKSCOUT_API_BASE = 'https://celo.blockscout.com/api/v2'
+// Use TuCop backend Blockscout passthrough so the API key stays on the server.
+const BLOCKSCOUT_API_BASE = networkConfig.blockscoutProxyBase
 
 // System contracts to ignore (internal transfers, fees, etc)
 const SYSTEM_CONTRACTS = new Set([

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -92,8 +92,8 @@ interface NetworkConfig {
   getWalletTransactionsUrl: string
   getWalletBalancesUrl: string
   getExchangeRateUrl: string
-  blockscoutApiUrl: string
-  blockscoutApiKey: string
+  getXautPriceUrl: string
+  blockscoutProxyBase: string
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_MAINNET = 'https://eth-mainnet.g.alchemy.com/v2/'
@@ -266,10 +266,12 @@ const SET_REGISTRATION_PROPERTIES_AUTH_MAINNET = {
 
 const CROSS_CHAIN_EXPLORER_URL = 'https://axelarscan.io/gmp/'
 
-// Blockscout Pro API for transaction history
-const BLOCKSCOUT_API_URL_MAINNET = 'https://api.blockscout.com/42220/api/v2'
-const BLOCKSCOUT_API_KEY =
-  'proapi_bKq9uPjU8efoqgyU2cWqB5Bgq9eqHJjUJFU5d32TGL833jaLdJ53AyKNEGct6WcSw_cK2q52'
+// TuCop backend proxies (Railway). Used to remove third-party API keys from the mobile app:
+// - /api/prices/xaut       -> XAUt0 USD price (replaces CoinMarketCap)
+// - /api/v2/...            -> Blockscout passthrough (replaces direct Blockscout calls + key)
+const TUCOP_BACKEND_BASE = 'https://tucop-backend-production.up.railway.app'
+const GET_XAUT_PRICE_URL = `${TUCOP_BACKEND_BASE}/api/prices/xaut?vs=usd`
+const BLOCKSCOUT_PROXY_BASE = `${TUCOP_BACKEND_BASE}/api/v2`
 
 const networkConfig: NetworkConfig = {
   networkId: '42220',
@@ -382,8 +384,8 @@ const networkConfig: NetworkConfig = {
   getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_MAINNET,
   getWalletBalancesUrl: GET_WALLET_BALANCES_MAINNET,
   getExchangeRateUrl: GET_EXCHANGE_RATE_MAINNET,
-  blockscoutApiUrl: BLOCKSCOUT_API_URL_MAINNET,
-  blockscoutApiKey: BLOCKSCOUT_API_KEY,
+  getXautPriceUrl: GET_XAUT_PRICE_URL,
+  blockscoutProxyBase: BLOCKSCOUT_PROXY_BASE,
 }
 
 const CELOSCAN_BASE_URL_MAINNET = 'https://celoscan.io'


### PR DESCRIPTION
Plan 04 Tasks 5 + 6. Closes the loop on backend proxy migration.

### Hardcoded keys REMOVED (2)
- CoinMarketCap key at `src/gold/api.ts:10`
- Blockscout key at `src/web3/networkConfig.ts:271-272`

### New endpoints consumed
All point to `https://tucop-backend-production.up.railway.app`:
- `GET /api/prices/xaut?vs=usd` → `networkConfig.getXautPriceUrl` (CMC proxy, 60s Redis cache)
- `GET /api/v2/...` → `networkConfig.blockscoutProxyBase` (Blockscout proxy, 30-300s cache)

### Files modified (4)
- `src/web3/networkConfig.ts`: added `getXautPriceUrl` + `blockscoutProxyBase`. Removed orphaned `blockscoutApiUrl` field and the hardcoded `BLOCKSCOUT_API_KEY`
- `src/gold/api.ts`: `fetchFromCoinMarketCap` → `fetchFromTucopBackend` (no key headers). DIA fallback preserved
- `src/transactions/blockscoutApi.ts`: base URL now reads from `networkConfig.blockscoutProxyBase`
- NEW `src/gold/api.test.ts`: 5 tests (backend URL, no key headers, DIA fallback, hardcoded fallback, networkConfig shape)

### Verification
- yarn build:ts ✓
- yarn lint ✓
- 23 test suites pass, 201/201 tests pass
- `grep -rn 'coinmarketcap|cmc_pro_api_key|CMC_PRO|x-cmc|x-blockscout-api' src/` only returns the negative-assertion line in the new test

### Backend cache impact (confirmed live)
- Price endpoint: cold 500-8000ms → hot 350ms (2-20x speedup)
- Tx history: cold 5-8s → hot 590ms (~10x speedup)

App store bundle no longer contains either API key.