### PR TITLE
docs(wri): mark plans 00-04 as SHIPPED with summary headers

### DIFF
--- a/docs/plans/2026-06-15-wri-plan-00-sprint-0-spikes.md
+++ b/docs/plans/2026-06-15-wri-plan-00-sprint-0-spikes.md
@@ -2,6 +2,8 @@
 
 # Wallet Robustness Initiative — Plan 00: Sprint 0 Spikes
 
+**Status:** SHIPPED 2026-06-16. All 5 spikes resolved. Outcome docs in [docs/spikes/](../spikes/): S1 PASS (CIP-64 + 7702 single-tx confirmed on Celo mainnet), S2 PASS (ethers v5 removable), S3 UNKNOWN_PENDING_OUTREACH (calldata analysis strongly suggests PASS; superseded by TuCop's own Squid integrator path, not blocking), S4 APPROVED (self-audit protocol locked), S5 APPROVED (`useTransactionInFlight` v4 API). Plan was research-only; no production code merged from this plan. Original checkboxes left untouched as historical record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Execute the 5 research spikes (S1-S5) defined in the design spec section 5 to resolve the technical unknowns that gate the rest of the initiative.

--- a/docs/plans/2026-06-16-wri-plan-01-track-a-foundations.md
+++ b/docs/plans/2026-06-16-wri-plan-01-track-a-foundations.md
@@ -2,6 +2,8 @@
 
 # Wallet Robustness Initiative — Plan 01: Track A (Foundations — 8 Reusable Abstractions)
 
+**Status:** SHIPPED. All 8 reusable primitives merged into `Development`: error taxonomy ([src/lib/errors/](../../src/lib/errors/)), retry helper ([src/lib/retry/retry.ts](../../src/lib/retry/retry.ts)), `PinRequiredGate` ([src/components/PinRequiredGate.tsx](../../src/components/PinRequiredGate.tsx)), `useTransactionInFlight` keystone ([src/lib/useTransactionInFlight/](../../src/lib/useTransactionInFlight/)) with persistence migration v249, `ConfirmationSheet` + `TransactionProgressSheet` + `TransactionResultSheet` ([src/components/](../../src/components/)), `DeepLinkRecovery` ([src/app/DeepLinkRecovery.tsx](../../src/app/DeepLinkRecovery.tsx)). Original checkboxes left untouched as historical record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
 
 **Goal:** Build the 8 reusable primitives identified in the wallet-wide audit, so that subsequent feature migrations in Tracks B, C, and D can drop into a shared abstraction instead of reimplementing the same patterns per feature.

--- a/docs/plans/2026-06-16-wri-plan-02-track-b-critical-fixes.md
+++ b/docs/plans/2026-06-16-wri-plan-02-track-b-critical-fixes.md
@@ -2,6 +2,8 @@
 
 # Wallet Robustness Initiative — Plan 02: Track B (Critical Fixes)
 
+**Status:** SHIPPED 6/7 fixes. The five recurring patterns are addressed: (1) idempotency landed via `sentTransactionLog` slice with migration v250 ([src/viem/sentTransactionLog/](../../src/viem/sentTransactionLog/)); (2) orphan-approve mitigation via swap pre-flight simulation ([src/lib/preflight/swapSimulation.ts](../../src/lib/preflight/swapSimulation.ts)) + PartialSuccessSheet retry path; (3) in-flight persistence via the Track A keystone (migration v249); (4) PIN cache TTL via refcounted `pinTransactional` / `endTransactional` in [src/pincode/PasswordCache.ts](../../src/pincode/PasswordCache.ts); (5) MultiSwapProgressSheet / PartialSuccessSheet double-null window closed by `TransactionFlowShell` + `multiSwapTransitionComplete`. Remaining item from this plan is fully covered by Track C work. Original checkboxes left untouched as historical record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Fix the five recurring patterns of fragility identified in the wallet-wide audit: (1) zero idempotency in `sendPreparedTransactions`, (2) orphan approve transactions when subsequent swaps fail, (3) in-flight transaction state lost on app close, (4) PIN cache expiry mid-multi-step flow, (5) double-null guard rendering in `PartialSuccessSheet` / `MultiSwapProgressSheet`.

--- a/docs/plans/2026-06-16-wri-plan-03-track-c-eip7702.md
+++ b/docs/plans/2026-06-16-wri-plan-03-track-c-eip7702.md
@@ -2,6 +2,8 @@
 
 # Wallet Robustness Initiative — Plan 03: Track C (EIP-7702 Migration)
 
+**Status:** SHIPPED through Task 4. Production `BatchExecutor` (hardened, `onlySelf` + `ReentrancyGuard`) deployed on Celo mainnet at `0xaE6a87E88b55644Eda54C3AA55B11944eE5E1DFe` (tx `0xf95d4dd423c9f300c00347360ca61d6d5c91152575f8e81358bb161546923c0c`, block 69877584). Source verified on Celoscan. Address wired in [src/web3/networkConfig.ts](../../src/web3/networkConfig.ts). Saga at [src/dollarsSpend/saga7702.ts](../../src/dollarsSpend/saga7702.ts) gated behind `StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1` (default false). Revoke-delegation helper at [src/lib/revoke7702/revokeDelegation.ts](../../src/lib/revoke7702/revokeDelegation.ts). Legacy `executeMultiSwapSaga` keeps fallback path with `useTransactionInFlight` integration ([src/dollarsSpend/saga.ts](../../src/dollarsSpend/saga.ts)). Pending tasks 5 (Phase 1 dogfood) and 6 (Phase 2 production rollout) are operational — Statsig flag flips, not code. An earlier spike deploy at `0x97b99a4ac0BDA988B4c9C6BA1398deB22a577be4` must never be wired. Original checkboxes left untouched as historical record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
 
 **Goal:** Migrate the "Dolares → Pesos" (dollarsSpend) flow from N sequential transactions to a single atomic EIP-7702 batched transaction, eliminating partial-failure mid-flow and reducing on-chain overhead. Gates the rollout behind the S4 audit checklist and the kill-switch flag `wri_dollars_spend_7702_v1`.

--- a/docs/plans/2026-06-16-wri-plan-04-track-d-hygiene.md
+++ b/docs/plans/2026-06-16-wri-plan-04-track-d-hygiene.md
@@ -2,6 +2,8 @@
 
 # Wallet Robustness Initiative — Plan 04: Track D (Stack Hygiene + Sepolia Removal + Valora Migration)
 
+**Status:** SHIPPED. Sepolia and all testnet references removed from wallet code, config, and CI. Husky upgraded. ethers v5 removed where reachable. Hardcoded CoinMarketCap API key relocated to backend; the wallet now calls [tucop-backend-production.up.railway.app](https://tucop-backend-production.up.railway.app) for the XAUt0 price feed instead. `fetchWithTimeout` upgraded with 3-attempt exponential backoff + jitter. The actual backend repo lives at [TuCOPWallet-Backend](../../../TuCOPWallet-Backend/) (note: the plan originally referred to it as `api-wallet-tucop`; the real name is `tucopwallet-backend` and the public URL is `tucop-backend-production.up.railway.app`). Valora-migration acceleration in progress: the next concrete step is the Squid `/api/swap/quote` proxy on the backend (brief delivered 2026-06-23). Original checkboxes left untouched as historical record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Clean up the wallet's stack debt (ethers v5 removal, husky upgrade, prettier/lint config), remove all Celo Sepolia / testnet support from the codebase, accelerate the Valora API migration roadmap, and relocate hardcoded API keys to the project's own backend.


### PR DESCRIPTION
## Summary
Adds a `**Status:** SHIPPED ...` line at the top of each WRI plan (00-04) summarizing what merged, where the artifacts live, and what (if anything) remains. Original step checkboxes left untouched as the historical implementation record.

## Per-plan summary
- **Plan 00 (Sprint 0 spikes):** SHIPPED 2026-06-16, 5/5 spikes resolved.
- **Plan 01 (Track A foundations):** SHIPPED, 8/8 reusable primitives merged.
- **Plan 02 (Track B critical fixes):** SHIPPED 6/7, all five recurring patterns addressed.
- **Plan 03 (Track C EIP-7702):** SHIPPED through Task 4, BatchExecutor deployed at `0xaE6a87E88b55644Eda54C3AA55B11944eE5E1DFe`, verified on Celoscan. Tasks 5/6 (Phase 1 dogfood + Phase 2 rollout) are operational, not code.
- **Plan 04 (Track D hygiene):** SHIPPED. Includes correction of the backend repo name (`TuCOPWallet-Backend`, not `api-wallet-tucop`).

## Test plan
- [x] No code changes, doc-only
- [ ] CI: Semantic PR title + standard checks