### PR TITLE
feat(send): migrate to useTransactionInFlight alongside legacy actions

### DIFF
--- a/src/send/saga.ts
+++ b/src/send/saga.ts
@@ -2,6 +2,13 @@ import { showErrorOrFallback } from 'src/alert/actions'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { CeloExchangeEvents, SendEvents } from 'src/analytics/Events'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { classifyError } from 'src/lib/errors'
+import {
+  inFlightAbort,
+  inFlightAdvance,
+  inFlightFail,
+  inFlightStart,
+} from 'src/lib/useTransactionInFlight/actions'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { handleQRCodeDefault, handleQRCodeSecureSend, shareSVGImage } from 'src/qrcode/utils'
@@ -47,6 +54,7 @@ export function* sendPaymentSaga({
   fromModal,
   preparedTransaction: serializablePreparedTransaction,
 }: SendPaymentAction) {
+  const flowId = `send-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
   try {
     const context = newTransactionContext(TAG, 'Send payment')
     const recipientAddress = recipient.address
@@ -60,6 +68,20 @@ export function* sendPaymentSaga({
     if (!tokenInfo) {
       throw new Error(`Could not find token info for token id: ${tokenId}`)
     }
+
+    yield* put(
+      inFlightStart({
+        flowId,
+        flowKind: 'send',
+        steps: 1,
+        currentStep: 0,
+        status: 'preparing',
+        preparedTransactions: [serializablePreparedTransaction],
+        networkId: tokenInfo.networkId,
+        retryCount: 0,
+        startedAt: Date.now(),
+      })
+    )
 
     const createStandbyTransaction = (
       transactionHash: string,
@@ -89,12 +111,16 @@ export function* sendPaymentSaga({
       amount
     )
 
+    yield* put(inFlightAdvance({ flowId, toStatus: 'submitting' }))
+
     const [hash] = yield* call(
       sendPreparedTransactions,
       [serializablePreparedTransaction],
       tokenInfo.networkId,
       [createStandbyTransaction]
     )
+
+    yield* put(inFlightAdvance({ flowId, toStatus: 'pending-confirmation' }))
 
     const receipt = yield* call(
       [publicClient[networkIdToNetwork[tokenInfo.networkId]], 'waitForTransactionReceipt'],
@@ -123,6 +149,7 @@ export function* sendPaymentSaga({
     }
 
     yield* put(sendPaymentSuccess({ amount, tokenId }))
+    yield* put(inFlightAdvance({ flowId, toStatus: 'succeeded' }))
 
     // Show success vibration and navigate to success screen
     vibrateSuccess()
@@ -145,10 +172,12 @@ export function* sendPaymentSaga({
     const error = ensureError(err)
     if (error.message === ErrorMessages.PIN_INPUT_CANCELED) {
       Logger.info(`${TAG}/sendPaymentSaga`, 'Send cancelled by user')
+      yield* put(inFlightAbort({ flowId }))
       return
     }
     Logger.error(`${TAG}/sendPaymentSaga`, 'Send payment failed', error)
     AppAnalytics.track(SendEvents.send_tx_error, { error: error.message })
+    yield* put(inFlightFail({ flowId, errorClass: classifyError(error) }))
   }
 }
 


### PR DESCRIPTION
First feature migration to the new keystone abstraction. Send saga now dispatches the new `inFlightStart` / `inFlightAdvance` / `inFlightFail` / `inFlightAbort` action creators ALONGSIDE the existing `sendPaymentSuccess` / `sendPaymentFailure`. Legacy dispatches preserved so existing code/tests are unchanged.

### Flow
- saga start: `inFlightStart({ flowKind: 'send', steps: 1, status: 'preparing', ... })`
- before sendPreparedTransactions: `inFlightAdvance(flowId, 'submitting')`
- after submit, before receipt: `inFlightAdvance(flowId, 'pending-confirmation')`
- on success: `inFlightAdvance(flowId, 'succeeded')`
- on PIN cancel: `inFlightAbort(flowId)`
- on other error: `inFlightFail(flowId, classifyError(error))`

### Verification
- yarn build:ts ✓
- yarn lint ✓
- 5/5 send saga tests pass (existing tests unchanged)

### Pattern for follow-up migrations
This is the template. Swap, earn, buckspay, gold, jumpstart, subsidies follow the same shape: layer in-flight dispatches alongside the legacy ones without breaking existing call sites. Cleanup of legacy slices is a later phase.