### PR TITLE
feat(swap): route swap quotes through TuCop backend (Squid integrator)

### DIFF
--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -215,7 +215,11 @@ const RESOLVE_ID_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/resolveId`
 
 const NFTS_APP_URL = 'https://nfts.valoraapp.com/'
 
-const GET_SWAP_QUOTE_URL = `${CLOUD_FUNCTIONS_MAINNET}/getSwapQuote`
+// Swap quote now flows through TuCop's own backend proxy so the TuCop Squid
+// integratorId is attached (Squid attribution + revenue share lands with us
+// instead of Valora). The backend at TUCOP_BACKEND_BASE below preserves the
+// FetchQuoteResponse shape that this app already consumes (drop-in URL flip).
+const GET_SWAP_QUOTE_URL = 'https://tucop-backend-production.up.railway.app/api/swap/quote'
 
 const HOOKS_API_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/hooks-api`
 


### PR DESCRIPTION
## Summary
Flips `GET_SWAP_QUOTE_URL` from Valora's `api.mainnet.valora.xyz/getSwapQuote` to the new `/api/swap/quote` endpoint on [tucop-backend-production.up.railway.app](https://tucop-backend-production.up.railway.app/api/swap/quote). The backend attaches TuCop's own Squid `integratorId` at request time, so attribution + revenue share land with TuCop instead of Valora.

## Why now
The backend repo's [PR #6](https://github.com/TuCopFinance/TuCOPWallet-Backend/pull/6) shipped this morning (449a130, Railway deploy 76643ff8 SUCCESS). Backend smoke test was 0.1 USDC → USDT on Celo: 200 OK, correct shape (`unvalidatedSwapTransaction.buyAmount=100066`, `price=1.00066`, `to=0xce16F69375520ab01377ce7B88f5BA8C48F8D666`).

## Drop-in shape
The backend mirrors the `FetchQuoteResponse` type defined in [src/swap/types.ts](src/swap/types.ts) (validated against `unvalidatedSwapTransaction` + `details.swapProvider`), so no call-site changes are needed in the wallet — just the URL constant flip.

## Test plan
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn test src/swap src/dollarsSpend src/web3` -> 22 suites, 185 tests pass
- [ ] CI checks
- [ ] Manual smoke after merge: do a real swap in a dev build, confirm the request hits the backend