### PR TITLE
feat(7702): add production BatchExecutor deploy script (hardened source)

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -10,6 +10,9 @@ evm_version = "prague"
 [rpc_endpoints]
 celo = "https://forno.celo.org"
 
+[etherscan]
+celo = { key = "${CELOSCAN_API_KEY}", url = "https://api.celoscan.io/api", chain = 42220 }
+
 [invariant]
 runs = 50000
 depth = 100

--- a/contracts/script/DeployBatchExecutor.s.sol
+++ b/contracts/script/DeployBatchExecutor.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {BatchExecutor} from "../src/BatchExecutor.sol";
+
+/// @notice Deploys the hardened production BatchExecutor used by the
+///         dollarsSpend single-tx path (Track C, WRI). Reads the deploy key
+///         from the env var BATCH_EXECUTOR_DEPLOYER_PK to keep it distinct
+///         from any spike key, then prints the deployed address. The address
+///         must be written to src/web3/networkConfig.ts -> BATCH_EXECUTOR_ADDRESS_CELO
+///         in a follow-up wallet PR.
+///
+/// Usage (Celo mainnet):
+///   cd contracts
+///   export BATCH_EXECUTOR_DEPLOYER_PK=0x...
+///   forge script script/DeployBatchExecutor.s.sol \
+///     --rpc-url celo \
+///     --broadcast \
+///     --verify --etherscan-api-key "$CELOSCAN_API_KEY"
+///
+/// The contract is `BatchExecutor` from contracts/src/BatchExecutor.sol — the
+/// hardened version with the `onlySelf` modifier and ReentrancyGuard. Any
+/// future deploy must come from THIS script, not from contracts-spike/.
+contract DeployBatchExecutor is Script {
+    function run() external returns (address deployed) {
+        uint256 pk = vm.envUint("BATCH_EXECUTOR_DEPLOYER_PK");
+        address deployer = vm.addr(pk);
+        console2.log("Deployer:", deployer);
+        console2.log("Deployer balance (wei):", deployer.balance);
+
+        vm.startBroadcast(pk);
+        BatchExecutor exec = new BatchExecutor();
+        vm.stopBroadcast();
+
+        deployed = address(exec);
+        console2.log("BatchExecutor deployed at:", deployed);
+        console2.log("Chain id:", block.chainid);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds [contracts/script/DeployBatchExecutor.s.sol](contracts/script/DeployBatchExecutor.s.sol) that imports the **hardened** [contracts/src/BatchExecutor.sol](contracts/src/BatchExecutor.sol) — the version with `onlySelf` modifier + ReentrancyGuard.
- Adds an `[etherscan]` block in [contracts/foundry.toml](contracts/foundry.toml) so the deploy can optionally `--verify` with the Celoscan API key.
- Companion to PR #194 (revert of spike address).

## Why
The previous deploy (PR #193, since reverted) used the **spike** script in `contracts-spike/`, whose `BatchExecutor` source explicitly says *"SPIKE-ONLY. NOT for mainnet deployment with user funds."* and lacks the `onlySelf` modifier — meaning anyone could call `execute()` on a delegated EOA.

This script targets the hardened source instead, so the next deploy lands the right contract.

## Dry-run verification
```
Deployer: 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
BatchExecutor deployed at: 0x63f58053c9499E1104a6f6c6d2581d6D83067EEB
Chain id: 42220
Estimated gas: 348,260 (~0.14 CELO at 400 gwei)
SIMULATION COMPLETE.
```

## How to deploy (user action)
```bash
cd contracts
export BATCH_EXECUTOR_DEPLOYER_PK=0x...      # production deploy key
export CELOSCAN_API_KEY=...                  # only needed for --verify
forge script script/DeployBatchExecutor.s.sol \
  --rpc-url celo \
  --broadcast \
  --verify --etherscan-api-key "$CELOSCAN_API_KEY"
```
The printed address goes into [src/web3/networkConfig.ts](src/web3/networkConfig.ts) -> `BATCH_EXECUTOR_ADDRESS_CELO` in a follow-up wallet PR.

## Test plan
- [x] `forge build` clean
- [x] `forge script ... --rpc-url celo` dry-run succeeds and simulates against forno.celo.org
- [ ] CI: Lint / Dependencies / Licenses / Semantic PR title (CI doesn't compile Solidity here — that lives separately)