### PR TITLE
fix(7702): unlock keychain account before signing the authorization

### DIFF
--- a/src/dollarsSpend/saga7702.test.ts
+++ b/src/dollarsSpend/saga7702.test.ts
@@ -16,6 +16,7 @@ import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
 import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 jest.mock('src/statsig')
@@ -156,6 +157,7 @@ describe('dollarsSpend saga dispatcher (flag-gated)', () => {
         [matchers.select.selector(feeCurrenciesSelector), []],
         [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
         [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+        [matchers.call.fn(getConnectedUnlockedAccount), MOCK_WALLET],
       ])
       .put(multiSwapStarted({ steps: [stepUsat] }))
       .put(multiSwapStepSucceeded({ index: 0 }))

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -18,6 +18,7 @@ import { Network, NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'dollarsSpend/saga7702'
@@ -156,6 +157,15 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
     if (!account) {
       throw new Error('Wallet has no account loaded')
     }
+
+    // Unlock the keychain account before signing. Without this, the
+    // PrivateKeyAccount that backs the keychain LocalAccount is null and
+    // `signAuthorization` (delegated through getUnlockedAccount in
+    // src/viem/keychainAccountToAccount.ts) throws
+    // "authentication needed: password or unlock". The legacy path goes
+    // through sendPreparedTransactions which calls this internally; this
+    // 7702 path signs directly via signAuthorization so it must unlock here.
+    yield* call(getConnectedUnlockedAccount)
 
     // Sign EIP-7702 authorization delegating THIS EOA -> BatchExecutor.
     // executor: 'self' so viem uses the wallet's nonce sequence. Wrap in a


### PR DESCRIPTION
## Summary
Second of two root-cause bugs blocking the WRI Track C smoke test today.

[saga7702.ts](src/dollarsSpend/saga7702.ts) called `wallet.signAuthorization()` directly without unlocking the keychain-backed account first. With PR #201 (signAuthorization delegate) shipped, the smoke test surfaced this next error:

```
WARN dollarsSpend/saga7702: 7702 batch failed:
  authentication needed: password or unlock
```

## Why legacy doesn't hit this
The legacy path calls `sendPreparedTransactions` which internally calls [getConnectedUnlockedAccount](src/web3/saga.ts) before any signing. The 7702 path uses `signAuthorization` independently of `sendTransaction`, so the unlock dance must happen explicitly here.

## Fix
Mirror the pattern from [src/viem/saga.ts:82](src/viem/saga.ts#L82):
```ts
// Unlock account before executing tx
yield* call(getConnectedUnlockedAccount)
```

## Test plan
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn test src/dollarsSpend/saga7702` — 4/4 pass (added the `getConnectedUnlockedAccount` provider to the test mock)
- [ ] Manual smoke test on simulator after this + #201 land
- [ ] CI