### PR TITLE
fix(7702): revert BatchExecutor address — prior deploy was the spike contract

### DIFF
--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -152,12 +152,15 @@ const USAT_TOKEN_ID_MAINNET = `${NetworkId['celo-mainnet']}:0xd2ab3c9a02dbbab236
 // dollarsSpend single-tx path (Track C). Used by saga7702.ts to encode the
 // authorization + execute(calls) calldata.
 //
-// Deployed on Celo mainnet (chainId 42220) via DeployBatchExecutor.s.sol:
-//   tx: 0x7744ce5119aa90310acea1eff58c64187203a96976c432eb980cf93451df1e61
-//   block: 69680022 (0x4275196)
-// The saga7702 path stays gated behind StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1
-// until Phase 1 internal dogfood + Phase 2 production rollout.
-export const BATCH_EXECUTOR_ADDRESS_CELO: Address = '0x97b99a4ac0BDA988B4c9C6BA1398deB22a577be4'
+// TODO(WRI Track C Task 2): Replace with the address from the hardened
+// production contract (contracts/src/BatchExecutor.sol) once the user
+// authorizes the production deploy. A prior deploy via the spike script
+// (tx 0x7744ce5119aa90310acea1eff58c64187203a96976c432eb980cf93451df1e61
+// at 0x97b99a4ac0BDA988B4c9C6BA1398deB22a577be4) used the SPIKE source which
+// lacks the onlySelf modifier + ReentrancyGuard, so it must NOT be wired
+// here. The saga7702 path stays gated behind WRI_DOLLARS_SPEND_7702_V1 so
+// no user funds touch the zero-address while we wait.
+export const BATCH_EXECUTOR_ADDRESS_CELO: Address = '0x0000000000000000000000000000000000000000'
 
 const CLOUD_FUNCTIONS_MAINNET = 'https://api.mainnet.valora.xyz'
 


### PR DESCRIPTION
## TL;DR
Prior PR #193 wired `0x97b99a4ac0BDA988B4c9C6BA1398deB22a577be4` as the production BatchExecutor on Celo mainnet. Bytecode comparison after the merge shows that address is the **SPIKE** contract, not the hardened production contract.

This PR reverts `BATCH_EXECUTOR_ADDRESS_CELO` to the zero-address placeholder until we deploy the real hardened contract.

## What I found

| | Bytecode size |
|---|---|
| Deployed at `0x97b99a4ac0BDA988B4c9C6BA1398deB22a577be4` | **1535 chars** |
| `contracts-spike/src/BatchExecutor.sol` (SPIKE, "NOT for mainnet") | **1535 chars** |
| `contracts/src/BatchExecutor.sol` (hardened production) | **1783 chars** |

The deploy script `contracts-spike/script/DeployBatchExecutor.s.sol` imports `../src/BatchExecutor.sol`, which is the spike source. No broadcast log exists for `contracts/`.

## What the spike contract is missing
- `onlySelf` modifier (`msg.sender == address(this)`) — without it, anyone can call `execute()` on a delegated EOA and run arbitrary calls in its context.
- `ReentrancyGuard` from OpenZeppelin.
- `EmptyBatch` revert.

Source comment on the spike literally says: *"SPIKE-ONLY. NOT for mainnet deployment with user funds."*

## Risk
**Zero today.** The saga7702 path is gated off behind `StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1` (defaults to false), so no users delegate to anything. But flipping Phase 1 dogfood with the spike wired would have exposed internal IDs.

## Next steps
1. Land this revert.
2. Add `contracts/script/DeployBatchExecutor.s.sol` that targets the hardened source. (Follow-up PR.)
3. User runs `forge script` with the production deploy key.
4. Wire the new address. (Another follow-up PR.)
5. Then Phase 1 dogfood.

## Test plan
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn test src/web3 src/dollarsSpend/saga7702` (45/45 pass)
- [ ] CI checks