### PR TITLE
fix(viem): add signAuthorization to ViemKeychainAccount for EIP-7702

### DIFF
--- a/src/viem/keychainAccountToAccount.ts
+++ b/src/viem/keychainAccountToAccount.ts
@@ -44,6 +44,15 @@ export function keychainAccountToAccount({
   return {
     ...account,
     source: 'keychain',
+    // EIP-7702 support. viem's toAccount() factory only exposes signMessage /
+    // signTransaction / signTypedData on the returned LocalAccount, so the
+    // wallet's signAuthorization Action throws AccountTypeNotSupportedError
+    // ("The signAuthorization Action does not support JSON-RPC Accounts"
+    // — misleading; the underlying check is `if (!account.signAuthorization)`).
+    // Delegate to the unlocked PrivateKeyAccount, which implements it natively.
+    async signAuthorization(...args: Parameters<PrivateKeyAccount['signAuthorization']>) {
+      return getUnlockedAccount().signAuthorization(...args)
+    },
     // This is meant to be called by KeychainAccounts
     unlock: (privateKey: Hex) => {
       const privateKeyAccount = privateKeyToAccount(privateKey)


### PR DESCRIPTION
## Summary
Real root-cause fix surfaced during the WRI Track C smoke test today. The Statsig override worked, the 7702 saga ran, but `walletClient.signAuthorization()` threw `AccountTypeNotSupportedError` because the keychain-backed `LocalAccount` lacks a `signAuthorization` method.

## Diagnostic chain (from the running app's RN log file)
```
DEBUG Statsig: Setting up gate overrides "wri_dollars_spend_7702_v1=true"  ← override applied
...
WARN dollarsSpend/saga7702: 7702 batch failed:
  Account type "local" is not supported.
  The signAuthorization Action does not support JSON-RPC Accounts.
  Version: viem@2.31.0
```

The misleading "JSON-RPC Accounts" error is from viem 2.31 — the actual check at [node_modules/viem/actions/wallet/signAuthorization.ts:97](node_modules/viem/actions/wallet/signAuthorization.ts) is:

```ts
if (!account.signAuthorization)
  throw new AccountTypeNotSupportedError(...)
```

Our `ViemKeychainAccount` IS `type === 'local'`, but viem's `toAccount()` factory only exposes `signMessage / signTransaction / signTypedData`, so `signAuthorization` is undefined on the resulting object.

## Fix
Delegate to the unlocked `PrivateKeyAccount` (same pattern the other 3 sign methods already use):

```ts
async signAuthorization(...args) {
  return getUnlockedAccount().signAuthorization(...args)
}
```

`PrivateKeyAccount` implements `signAuthorization` natively in viem 2.x.

## User-visible impact
Before the fix: the WRI 7702 atomic-batch path never sends a single tx — the PartialSuccessSheet shows "Completaste 0 de 3 pasos" because saga7702 errors before broadcast.

After the fix: the keychain account signs the 7702 authorization correctly; the saga can broadcast the type-0x04 transaction to Celo.

## Test plan
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn test src/viem/keychainAccountToAccount` — 7/7 pass
- [ ] Manual smoke test on simulator with the spike v2 wallet — re-run Dolares → Pesos with 7702 override active, expect 1 type-0x04 tx with our hardened BatchExecutor as Authority
- [ ] CI