### PR TITLE
fix(feed): label USDm + USDC + USAT swaps as 'Dolares' (not legacy names)

### DIFF
--- a/src/transactions/feed/SwapFeedItem.test.tsx
+++ b/src/transactions/feed/SwapFeedItem.test.tsx
@@ -56,7 +56,7 @@ describe('SwapFeedItem', () => {
 
     expect(getByTestId('SwapFeedItem/title')).toHaveTextContent('feedItemSwapTitle')
     expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent(
-      'feedItemSwapPath, {"token1":"Celo Dollars","token2":"Celo Euros"}'
+      'feedItemSwapPath, {"token1":"assets.dollars","token2":"Celo Euros"}'
     )
     expect(getByTestId('SwapFeedItem/incomingAmount')).toHaveTextContent('+2.93 cEUR')
     expect(getByTestId('SwapFeedItem/outgoingAmount')).toHaveTextContent('-2.87 cUSD')

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -37,7 +37,9 @@ function SwapFeedItem({ transaction }: Props) {
 
   const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction
 
-  // Get friendly token name - also accepts tokenId for when token info isn't available
+  // Get friendly token name - also accepts tokenId for when token info isn't available.
+  // Per .claude/rules/tokens.md the entire USAT/USDm/USDC/USDT group is shown as
+  // "Dolares" in the UI; only XAUt0 is "Oro" and COPm is "Pesos".
   const getTokenName = (token: any, tokenId?: string) => {
     // First check by tokenId (works even when token info not loaded)
     const idToCheck = tokenId || token?.tokenId
@@ -45,7 +47,12 @@ function SwapFeedItem({ transaction }: Props) {
       if (idToCheck === networkConfig.copmTokenId) {
         return t('assets.pesos')
       }
-      if (idToCheck === networkConfig.usdtTokenId) {
+      if (
+        idToCheck === networkConfig.usdtTokenId ||
+        idToCheck === networkConfig.usdcTokenId ||
+        idToCheck === networkConfig.usdmTokenId ||
+        idToCheck === networkConfig.usatTokenId
+      ) {
         return t('assets.dollars')
       }
       if (idToCheck === networkConfig.xaut0TokenId) {
@@ -61,12 +68,21 @@ function SwapFeedItem({ transaction }: Props) {
       return '...'
     }
 
-    // Check by symbol as fallback
+    // Check by symbol as fallback. Note 'cusd' is the legacy on-chain symbol for
+    // USDm and 'usat' is sometimes shown lowercased; both must collapse to Dolares.
     const symbol = token.symbol?.toLowerCase() || ''
     if (symbol === 'copm' || symbol === 'ccop') {
       return t('assets.pesos')
     }
-    if (symbol === 'usdt' || symbol === 'usd₮' || symbol === 'usdt0') {
+    if (
+      symbol === 'usdt' ||
+      symbol === 'usd₮' ||
+      symbol === 'usdt0' ||
+      symbol === 'usdc' ||
+      symbol === 'usdm' ||
+      symbol === 'cusd' ||
+      symbol === 'usat'
+    ) {
       return t('assets.dollars')
     }
     if (symbol === 'xaut0' || symbol === 'xaut') {


### PR DESCRIPTION
## Summary
Surfaced today during the WRI smoke-test in the simulator: a multi-step Dolares -> Pesos run produced 3 different labels in the transaction feed for the same group of stablecoin swaps.

Screenshot showed:
- `Intercambio · Dolares > Pesos` (USDT, correct)
- `Intercambio · USDC > Pesos` (USDC, wrong — should be 'Dolares')
- `Intercambio · Celo Dollar > Pesos` (USDm, wrong — should be 'Dolares')

Per [.claude/rules/tokens.md](.claude/rules/tokens.md): USAT / USDm / USDC / USDT all share the 'Dolares' label in UI.

## Root cause
[src/transactions/feed/SwapFeedItem.tsx](src/transactions/feed/SwapFeedItem.tsx) `getTokenName` only mapped USDT (and COPm + XAUt0). USDm, USDC, USAT fell through to `token.name ?? token.symbol`:
- USDm → 'Celo Dollar' (on-chain symbol still 'cUSD' from pre-Mento-rebrand)
- USDC → 'USDC'
- USAT → 'USAT'

## Fix
- Extended the tokenId check to cover `usdcTokenId`, `usdmTokenId`, `usatTokenId` alongside `usdtTokenId`.
- Extended the symbol fallback to cover `usdc`, `usdm`, `cusd` (legacy), `usat`.
- Updated the cUSD → cEUR test to reflect the new (correct) label.

## Test plan
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn test src/transactions/feed/SwapFeedItem` — 3/3 pass
- [ ] CI