### PR TITLE
fix(statsig): allow launch-arg gate overrides in debug builds

### DIFF
--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -125,8 +125,13 @@ export function* appInit() {
   const supportedBiometryType = yield* call(Keychain.getSupportedBiometryType)
   yield* put(setSupportedBiometryType(supportedBiometryType))
 
-  // setup statsig overrides for E2E tests
-  if (isE2EEnv) {
+  // setup statsig overrides from launch args. Originally added for Detox E2E
+  // tests; also enabled in any debug build so internal dogfooders / WRI
+  // smoke-testers can flip specific gates per simulator launch via:
+  //   xcrun simctl launch <device> <bundle> -statsigGateOverrides 'gate=true'
+  // Release builds intentionally ignore launch-arg overrides so a real user
+  // can never coerce the app into a different feature surface.
+  if (isE2EEnv || __DEV__) {
     setupOverridesFromLaunchArgs()
   }
 }


### PR DESCRIPTION
## Summary
[setupOverridesFromLaunchArgs()](src/app/saga.ts) was gated behind `isE2EEnv`, so the `-statsigGateOverrides` launch arg only worked under Detox. Any other debug build (dev simulator runs, manual dogfooding, internal QA on a device) silently ignored the override.

## Why this matters now
Blocked the WRI Track C smoke test today. Launching the dev build with:
```
xcrun simctl launch <device> org.tucop -statsigGateOverrides 'wri_dollars_spend_7702_v1=true'
```
had no effect — the saga read the gate as default (false) and ran the legacy sequential path instead of the new 7702 atomic batch.

## Fix
Extend the condition to also fire under `__DEV__` so manual testing works in any debug build. Release builds intentionally keep the lock so a real user can't coerce a feature gate via launch args.

## Test plan
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn test src/app/saga` — 46/46 pass
- [x] Manually verified in iOS simulator: app picked up the override after metro hot-reload + `simctl terminate` + `simctl launch -statsigGateOverrides`
- [ ] CI