### PR TITLE
feat(recovery): add DeepLinkRecovery banner for unresolved in-flight flows

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3187,5 +3187,9 @@
     "multiStep": "Step {{currentStep}} of {{total}}",
     "succeeded": "Done. Your {{noun}} completed.",
     "connectivityLost": "We lost connection. Your {{noun}} is still in progress; waiting for connection to come back."
+  },
+  "recovery": {
+    "banner": "Your transfer was left in progress. Tap to see details.",
+    "staleBanner": "You have an operation that has been incomplete for over a day. Tap to review it."
   }
 }

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3280,5 +3280,9 @@
     "multiStep": "Paso {{currentStep}} de {{total}}",
     "succeeded": "Listo. Tu {{noun}} se completo.",
     "connectivityLost": "Perdimos la conexion. Tu {{noun}} sigue en curso; esperando que vuelvas a tener conexion."
+  },
+  "recovery": {
+    "banner": "Tu transferencia se quedo a medias, ver detalles.",
+    "staleBanner": "Tienes una operacion sin completar desde hace mas de un dia. Revisala."
   }
 }

--- a/src/app/DeepLinkRecovery.test.tsx
+++ b/src/app/DeepLinkRecovery.test.tsx
@@ -1,0 +1,107 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import DeepLinkRecovery from 'src/app/DeepLinkRecovery'
+import { NetworkId } from 'src/transactions/types'
+import { createMockStore } from 'test/utils'
+
+describe('DeepLinkRecovery', () => {
+  function stateWithFlow(startedAt: number) {
+    return {
+      transactionInFlight: {
+        byFlow: {
+          'flow-1': {
+            flowId: 'flow-1',
+            flowKind: 'dollarsSpend' as const,
+            steps: 3,
+            currentStep: 1,
+            status: 'progress' as const,
+            preparedTransactions: [],
+            networkId: NetworkId['celo-mainnet'],
+            retryCount: 0,
+            startedAt,
+          },
+        },
+      },
+    }
+  }
+
+  it('renders nothing when no in-flight', () => {
+    const { queryByTestId } = render(
+      <Provider store={createMockStore({ transactionInFlight: { byFlow: {} } })}>
+        <DeepLinkRecovery />
+      </Provider>
+    )
+    expect(queryByTestId('DeepLinkRecovery')).toBeNull()
+  })
+
+  it('renders standard banner for in-flight under 24h', () => {
+    const tenMinutesAgo = Date.now() - 10 * 60 * 1000
+    const { getByText, getByTestId } = render(
+      <Provider store={createMockStore(stateWithFlow(tenMinutesAgo))}>
+        <DeepLinkRecovery />
+      </Provider>
+    )
+    expect(getByTestId('DeepLinkRecovery')).toBeTruthy()
+    expect(getByText('recovery.banner')).toBeTruthy()
+  })
+
+  it('renders stale banner for in-flight older than 24h', () => {
+    const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000
+    const { getByText, getByTestId } = render(
+      <Provider store={createMockStore(stateWithFlow(twoDaysAgo))}>
+        <DeepLinkRecovery />
+      </Provider>
+    )
+    expect(getByTestId('DeepLinkRecovery')).toBeTruthy()
+    expect(getByText('recovery.staleBanner')).toBeTruthy()
+  })
+
+  it('does not render when in-flight is less than 60s old', () => {
+    const tenSecondsAgo = Date.now() - 10 * 1000
+    const { queryByTestId } = render(
+      <Provider store={createMockStore(stateWithFlow(tenSecondsAgo))}>
+        <DeepLinkRecovery />
+      </Provider>
+    )
+    expect(queryByTestId('DeepLinkRecovery')).toBeNull()
+  })
+
+  it('ignores succeeded and failed flows', () => {
+    const tenMinutesAgo = Date.now() - 10 * 60 * 1000
+    const state = {
+      transactionInFlight: {
+        byFlow: {
+          'done-flow': {
+            flowId: 'done-flow',
+            flowKind: 'send' as const,
+            steps: 1,
+            currentStep: 1,
+            status: 'succeeded' as const,
+            preparedTransactions: [],
+            networkId: NetworkId['celo-mainnet'],
+            retryCount: 0,
+            startedAt: tenMinutesAgo,
+          },
+          'failed-flow': {
+            flowId: 'failed-flow',
+            flowKind: 'send' as const,
+            steps: 1,
+            currentStep: 1,
+            status: 'failed' as const,
+            preparedTransactions: [],
+            networkId: NetworkId['celo-mainnet'],
+            retryCount: 0,
+            startedAt: tenMinutesAgo,
+          },
+        },
+      },
+    }
+    const { queryByTestId } = render(
+      <Provider store={createMockStore(state)}>
+        <DeepLinkRecovery />
+      </Provider>
+    )
+    expect(queryByTestId('DeepLinkRecovery')).toBeNull()
+  })
+})

--- a/src/app/DeepLinkRecovery.tsx
+++ b/src/app/DeepLinkRecovery.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AppState, AppStateStatus, StyleSheet, Text } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Touchable from 'src/components/Touchable'
+import { allInFlightSelector } from 'src/lib/useTransactionInFlight'
+import type { InFlightDescriptor } from 'src/lib/useTransactionInFlight'
+import { useSelector } from 'src/redux/hooks'
+import colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+
+const MIN_AGE_MS = 60 * 1000 // 1 minute
+const STALE_AGE_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+// Statuses considered unresolved (still recoverable) when surfacing the banner.
+const UNRESOLVED_STATUSES: ReadonlyArray<InFlightDescriptor['status']> = [
+  'idle',
+  'preparing',
+  'awaiting-pin',
+  'submitting',
+  'pending-confirmation',
+  'progress',
+  'partial-failure',
+]
+
+function DeepLinkRecovery() {
+  const { t } = useTranslation()
+  const all = useSelector(allInFlightSelector)
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const refresh = () => setNow(Date.now())
+    const sub = AppState.addEventListener('change', (status: AppStateStatus) => {
+      if (status === 'active') refresh()
+    })
+    return () => sub.remove()
+  }, [])
+
+  const candidates = Object.values(all).filter(
+    (flow) => UNRESOLVED_STATUSES.includes(flow.status) && now - flow.startedAt >= MIN_AGE_MS
+  )
+
+  if (candidates.length === 0) {
+    return null
+  }
+
+  // Surface the oldest unresolved flow first. If the user has multiple, the
+  // recovery screen (linked from this banner) will list all of them.
+  const oldest = candidates.reduce((a, b) => (a.startedAt < b.startedAt ? a : b))
+  const isStale = now - oldest.startedAt >= STALE_AGE_MS
+  const messageKey = isStale ? 'recovery.staleBanner' : 'recovery.banner'
+
+  const onPress = () => {
+    // Recovery screen wiring lands in a follow-up. The banner is intentionally
+    // non-blocking and a no-op for now so the surface ships behind the
+    // existing in-flight selectors without coupling to a placeholder route.
+  }
+
+  return (
+    <SafeAreaView
+      style={[styles.container, isStale ? styles.containerStale : styles.containerStandard]}
+      edges={['top']}
+      testID="DeepLinkRecovery"
+    >
+      <Touchable onPress={onPress} hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+        <Text style={styles.text} numberOfLines={2}>
+          {t(messageKey)}
+        </Text>
+      </Touchable>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 5,
+  },
+  containerStandard: {
+    backgroundColor: colors.warningDark,
+  },
+  containerStale: {
+    backgroundColor: colors.errorDark,
+  },
+  text: {
+    ...typeScale.labelXSmall,
+    color: colors.white,
+    textAlign: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+})
+
+export default DeepLinkRecovery

--- a/src/navigator/NavigatorWrapper.tsx
+++ b/src/navigator/NavigatorWrapper.tsx
@@ -9,6 +9,7 @@ import SplashScreen from 'react-native-splash-screen'
 import ShakeForSupport from 'src/account/ShakeForSupport'
 import AlertBanner from 'src/alert/AlertBanner'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import DeepLinkRecovery from 'src/app/DeepLinkRecovery'
 import UpgradeScreen from 'src/app/UpgradeScreen'
 import { activeScreenChanged } from 'src/app/actions'
 import { getAppLocked } from 'src/app/selectors'
@@ -259,6 +260,7 @@ export const NavigatorWrapper = () => {
           </View>
         )}
         <AlertBanner />
+        <DeepLinkRecovery />
         <ShakeForSupport />
         <JumpstartClaimStatusToasts />
       </View>


### PR DESCRIPTION
Plan 02 Track B Task 6 (also fulfills spec section 6.1.9 and Track A Task 8).

Mounted in NavigatorWrapper, scans `allInFlightSelector` on app foreground. Shows two banner copies based on age:
- < 24h: 'Tu transferencia se quedo a medias, ver detalles.' (warning color)
- > 24h: 'Tienes una operacion sin completar desde hace mas de un dia. Revisala.' (error color)

Min age 60s (avoid flashing during the normal flow).

### Files (5)
- NEW src/app/DeepLinkRecovery.tsx
- NEW src/app/DeepLinkRecovery.test.tsx (5 tests)
- MODIFIED src/navigator/NavigatorWrapper.tsx (mounted near root alongside AlertBanner)
- MODIFIED locales/base + es-419 (recovery.banner + recovery.staleBanner)

### Verification
- 5/5 DeepLinkRecovery tests pass
- 2/2 NavigatorWrapper tests still pass (mount safe)
- yarn build:ts + lint ✓

### Followup
onPress is currently a placeholder. Navigation to a recovery screen (which can offer 'Continuar donde quedo' / 'Ver detalles' actions) is a follow-up task — the data is fully available via useTransactionInFlight and sentTransactionLog.