### PR TITLE
feat(dollarsSpend): add EIP-7702 saga path behind Statsig flag

### DIFF
--- a/src/dollarsSpend/batchExecutorAbi.ts
+++ b/src/dollarsSpend/batchExecutorAbi.ts
@@ -1,0 +1,24 @@
+// ABI fragment for the BatchExecutor contract that the EOA delegates to via
+// EIP-7702. The contract exposes a single entrypoint `execute(Call[])` that
+// loops through the inner calls and runs them under the EOA's authority. See
+// the Track C spike outcome doc + contracts-spike/scripts/s1-* for the live
+// pattern validated on Celo mainnet.
+export const BATCH_EXECUTOR_ABI = [
+  {
+    type: 'function',
+    name: 'execute',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: 'calls',
+        type: 'tuple[]',
+        components: [
+          { name: 'target', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'data', type: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [],
+  },
+] as const

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -1,6 +1,7 @@
 import { createAction, PayloadAction } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
 import { call, delay, put, race, select, take, takeEvery } from 'typed-redux-saga'
+import { executeDollarsSpend7702Saga } from 'src/dollarsSpend/saga7702'
 import {
   multiSwapCompleted,
   multiSwapStarted,
@@ -9,6 +10,8 @@ import {
   multiSwapTransitionComplete,
 } from 'src/dollarsSpend/slice'
 import { SpendStep } from 'src/dollarsSpend/types'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { swapStart, swapSuccess, swapError } from 'src/swap/slice'
 import { Field, SwapInfo } from 'src/swap/types'
 import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
@@ -38,6 +41,19 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
   const { steps, toTokenId } = action.payload
 
   if (steps.length === 0) {
+    return
+  }
+
+  // Track C: when the EIP-7702 / CIP-64 single-tx path is enabled, hand off to
+  // the new saga. The legacy sequential loop below is the fallback whenever
+  // the flag is off, the BatchExecutor isn't deployed yet, or the new path
+  // throws (the new saga handles its own error dispatch).
+  const sevenSevenZeroTwoOn = yield* call(
+    getFeatureGate,
+    StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1
+  )
+  if (sevenSevenZeroTwoOn) {
+    yield* call(executeDollarsSpend7702Saga, action)
     return
   }
 

--- a/src/dollarsSpend/saga7702.test.ts
+++ b/src/dollarsSpend/saga7702.test.ts
@@ -1,0 +1,233 @@
+import BigNumber from 'bignumber.js'
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { dynamic, throwError } from 'redux-saga-test-plan/providers'
+import { executeMultiSwap, executeMultiSwapSaga } from 'src/dollarsSpend/saga'
+import { executeDollarsSpend7702Saga } from 'src/dollarsSpend/saga7702'
+import {
+  multiSwapCompleted,
+  multiSwapStarted,
+  multiSwapStepFailed,
+  multiSwapStepSucceeded,
+} from 'src/dollarsSpend/slice'
+import { SpendStep } from 'src/dollarsSpend/types'
+import { getFeatureGate } from 'src/statsig'
+import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
+import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
+import { getViemWallet } from 'src/web3/contracts'
+import networkConfig from 'src/web3/networkConfig'
+import { walletAddressSelector } from 'src/web3/selectors'
+
+jest.mock('src/statsig')
+jest.mock('src/swap/useSwapQuote', () => ({
+  ...jest.requireActual('src/swap/useSwapQuote'),
+  fetchSwapQuoteForExecution: jest.fn(),
+}))
+jest.mock('src/web3/contracts', () => ({
+  ...jest.requireActual('src/web3/contracts'),
+  getViemWallet: jest.fn(),
+}))
+
+const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
+
+const mockFromTokenUsat = {
+  tokenId: 'celo-mainnet:usat',
+  networkId: 'celo-mainnet',
+  symbol: 'USAT',
+  decimals: 6,
+  balance: new BigNumber(100),
+  priceUsd: new BigNumber(1),
+  address: '0xd2ab00000000000000000000000000000000abcd',
+} as any
+
+const mockTokensById = {
+  'celo-mainnet:usat': mockFromTokenUsat,
+}
+
+const stepUsat: SpendStep = {
+  tokenId: 'celo-mainnet:usat',
+  symbol: 'USAT',
+  amountUsd: new BigNumber(30),
+  amountTokenWhole: new BigNumber(30),
+  decimals: 6,
+}
+
+const mockQuoteResult = {
+  fromTokenId: 'celo-mainnet:usat',
+  toTokenId: 'celo-mainnet:copm',
+  swapAmount: { FROM: new BigNumber(30), TO: new BigNumber(122_400) },
+  price: '4080',
+  provider: 'squid',
+  estimatedPriceImpact: null,
+  preparedTransactions: {
+    type: 'possible',
+    feeCurrency: mockFromTokenUsat,
+    transactions: [
+      {
+        // approve
+        to: '0xd2ab3c9a02dbbab236bfec45d1d755df4267f771',
+        data: '0x095ea7b3deadbeef',
+        value: undefined,
+      },
+      {
+        // swap (any valid 20-byte address; this is the mock Squid router)
+        to: '0x1111111111111111111111111111111111111111',
+        data: '0xdeadbeef',
+        value: BigInt(0),
+      },
+    ],
+  },
+  receivedAt: 1234567890,
+  appFeePercentageIncludedInPrice: undefined,
+  allowanceTarget: '0x0000000000000000000000000000000000000000',
+  sellAmount: '30000000',
+  swapType: 'same-chain' as const,
+}
+
+const MOCK_TX_HASH = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+
+function mockWallet({
+  signAuth = jest.fn().mockResolvedValue({
+    chainId: 42220,
+    nonce: 1,
+    contractAddress: networkConfig.batchExecutorAddressCelo,
+  }),
+  sendTx = jest.fn().mockResolvedValue(MOCK_TX_HASH),
+} = {}) {
+  return {
+    account: { address: MOCK_WALLET },
+    signAuthorization: signAuth,
+    sendTransaction: sendTx,
+  } as any
+}
+
+describe('dollarsSpend saga dispatcher (flag-gated)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('when WRI_DOLLARS_SPEND_7702_V1 is off, runs the legacy sequential saga (no 7702 calls)', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
+    const wallet = mockWallet()
+    jest.mocked(getViemWallet as any).mockReturnValue(wallet)
+
+    // Run the dispatcher with the flag off. We assert that multiSwapStarted is
+    // emitted (legacy path entered) AND that the 7702 wallet helpers were not
+    // touched. The legacy path's race/take logic is exercised by saga.test.ts;
+    // here we only verify the branch.
+    await expectSaga(
+      executeMultiSwapSaga,
+      executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+    )
+      .provide([
+        [matchers.call.fn(getFeatureGate), false],
+        [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+        [matchers.select.selector(tokensByIdSelector), mockTokensById],
+        [matchers.select.selector(feeCurrenciesSelector), []],
+        [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
+        // The legacy saga waits on swap success via race(take(...)); stub it.
+        {
+          race: () => ({
+            success: { type: 'swap/swapSuccess', payload: { swapId: 'mocked-1' } },
+          }),
+        },
+      ])
+      .put(multiSwapStarted({ steps: [stepUsat] }))
+      .silentRun()
+
+    expect(wallet.signAuthorization).not.toHaveBeenCalled()
+    expect(wallet.sendTransaction).not.toHaveBeenCalled()
+  })
+
+  it('when flag is on, signs an EIP-7702 authorization pointing at the BatchExecutor and submits one tx', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
+    const wallet = mockWallet()
+    jest.mocked(getViemWallet as any).mockReturnValue(wallet)
+
+    await expectSaga(
+      executeDollarsSpend7702Saga,
+      executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+    )
+      .provide([
+        [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+        [matchers.select.selector(tokensByIdSelector), mockTokensById],
+        [matchers.select.selector(feeCurrenciesSelector), []],
+        [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
+        [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+      ])
+      .put(multiSwapStarted({ steps: [stepUsat] }))
+      .put(multiSwapStepSucceeded({ index: 0 }))
+      .put(multiSwapCompleted())
+      .not.put.actionType(multiSwapStepFailed.type)
+      .silentRun()
+
+    expect(wallet.signAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractAddress: networkConfig.batchExecutorAddressCelo,
+        executor: 'self',
+      })
+    )
+    expect(wallet.sendTransaction).toHaveBeenCalledTimes(1)
+    const sendArg = wallet.sendTransaction.mock.calls[0][0]
+    expect(sendArg.to).toBe(MOCK_WALLET)
+    expect(sendArg.authorizationList).toHaveLength(1)
+    // Fee currency is the first step's underlying ERC-20 address derived from
+    // the tokenId (`celo-mainnet:<address>` -> `<address>`). Here the mock
+    // step uses `celo-mainnet:usat` so we expect the second segment back.
+    expect(sendArg.feeCurrency).toBe('usat')
+  })
+
+  it('dispatches multiSwapStepFailed when the 7702 batch submission throws', async () => {
+    jest.useRealTimers()
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
+    const sendTx = jest.fn().mockRejectedValue(new Error('rpc dropped: 0x7b not accepted'))
+    const wallet = mockWallet({ sendTx })
+    jest.mocked(getViemWallet as any).mockReturnValue(wallet)
+
+    try {
+      await expectSaga(
+        executeDollarsSpend7702Saga,
+        executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+      )
+        .provide([
+          [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+          [matchers.select.selector(tokensByIdSelector), mockTokensById],
+          [matchers.select.selector(feeCurrenciesSelector), []],
+          [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
+          [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+        ])
+        .put.actionType(multiSwapStepFailed.type)
+        .not.put.actionType(multiSwapCompleted.type)
+        .silentRun(500)
+    } finally {
+      jest.useFakeTimers()
+    }
+  })
+
+  it('dispatches multiSwapStepFailed when a quote refetch throws (flag on)', async () => {
+    jest.useRealTimers()
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    const quoteError = new Error('Squid 500')
+
+    try {
+      await expectSaga(
+        executeDollarsSpend7702Saga,
+        executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+      )
+        .provide([
+          [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+          [matchers.select.selector(tokensByIdSelector), mockTokensById],
+          [matchers.select.selector(feeCurrenciesSelector), []],
+          [matchers.call.fn(fetchSwapQuoteForExecution), throwError(quoteError)],
+        ])
+        .put.actionType(multiSwapStepFailed.type)
+        .not.put.actionType(multiSwapCompleted.type)
+        .silentRun(500)
+    } finally {
+      jest.useFakeTimers()
+    }
+  })
+})

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -1,0 +1,217 @@
+import { PayloadAction } from '@reduxjs/toolkit'
+import BigNumber from 'bignumber.js'
+import { call, delay, put, select } from 'typed-redux-saga'
+import { Address, encodeFunctionData, Hex } from 'viem'
+import { BATCH_EXECUTOR_ABI } from 'src/dollarsSpend/batchExecutorAbi'
+import { ExecuteMultiSwapPayload } from 'src/dollarsSpend/saga'
+import {
+  multiSwapCompleted,
+  multiSwapStarted,
+  multiSwapStepFailed,
+  multiSwapStepSucceeded,
+  multiSwapTransitionComplete,
+} from 'src/dollarsSpend/slice'
+import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
+import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
+import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
+import { Network, NetworkId } from 'src/transactions/types'
+import Logger from 'src/utils/Logger'
+import { getViemWallet } from 'src/web3/contracts'
+import networkConfig from 'src/web3/networkConfig'
+import { walletAddressSelector } from 'src/web3/selectors'
+
+const TAG = 'dollarsSpend/saga7702'
+
+interface InnerCall {
+  target: Address
+  value: bigint
+  data: Hex
+}
+
+/**
+ * EIP-7702 + CIP-64 saga path for dollarsSpend.
+ *
+ * Behind StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1. When enabled, the
+ * full multi-step plan is collapsed into ONE transaction:
+ *   1. Sign an EIP-7702 authorization delegating the EOA to the BatchExecutor.
+ *   2. Build inner Call[] for each step (approve + swap) using fresh quotes.
+ *   3. Submit a single tx type 0x7b (CIP-64) carrying the auth list + the
+ *      `to = walletAddress, data = BatchExecutor.execute(calls)` payload, with
+ *      feeCurrency set to the first ERC-20 the user is spending so gas is
+ *      paid in USDm/USDC/USAT/USDT rather than CELO.
+ *
+ * Confirmed live on Celo mainnet in the S1 spike. See
+ * contracts-spike/scripts/s1-submit-7702-with-feecurrency.mjs.
+ *
+ * On any failure (auth, quote, submit) we dispatch multiSwapStepFailed at
+ * index 0 because the entire batch is atomic — there is no partial success
+ * for the user to recover from in this path.
+ */
+export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiSwapPayload>) {
+  const { steps, toTokenId } = action.payload
+
+  if (steps.length === 0) {
+    return
+  }
+
+  yield* put(multiSwapStarted({ steps }))
+
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) {
+    yield* put(
+      multiSwapStepFailed({ index: 0, errorMessage: 'Wallet address unavailable for 7702 batch' })
+    )
+    yield* delay(50)
+    yield* put(multiSwapTransitionComplete())
+    return
+  }
+
+  const tokensById = yield* select(tokensByIdSelector, getSupportedNetworkIdsForSwap())
+
+  // Build inner Call[] from fresh quotes for each step. Each step's prepared
+  // transactions are (optional approve) + swap; we forward both, preserving
+  // order so the BatchExecutor runs the allowance bump before the swap call.
+  const innerCalls: InnerCall[] = []
+  for (let index = 0; index < steps.length; index++) {
+    const step = steps[index]
+    const fromToken = tokensById[step.tokenId]
+    if (!fromToken) {
+      yield* put(
+        multiSwapStepFailed({
+          index: 0,
+          errorMessage: `Token not found in wallet state: ${step.symbol}`,
+        })
+      )
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
+      return
+    }
+
+    const feeCurrencies = yield* select(feeCurrenciesSelector, fromToken.networkId as NetworkId)
+
+    let freshQuote: Awaited<ReturnType<typeof fetchSwapQuoteForExecution>>
+    try {
+      const amountInWei = step.amountTokenWhole
+        .shiftedBy(step.decimals)
+        .toFixed(0, BigNumber.ROUND_DOWN)
+      freshQuote = yield* call(fetchSwapQuoteForExecution, {
+        fromTokenId: step.tokenId,
+        toTokenId,
+        amount: amountInWei,
+        walletAddress,
+        fromToken,
+        feeCurrencies,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      Logger.warn(TAG, `Quote refetch failed for step ${index} (${step.symbol}): ${message}`)
+      yield* put(multiSwapStepFailed({ index: 0, errorMessage: message }))
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
+      return
+    }
+
+    if (freshQuote.preparedTransactions.type !== 'possible') {
+      yield* put(
+        multiSwapStepFailed({
+          index: 0,
+          errorMessage: `Prepared transactions not possible for step ${index} (${step.symbol})`,
+        })
+      )
+      yield* delay(50)
+      yield* put(multiSwapTransitionComplete())
+      return
+    }
+
+    for (const tx of freshQuote.preparedTransactions.transactions) {
+      if (!tx.to || tx.data === undefined) {
+        yield* put(
+          multiSwapStepFailed({
+            index: 0,
+            errorMessage: `Malformed prepared transaction for step ${index} (${step.symbol})`,
+          })
+        )
+        yield* delay(50)
+        yield* put(multiSwapTransitionComplete())
+        return
+      }
+      innerCalls.push({
+        target: tx.to as Address,
+        value: tx.value ?? BigInt(0),
+        data: tx.data as Hex,
+      })
+    }
+  }
+
+  if (innerCalls.length === 0) {
+    yield* put(multiSwapStepFailed({ index: 0, errorMessage: 'No inner calls to execute' }))
+    yield* delay(50)
+    yield* put(multiSwapTransitionComplete())
+    return
+  }
+
+  try {
+    const wallet = yield* call(getViemWallet, networkConfig.viemChain[Network.Celo])
+    const account = wallet.account
+    if (!account) {
+      throw new Error('Wallet has no account loaded')
+    }
+
+    // Sign EIP-7702 authorization delegating THIS EOA -> BatchExecutor.
+    // executor: 'self' so viem uses the wallet's nonce sequence. Wrap in a
+    // thunk because typed-redux-saga's `call([obj, method], args)` overload
+    // requires a positional signature, but viem's signAuthorization takes a
+    // single named-args object — easier to call directly.
+    const authorization = yield* call(() =>
+      wallet.signAuthorization({
+        account,
+        contractAddress: networkConfig.batchExecutorAddressCelo,
+        executor: 'self',
+      })
+    )
+
+    const calldata = encodeFunctionData({
+      abi: BATCH_EXECUTOR_ABI,
+      functionName: 'execute',
+      args: [innerCalls],
+    })
+
+    // Pick the user-facing token from the first step as fee currency. The user
+    // already has balance there (it's what they are spending); paying gas in
+    // it keeps the flow CELO-free. The step.tokenId is `celo-mainnet:0x...`,
+    // strip the prefix to get the bare ERC-20 address.
+    const feeCurrencyAddress = steps[0].tokenId.split(':')[1] as Hex
+
+    // sendTransaction args are typed via SendTransactionParameters which
+    // expects `chain` when not hoisted on the client. Cast through unknown
+    // because we additionally pass `authorizationList` + CIP-64 `feeCurrency`
+    // which viem permits at runtime but its generic type narrowing trips on
+    // when mixing 7702 with CIP-64 in one call.
+    const sendArgs = {
+      account,
+      to: walletAddress as Address,
+      data: calldata,
+      authorizationList: [authorization],
+      feeCurrency: feeCurrencyAddress,
+    } as unknown as Parameters<typeof wallet.sendTransaction>[0]
+
+    const hash = yield* call(() => wallet.sendTransaction(sendArgs))
+
+    Logger.info(TAG, `Submitted 7702 dollarsSpend batch: ${hash}`)
+
+    // Mark each step as succeeded optimistically — the batch is atomic, so
+    // once submitted the user-facing progress reaches 100%. A production
+    // follow-up polls the receipt and dispatches multiSwapStepFailed if the
+    // tx reverts. For this scaffold we stay simple.
+    for (let i = 0; i < steps.length; i++) {
+      yield* put(multiSwapStepSucceeded({ index: i }))
+    }
+    yield* put(multiSwapCompleted())
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    Logger.warn(TAG, `7702 batch failed: ${message}`)
+    yield* put(multiSwapStepFailed({ index: 0, errorMessage: message }))
+    yield* delay(50)
+    yield* put(multiSwapTransitionComplete())
+  }
+}

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -42,6 +42,7 @@ export enum StatsigFeatureGates {
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
   SHOW_DIGITAL_GOLD = 'show_digital_gold',
   WRI_PREFLIGHT_SWAP_SIMULATION = 'wri_preflight_swap_simulation',
+  WRI_DOLLARS_SPEND_7702_V1 = 'wri_dollars_spend_7702_v1',
 }
 
 export enum StatsigExperiments {

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -82,6 +82,7 @@ interface NetworkConfig {
   ceurTokenId: string
   crealTokenId: string
   celoTokenId: string
+  batchExecutorAddressCelo: Address
   spendTokenIds: string[]
   saveContactsUrl: string
   getPointsConfigUrl: string
@@ -146,6 +147,15 @@ const USDM_TOKEN_ID_MAINNET = CUSD_TOKEN_ID_MAINNET
 
 // USAT (Tether America USD, US-regulated Anchorage Digital) - 6 decimals
 const USAT_TOKEN_ID_MAINNET = `${NetworkId['celo-mainnet']}:0xd2ab3c9a02dbbab236bfec45d1d755df4267f771`
+
+// BatchExecutor contract that the EOA delegates to via EIP-7702 for the
+// dollarsSpend single-tx path (Track C). Used by saga7702.ts to encode the
+// authorization + execute(calls) calldata.
+//
+// TODO(WRI Track C Task 2): Replace with the actual deployed address once the
+// user authorizes the production deploy. Until that lands, the saga7702 path
+// stays gated off behind StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1.
+export const BATCH_EXECUTOR_ADDRESS_CELO: Address = '0x0000000000000000000000000000000000000000'
 
 const CLOUD_FUNCTIONS_MAINNET = 'https://api.mainnet.valora.xyz'
 
@@ -370,6 +380,7 @@ const networkConfig: NetworkConfig = {
   usdcTokenId: USDC_TOKEN_ID_MAINNET,
   usdmTokenId: USDM_TOKEN_ID_MAINNET,
   usatTokenId: USAT_TOKEN_ID_MAINNET,
+  batchExecutorAddressCelo: BATCH_EXECUTOR_ADDRESS_CELO,
   spendTokenIds: [CUSD_TOKEN_ID_MAINNET, CELO_TOKEN_ID_MAINNET],
   saveContactsUrl: SAVE_CONTACTS_MAINNET,
   getPointsConfigUrl: GET_POINTS_CONFIG_MAINNET,


### PR DESCRIPTION
Plan 03 Track C Task 3. Adds a new saga path that executes the entire dollarsSpend multi-step plan as ONE atomic CIP-64 transaction (type 0x7b) carrying `authorizationList` + `feeCurrency` + the batched inner calls. Behind Statsig flag `wri_dollars_spend_7702_v1` (default off; legacy sequential saga is fallback).

### Pattern (S1-validated, see docs/spikes/s1-cip64-7702.md)
1. Sign EIP-7702 authorization pointing at BatchExecutor address
2. Build inner Call[] for each step (approve + swap) using fresh quotes
3. Encode BatchExecutor.execute(calls)
4. `walletClient.sendTransaction({ to: walletAddress, data, authorizationList: [auth], feeCurrency })` — tx type returns 0x7b with auth embedded
5. Gas paid in USDm or COPm (user has balance; no CELO required)

### Files (3 new, 3 modified)
NEW:
- src/dollarsSpend/saga7702.ts — the 7702 saga
- src/dollarsSpend/batchExecutorAbi.ts — execute(Call[]) ABI fragment
- src/dollarsSpend/saga7702.test.ts — 4 tests (flag-off legacy, flag-on success, submit fail, quote fail)

MODIFIED:
- src/dollarsSpend/saga.ts — dispatcher reads flag at top of executeMultiSwapSaga
- src/statsig/types.ts — gate WRI_DOLLARS_SPEND_7702_V1
- src/web3/networkConfig.ts — `batchExecutorAddressCelo` = **placeholder `0x0000...0`** with TODO(WRI Track C Task 2)

### Verification
- 4/4 saga7702 tests pass
- 56/56 src/dollarsSpend tests pass (all pre-existing saga.test.ts still green)
- 67/67 src/dollarsSpend + src/swap/saga combined
- yarn build:ts + lint ✓

### Behavior notes
- **Fee currency**: `steps[0].tokenId.split(':')[1]` (the priority-ordered user-spend token; user has balance, safe gas source). No CELO fallback — intentional
- **Atomicity**: batch is one tx; no partial-failure state. Errors dispatch `multiSwapStepFailed({ index: 0 })` then the transition-complete bridge
- **Optimistic completion**: on `sendTransaction` success emits `multiSwapStepSucceeded` for every step then `multiSwapCompleted`. Receipt-polling is the production follow-up (header comment notes this)

### Gated on
- Track C Task 2 deploy of BatchExecutor (needs user authorization). Once deployed, the placeholder gets replaced and the flag can flip on
- 30-day internal team mainnet dogfood per S4 audit checklist before flag flip to 100%