### PR TITLE
chore(earn): repoint hooks-api to TuCop backend

### DIFF
--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -219,9 +219,11 @@ const NFTS_APP_URL = 'https://nfts.valoraapp.com/'
 // integratorId is attached (Squid attribution + revenue share lands with us
 // instead of Valora). The backend at TUCOP_BACKEND_BASE below preserves the
 // FetchQuoteResponse shape that this app already consumes (drop-in URL flip).
-const GET_SWAP_QUOTE_URL = 'https://tucop-backend-production.up.railway.app/api/swap/quote'
+const TUCOP_BACKEND_BASE_URL = 'https://tucop-backend-production.up.railway.app'
 
-const HOOKS_API_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/hooks-api`
+const GET_SWAP_QUOTE_URL = `${TUCOP_BACKEND_BASE_URL}/api/swap/quote`
+
+const HOOKS_API_URL_MAINNET = `${TUCOP_BACKEND_BASE_URL}/hooks-api`
 
 const JUMPSTART_CLAIM_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/walletJumpstart`
 


### PR DESCRIPTION
## Summary

- Routes `getPositions`/`getEarnPositions`/`v2/getShortcuts`/`triggerShortcut` to `tucop-backend` instead of Valora.
- Extracts `TUCOP_BACKEND_BASE_URL` so `HOOKS_API_URL_MAINNET` and `GET_SWAP_QUOTE_URL` share one source of truth.
- Eliminates external SPOF for the Earn experience.

## Why

Prep for Neeru Vaults integration. The backend hosts the hooks-api surface natively: Allbridge (ported from `valora-inc/hooks` under MIT, with attribution) + Neeru as new appId.

## Companion specs

- `tasks/plans/neeru-vaults-backend-spec.md` — backend work (indexer, endpoints, Allbridge port, Neeru handlers)
- `tasks/plans/2026-06-26-neeru-vaults-wallet.md` — wallet work (4 tranche cards, detail screen, close flow, emergency exit)

## Test plan

- [ ] Backend confirms Allbridge native handlers are deployed and getEarnPositions/getPositions/triggerShortcut return Valora-parity responses for appId allbridge.
- [ ] CI passes (yarn build:ts, yarn lint, yarn test).
- [ ] Manual: open Earn screen in dev build, confirm Allbridge cards still render and a small deposit succeeds end-to-end.

## Risks

If merged before backend has Allbridge native deployed, the Earn screen breaks for all users on this build. Coordinate merge with backend team. User has authorized merge regardless given no app store release is active.