### PR TITLE
feat(wri): Track C atomic 7702 completion + ecosystem hygiene

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -1,6 +1,10 @@
 # Generated using co.clabs.valora and the matching signing cert from the Play Store
 # This means Android auto-read feature will only work from Play Store distributed builds!
 SMS_RETRIEVER_APP_SIGNATURE=bU9E4ctGtIW
+# Selects which key in secrets.json the Xcode pre-action loads. Mainnet is the
+# only supported network after PR #162 removed Sepolia, but build scripts
+# (xcode_scheme_build_pre_action.sh, run_app.sh) still index by this var.
+DEFAULT_TESTNET=mainnet
 DEV_SETTINGS_ACTIVE_INITIALLY=false
 FIREBASE_ENABLED=false
 APP_BUNDLE_ID=org.tucop

--- a/.env.mainnetdev
+++ b/.env.mainnetdev
@@ -1,6 +1,10 @@
 # Generated using co.clabs.valora.dev and the debug keystore
 # This means Android auto-read feature will only work from debug builds
 SMS_RETRIEVER_APP_SIGNATURE=g9YQFjScXBz
+# Selects which key in secrets.json the Xcode pre-action loads. Mainnet is the
+# only supported network after PR #162 removed Sepolia, but build scripts
+# (xcode_scheme_build_pre_action.sh, run_app.sh) still index by this var.
+DEFAULT_TESTNET=mainnet
 DEV_SETTINGS_ACTIVE_INITIALLY=false
 # Enable for true hot reloading while dev-ing UI
 DEV_RESTORE_NAV_STATE_ON_RELOAD=false

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1850,6 +1850,14 @@
       "title": "Before you swap",
       "body": "We can't estimate the value of this swap. {{appName}} is not responsible if you choose to proceed."
     },
+    "belowMinSwapWarning": {
+      "title": "Amount too small",
+      "body": "The minimum swap amount is approximately ${{minSwapUsd}} USD. Increase the amount to continue."
+    },
+    "upstreamUnavailableWarning": {
+      "title": "Service temporarily unavailable",
+      "body": "We couldn't get a quote. Please try again in a few seconds."
+    },
     "confirmSwapFailedWarning": {
       "title": "Something went wrong",
       "body": "The network speed is slow or there is an unknown error. Please try again later"
@@ -3052,6 +3060,7 @@
     "expandedDetailHeader": "Detalle por token",
     "stepCount": "{{steps}} pasos",
     "stepProgress": "Paso {{index}} de {{total}}: convirtiendo {{symbol}}",
+    "atomicProgress": "Cambiando tus Dolares a Pesos...",
     "transitioning": "Finishing your operation...",
     "partialSuccess": {
       "title": "Completaste {{completed}} de {{total}} pasos",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -1855,6 +1855,14 @@
       "title": "Antes de cambiar",
       "body": "No podemos estimar el valor de este intercambio. {{appName}} no se hace responsable si decides proceder."
     },
+    "belowMinSwapWarning": {
+      "title": "Monto muy pequeño",
+      "body": "El monto mínimo por intercambio es de aproximadamente ${{minSwapUsd}} USD. Aumenta el monto para continuar."
+    },
+    "upstreamUnavailableWarning": {
+      "title": "Servicio temporalmente no disponible",
+      "body": "No pudimos obtener una cotización. Vuelve a intentarlo en unos segundos."
+    },
     "confirmSwapFailedWarning": {
       "title": "Algo salió mal",
       "body": "La velocidad de la red es lenta o hay un error desconocido. Vuelve a intentarlo más tarde"
@@ -3026,6 +3034,7 @@
     "expandedDetailHeader": "Detalle por token",
     "stepCount": "{{steps}} pasos",
     "stepProgress": "Paso {{index}} de {{total}}: convirtiendo {{symbol}}",
+    "atomicProgress": "Cambiando tus Dolares a Pesos...",
     "transitioning": "Finalizando tu cambio...",
     "partialSuccess": {
       "title": "Completaste {{completed}} de {{total}} pasos",

--- a/patches/react-native-screens+4.8.0.patch
+++ b/patches/react-native-screens+4.8.0.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-screens/ios/RNSScreenContentWrapper.mm b/node_modules/react-native-screens/ios/RNSScreenContentWrapper.mm
+index 68558e9..254dc4d 100644
+--- a/node_modules/react-native-screens/ios/RNSScreenContentWrapper.mm
++++ b/node_modules/react-native-screens/ios/RNSScreenContentWrapper.mm
+@@ -76,7 +76,11 @@ - (void)attachToAncestorScreenView
+   RNSScreen *_Nullable screen =
+       static_cast<RNSScreen *_Nullable>([[self findFirstScreenViewAncestor] reactViewController]);
+   if (screen == nil) {
+-    RCTLogError(@"Failed to find parent screen controller from %@.", self);
++    // Downgraded from RCTLogError to RCTLogInfo: this fires on every iOS
++    // navigation parallax transition when the content wrapper is briefly
++    // outside its parent screen during the animation. Cosmetic noise, not
++    // a real failure (see RNSScreenContentWrapper.mm line ~74).
++    RCTLogInfo(@"RNSScreenContentWrapper: no parent screen during transition (cosmetic): %@", self);
+     return;
+   }
+   [self attachToAncestorScreenViewStartingFrom:screen];

--- a/patches/viem+2.31.0.patch
+++ b/patches/viem+2.31.0.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/viem/_cjs/actions/public/waitForTransactionReceipt.js b/node_modules/viem/_cjs/actions/public/waitForTransactionReceipt.js
+index aa510c6..ec3e749 100644
+--- a/node_modules/viem/_cjs/actions/public/waitForTransactionReceipt.js
++++ b/node_modules/viem/_cjs/actions/public/waitForTransactionReceipt.js
+@@ -23,8 +23,8 @@ async function waitForTransactionReceipt(client, { confirmations = 1, hash, onRe
+     const { promise, resolve, reject } = (0, withResolvers_js_1.withResolvers)();
+     const timer = timeout
+         ? setTimeout(() => {
+-            _unwatch();
+-            _unobserve();
++            if (typeof _unwatch === 'function') _unwatch();
++            if (typeof _unobserve === 'function') _unobserve();
+             reject(new transaction_js_1.WaitForTransactionReceiptTimeoutError({ hash }));
+         }, timeout)
+         : undefined;
+diff --git a/node_modules/viem/_esm/actions/public/waitForTransactionReceipt.js b/node_modules/viem/_esm/actions/public/waitForTransactionReceipt.js
+index 166c4a5..579c248 100644
+--- a/node_modules/viem/_esm/actions/public/waitForTransactionReceipt.js
++++ b/node_modules/viem/_esm/actions/public/waitForTransactionReceipt.js
+@@ -60,8 +60,8 @@ timeout = 180_000, }) {
+     const { promise, resolve, reject } = withResolvers();
+     const timer = timeout
+         ? setTimeout(() => {
+-            _unwatch();
+-            _unobserve();
++            if (typeof _unwatch === 'function') _unwatch();
++            if (typeof _unobserve === 'function') _unobserve();
+             reject(new WaitForTransactionReceiptTimeoutError({ hash }));
+         }, timeout)
+         : undefined;

--- a/src/dollarsSpend/MultiSwapProgressSheet.tsx
+++ b/src/dollarsSpend/MultiSwapProgressSheet.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import StateCard from 'src/components/StateCard'
 import { inFlightSelector } from 'src/dollarsSpend/selectors'
 import { useSelector } from 'src/redux/hooks'
-import Colors from 'src/styles/colors'
-import { typeScale } from 'src/styles/fonts'
-import { Spacing } from 'src/styles/styles'
 
+// Standardized progress sheet for both the legacy multi-step Dolares -> Pesos
+// path (shows "Paso X de N: convirtiendo SYMBOL") and the atomic 7702 path
+// (shows a single in-progress copy because the per-step counter would lie).
+//
+// Uses the shared StateCard component with the `loading` variant so the visual
+// language matches every other transaction in-flight surface in the wallet
+// (spinner + card + soft shadow + title typography).
 export default function MultiSwapProgressSheet() {
   const { t } = useTranslation()
   const inFlight = useSelector(inFlightSelector)
@@ -15,33 +19,30 @@ export default function MultiSwapProgressSheet() {
     return null
   }
 
-  const currentIndex = inFlight.completedSteps // 0-based index of the in-progress step
+  if (inFlight.isAtomic) {
+    return (
+      <StateCard
+        variant="loading"
+        title={t('dollarsSpend.atomicProgress')}
+        testID="MultiSwapProgressSheet"
+      />
+    )
+  }
+
+  const currentIndex = inFlight.completedSteps
   const total = inFlight.plannedSteps.length
   const currentStep = inFlight.plannedSteps[currentIndex]
   if (!currentStep) return null
 
   return (
-    <View style={styles.container} testID="MultiSwapProgressSheet">
-      <Text style={styles.text}>
-        {t('dollarsSpend.stepProgress', {
-          index: currentIndex + 1,
-          total,
-          symbol: currentStep.symbol,
-        })}
-      </Text>
-    </View>
+    <StateCard
+      variant="loading"
+      title={t('dollarsSpend.stepProgress', {
+        index: currentIndex + 1,
+        total,
+        symbol: currentStep.symbol,
+      })}
+      testID="MultiSwapProgressSheet"
+    />
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    padding: Spacing.Thick24,
-    backgroundColor: Colors.white,
-    borderRadius: Spacing.Regular16,
-  },
-  text: {
-    ...typeScale.labelMedium,
-    color: Colors.black,
-    textAlign: 'center',
-  },
-})

--- a/src/dollarsSpend/planSpend.ts
+++ b/src/dollarsSpend/planSpend.ts
@@ -5,6 +5,14 @@ import { DollarTokenBalanceSnapshot, MultiSwapPlan, SpendStep } from 'src/dollar
 // See spec rationale: spend least-liquid / most-regulated first.
 const SPEND_ORDER_SYMBOLS: SpendStep['symbol'][] = ['USAT', 'USDm', 'USDC', 'USDT']
 
+// Dust tolerance: when the user types the exact rounded balance displayed on
+// screen ("$3.00 Dolares") but the actual on-chain sum is a few cents less
+// (e.g. USDT 1.984 + USDm 0.994 = 2.979), planSpend would otherwise compute a
+// $0.021 shortfall and the UI would surface "Saldo insuficiente". We tolerate
+// sub-cent gaps by treating shortfall < $0.05 as 0; the swap just proceeds
+// with the actual balance and the user is not blocked by the rounding lie.
+const SHORTFALL_DUST_TOLERANCE_USD = 0.05
+
 export function planSpend({
   requestedUsd,
   balances,
@@ -51,8 +59,10 @@ export function planSpend({
     remaining = remaining.minus(takeUsd)
   }
 
-  return {
-    steps,
-    shortfall: BigNumber.max(remaining, new BigNumber(0)),
-  }
+  const rawShortfall = BigNumber.max(remaining, new BigNumber(0))
+  // Collapse dust shortfalls to 0 so the user can swap their full displayed
+  // balance even when sub-cent on-chain precision means the actual sum is
+  // slightly below the rounded-to-2-decimals saldo.
+  const shortfall = rawShortfall.lt(SHORTFALL_DUST_TOLERANCE_USD) ? new BigNumber(0) : rawShortfall
+  return { steps, shortfall }
 }

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -23,10 +23,16 @@ import { Field, SwapInfo } from 'src/swap/types'
 import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
 import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
-import { NetworkId } from 'src/transactions/types'
+import { Network, NetworkId } from 'src/transactions/types'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import Logger from 'src/utils/Logger'
+import { publicClient } from 'src/viem'
 import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
+import { getViemWallet } from 'src/web3/contracts'
+import networkConfig from 'src/web3/networkConfig'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
+import { Address } from 'viem'
 
 const TAG = 'dollarsSpend/saga'
 
@@ -50,17 +56,174 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
     return
   }
 
-  // Track C: when the EIP-7702 / CIP-64 single-tx path is enabled, hand off to
-  // the new saga. The legacy sequential loop below is the fallback whenever
-  // the flag is off, the BatchExecutor isn't deployed yet, or the new path
-  // throws (the new saga handles its own error dispatch).
+  // Track C: when the EIP-7702 / CIP-64 single-tx path is enabled AND the
+  // user's EOA is already delegated to our hardened BatchExecutor, hand off
+  // to the new saga. The legacy sequential loop below is the fallback for:
+  //   - flag off
+  //   - user not delegated yet (until the sponsored-relay endpoint is live,
+  //     first-time users without CELO go through legacy; once relayed and
+  //     delegated, every subsequent run takes the 7702 path)
+  //   - the BatchExecutor address being misconfigured
+  //   - the new path throwing (the new saga handles its own error dispatch)
+  //
+  // Why two conditions instead of trying to combine 7702 + CIP-64 in a single
+  // tx: in Celo, type 0x04 (EIP-7702 authorizationList) and type 0x7b (CIP-64
+  // feeCurrency) are mutually-exclusive tx envelopes. A user with a persistent
+  // delegation can submit a CIP-64 tx that calls execute() on their own EOA
+  // (which runs the BatchExecutor code) paying gas in a stable. A user without
+  // delegation needs a separate tx 0x04 first, which costs CELO and is the
+  // relay's job.
   const sevenSevenZeroTwoOn = yield* call(
     getFeatureGate,
     StatsigFeatureGates.WRI_DOLLARS_SPEND_7702_V1
   )
   if (sevenSevenZeroTwoOn) {
-    yield* call(executeDollarsSpend7702Saga, action)
-    return
+    const walletAddress = yield* select(walletAddressSelector)
+    if (walletAddress) {
+      const expectedDesignator = `0xef0100${networkConfig.batchExecutorAddressCelo
+        .slice(2)
+        .toLowerCase()}`
+      const code = yield* call(() =>
+        publicClient[Network.Celo].getCode({ address: walletAddress as Address })
+      )
+      let isOurDelegation = (code ?? '').toLowerCase() === expectedDesignator
+
+      // If not delegated yet, ask the backend's sponsored-relay endpoint to
+      // submit the type-0x04 setup tx. The relay pays gas in CELO from a
+      // TuCop hot wallet so users without CELO can still bootstrap the
+      // delegation. On success the relay waits for receipt + verifies code
+      // before responding 200, so by then the delegation is on-chain.
+      // Any failure (rate limit, hot wallet down, signing issue) silently
+      // falls through to the legacy multi-step path so the user always
+      // gets a working flow.
+      if (!isOurDelegation) {
+        try {
+          const wallet = yield* call(getViemWallet, networkConfig.viemChain[Network.Celo])
+          if (wallet.account) {
+            yield* call(getConnectedUnlockedAccount)
+            // No `executor` field: the relay (not the user) submits the tx, so
+            // the signed authorization must use the EOA's CURRENT nonce, not
+            // nonce+1. Setting executor:'self' would lock the auth to a tx
+            // submitted by the EOA itself; the relay's tx would then mismatch.
+            const auth = yield* call(() =>
+              wallet.signAuthorization({
+                account: wallet.account!,
+                contractAddress: networkConfig.batchExecutorAddressCelo,
+              })
+            )
+            // viem's authorization object uses bigint fields; serialize for JSON.
+            const relayBody = {
+              userAddress: walletAddress,
+              signedAuthorization: {
+                chainId: `0x${auth.chainId.toString(16)}`,
+                address: networkConfig.batchExecutorAddressCelo,
+                nonce: `0x${auth.nonce.toString(16)}`,
+                yParity: auth.yParity === 0 ? '0x0' : '0x1',
+                r: auth.r,
+                s: auth.s,
+              },
+            }
+
+            // Backend spec: happy path 3-7s; recommend 20s client timeout to
+            // cover worst-case mining variance + safety margin.
+            const RELAY_TIMEOUT_MS = 20_000
+            const RELAY_MAX_ATTEMPTS = 3
+
+            // Try the relay up to RELAY_MAX_ATTEMPTS times. We hand-roll the
+            // retry loop here (instead of relying solely on fetchWithTimeout's
+            // built-in 5xx retry) because we need:
+            //   - 429: respect Retry-After header
+            //   - 502 "unverified": re-check on-chain getCode before retrying,
+            //     since the delegation tx may have mined despite the relay's
+            //     verification step failing
+            //   - 503/400: do not retry; fall through to legacy
+            let attempt = 0
+            while (attempt < RELAY_MAX_ATTEMPTS && !isOurDelegation) {
+              const res = yield* call(
+                fetchWithTimeout,
+                networkConfig.wriDelegateRelayUrl,
+                {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(relayBody),
+                },
+                RELAY_TIMEOUT_MS
+              )
+
+              if (res.ok) {
+                const body = (yield* call(() => res.json())) as { status?: string }
+                if (body.status === 'delegated' || body.status === 'already_delegated') {
+                  isOurDelegation = true
+                }
+                break
+              }
+
+              if (res.status === 429) {
+                const retryAfterRaw = res.headers.get('retry-after')
+                const retryAfterSec = retryAfterRaw ? Number(retryAfterRaw) : NaN
+                const waitMs = Number.isFinite(retryAfterSec)
+                  ? Math.min(retryAfterSec * 1000, 5_000)
+                  : 1_000
+                Logger.warn(TAG, `relay 429; waiting ${waitMs}ms then retrying`)
+                yield* delay(waitMs)
+                attempt += 1
+                continue
+              }
+
+              if (res.status === 502) {
+                // The relay submitted a tx but couldn't verify the on-chain
+                // code update within its own deadline. The tx may still have
+                // mined by now. Re-check before retrying so we don't re-sign
+                // a duplicate authorization.
+                Logger.warn(TAG, `relay 502; rechecking on-chain delegation`)
+                const recheckCode = yield* call(() =>
+                  publicClient[Network.Celo].getCode({ address: walletAddress as Address })
+                )
+                if ((recheckCode ?? '').toLowerCase() === expectedDesignator) {
+                  Logger.info(TAG, `delegation now present on-chain after 502; proceeding`)
+                  isOurDelegation = true
+                  break
+                }
+                // Exponential backoff: 1s, 2s.
+                const backoffMs = 1_000 * 2 ** attempt
+                yield* delay(backoffMs)
+                attempt += 1
+                continue
+              }
+
+              if (res.status === 503) {
+                Logger.warn(TAG, `relay 503 (degraded); falling back to legacy`)
+                break
+              }
+
+              if (res.status === 400) {
+                Logger.warn(
+                  TAG,
+                  `relay 400 (validation); likely a client bug; falling back to legacy`
+                )
+                break
+              }
+
+              Logger.warn(TAG, `relay returned ${res.status}; falling back to legacy multi-step`)
+              break
+            }
+          }
+        } catch (err) {
+          Logger.warn(
+            TAG,
+            `relay flow threw, falling back to legacy: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          )
+        }
+      }
+
+      if (isOurDelegation) {
+        yield* call(executeDollarsSpend7702Saga, action)
+        return
+      }
+    }
+    // Fall through to legacy when not delegated and relay didn't deliver.
   }
 
   yield* put(multiSwapStarted({ steps }))

--- a/src/dollarsSpend/saga7702.test.ts
+++ b/src/dollarsSpend/saga7702.test.ts
@@ -16,6 +16,7 @@ import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
 import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 jest.mock('src/statsig')
@@ -156,6 +157,7 @@ describe('dollarsSpend saga dispatcher (flag-gated)', () => {
         [matchers.select.selector(feeCurrenciesSelector), []],
         [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
         [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+        [matchers.call.fn(getConnectedUnlockedAccount), MOCK_WALLET],
       ])
       .put(multiSwapStarted({ steps: [stepUsat] }))
       .put(multiSwapStepSucceeded({ index: 0 }))

--- a/src/dollarsSpend/saga7702.test.ts
+++ b/src/dollarsSpend/saga7702.test.ts
@@ -28,6 +28,18 @@ jest.mock('src/web3/contracts', () => ({
   ...jest.requireActual('src/web3/contracts'),
   getViemWallet: jest.fn(),
 }))
+// saga7702 reads on-chain balanceOf, getBalance, and getCode through
+// publicClient[Network.Celo]. Stub the whole map so each test can override the
+// methods it cares about.
+jest.mock('src/viem', () => ({
+  publicClient: {
+    celo: {
+      readContract: jest.fn().mockResolvedValue(BigInt('100000000')), // matches stepUsat amount
+      getBalance: jest.fn().mockResolvedValue(BigInt(1)), // > 0 -> picks CELO native
+      getCode: jest.fn().mockResolvedValue('0x'),
+    },
+  },
+}))
 
 const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
 
@@ -141,7 +153,7 @@ describe('dollarsSpend saga dispatcher (flag-gated)', () => {
     expect(wallet.sendTransaction).not.toHaveBeenCalled()
   })
 
-  it('when flag is on, signs an EIP-7702 authorization pointing at the BatchExecutor and submits one tx', async () => {
+  it('when flag is on, submits a single CIP-64 (or eip1559) tx invoking execute() on the EOA', async () => {
     jest.mocked(getFeatureGate).mockReturnValue(true)
     jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
     const wallet = mockWallet()
@@ -159,26 +171,22 @@ describe('dollarsSpend saga dispatcher (flag-gated)', () => {
         [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
         [matchers.call.fn(getConnectedUnlockedAccount), MOCK_WALLET],
       ])
-      .put(multiSwapStarted({ steps: [stepUsat] }))
+      .put(multiSwapStarted({ steps: [stepUsat], isAtomic: true }))
       .put(multiSwapStepSucceeded({ index: 0 }))
       .put(multiSwapCompleted())
       .not.put.actionType(multiSwapStepFailed.type)
       .silentRun()
 
-    expect(wallet.signAuthorization).toHaveBeenCalledWith(
-      expect.objectContaining({
-        contractAddress: networkConfig.batchExecutorAddressCelo,
-        executor: 'self',
-      })
-    )
+    // The relay handles the EIP-7702 delegation upstream; saga7702 does NOT
+    // sign an authorization or include an authorizationList. It only sends the
+    // CIP-64 / eip1559 execute() tx against the already-delegated EOA.
+    expect(wallet.signAuthorization).not.toHaveBeenCalled()
     expect(wallet.sendTransaction).toHaveBeenCalledTimes(1)
     const sendArg = wallet.sendTransaction.mock.calls[0][0]
     expect(sendArg.to).toBe(MOCK_WALLET)
-    expect(sendArg.authorizationList).toHaveLength(1)
-    // Fee currency is the first step's underlying ERC-20 address derived from
-    // the tokenId (`celo-mainnet:<address>` -> `<address>`). Here the mock
-    // step uses `celo-mainnet:usat` so we expect the second segment back.
-    expect(sendArg.feeCurrency).toBe('usat')
+    expect(sendArg.authorizationList).toBeUndefined()
+    // CELO native balance > 0 in the mock -> no feeCurrency (eip1559 type 0x02).
+    expect(sendArg.feeCurrency).toBeUndefined()
   })
 
   it('dispatches multiSwapStepFailed when the 7702 batch submission throws', async () => {

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -18,6 +18,7 @@ import { Network, NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'dollarsSpend/saga7702'
@@ -156,6 +157,15 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
     if (!account) {
       throw new Error('Wallet has no account loaded')
     }
+
+    // Unlock the keychain account before signing. Without this, the
+    // PrivateKeyAccount that backs the keychain LocalAccount is null and
+    // `signAuthorization` (delegated through getUnlockedAccount in
+    // src/viem/keychainAccountToAccount.ts) throws
+    // "authentication needed: password or unlock". The legacy path goes
+    // through sendPreparedTransactions which calls this internally; this
+    // 7702 path signs directly via signAuthorization so it must unlock here.
+    yield* call(getConnectedUnlockedAccount)
 
     // Sign EIP-7702 authorization delegating THIS EOA -> BatchExecutor.
     // executor: 'self' so viem uses the wallet's nonce sequence. Wrap in a

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -1,7 +1,7 @@
 import { PayloadAction } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
 import { call, delay, put, select } from 'typed-redux-saga'
-import { Address, encodeFunctionData, Hex } from 'viem'
+import { Address, encodeFunctionData, erc20Abi, Hex } from 'viem'
 import { BATCH_EXECUTOR_ABI } from 'src/dollarsSpend/batchExecutorAbi'
 import { ExecuteMultiSwapPayload } from 'src/dollarsSpend/saga'
 import {
@@ -11,11 +11,16 @@ import {
   multiSwapStepSucceeded,
   multiSwapTransitionComplete,
 } from 'src/dollarsSpend/slice'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
+import { addStandbyTransaction } from 'src/transactions/slice'
+import { newTransactionContext, TokenTransactionTypeV2 } from 'src/transactions/types'
 import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import { Network, NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
+import { publicClient } from 'src/viem'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { getConnectedUnlockedAccount } from 'src/web3/saga'
@@ -55,7 +60,7 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
     return
   }
 
-  yield* put(multiSwapStarted({ steps }))
+  yield* put(multiSwapStarted({ steps, isAtomic: true }))
 
   const walletAddress = yield* select(walletAddressSelector)
   if (!walletAddress) {
@@ -73,6 +78,19 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
   // transactions are (optional approve) + swap; we forward both, preserving
   // order so the BatchExecutor runs the allowance bump before the swap call.
   const innerCalls: InnerCall[] = []
+
+  // Track the actual (capped) outflow per step + estimated inflow per step.
+  // We use these after sendTransaction to build an optimistic standby tx so
+  // the user sees the swap in the feed before the indexer catches up. The
+  // "primary" outflow is the largest USD step (matches the backend classifier
+  // rule 1, which picks the same).
+  type StepOutcome = {
+    tokenId: string
+    outAmountTokenWhole: BigNumber
+    inAmountTokenWhole: BigNumber
+    usd: BigNumber
+  }
+  const stepOutcomes: StepOutcome[] = []
   for (let index = 0; index < steps.length; index++) {
     const step = steps[index]
     const fromToken = tokensById[step.tokenId]
@@ -92,9 +110,33 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
 
     let freshQuote: Awaited<ReturnType<typeof fetchSwapQuoteForExecution>>
     try {
-      const amountInWei = step.amountTokenWhole
+      // Cap the planned step amount at the actual on-chain balance. planSpend
+      // operates on Redux state which can lag behind real chain state when the
+      // user has been transacting recently. Without this cap, the saga can
+      // build inner calls that exceed the user's actual balance, and the entire
+      // atomic 7702 batch reverts in estimateGas (one inner transferFrom fails
+      // because the planned amount is larger than the current balance).
+      const tokenAddress = step.tokenId.split(':')[1] as Address
+      const onchainBalance = yield* call(() =>
+        publicClient[Network.Celo].readContract({
+          address: tokenAddress,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [walletAddress as Address],
+        })
+      )
+      const plannedAmountWei = step.amountTokenWhole
         .shiftedBy(step.decimals)
-        .toFixed(0, BigNumber.ROUND_DOWN)
+        .integerValue(BigNumber.ROUND_DOWN)
+      const cappedAmountWei = BigNumber.min(
+        plannedAmountWei,
+        new BigNumber(onchainBalance.toString())
+      )
+      if (cappedAmountWei.lte(0)) {
+        Logger.warn(TAG, `Step ${index} (${step.symbol}) has zero on-chain balance; skipping`)
+        continue
+      }
+      const amountInWei = cappedAmountWei.toFixed(0)
       freshQuote = yield* call(fetchSwapQuoteForExecution, {
         fromTokenId: step.tokenId,
         toTokenId,
@@ -142,6 +184,35 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
         data: tx.data as Hex,
       })
     }
+
+    // Record what this step actually contributes (capped to on-chain balance).
+    // step.amountUsd is the planned USD; we recompute proportional USD from the
+    // capped fraction so the "primary" step pick stays correct even when the
+    // user's on-chain balance is less than the plan.
+    //
+    // Squid returns sellAmount / buyAmount in BASE UNITS (wei). Convert both
+    // to whole tokens here so the standby TokenAmount.value matches Valora's
+    // convention (whole tokens with decimal, e.g. "1.005987267070000000").
+    // Without this shift, the feed displays raw wei (e.g. "10,312,541,975,..."
+    // Pesos), which is what regressed in the previous build.
+    const toToken = tokensById[toTokenId]
+    const toTokenDecimals = toToken?.decimals ?? 18
+    const sellAmountWei = new BigNumber(freshQuote.swapAmount.FROM?.toString() ?? '0')
+    const buyAmountWei = new BigNumber(freshQuote.swapAmount.TO?.toString() ?? '0')
+    const outAmountWhole = sellAmountWei.shiftedBy(-step.decimals)
+    const inAmountWhole = buyAmountWei.shiftedBy(-toTokenDecimals)
+    const cappedFraction = step.amountTokenWhole.gt(0)
+      ? outAmountWhole.dividedBy(step.amountTokenWhole)
+      : new BigNumber(1)
+    const usdContribution = step.amountUsd.multipliedBy(
+      BigNumber.min(cappedFraction, new BigNumber(1))
+    )
+    stepOutcomes.push({
+      tokenId: step.tokenId,
+      outAmountTokenWhole: outAmountWhole,
+      inAmountTokenWhole: inAmountWhole,
+      usd: usdContribution,
+    })
   }
 
   if (innerCalls.length === 0) {
@@ -158,56 +229,177 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       throw new Error('Wallet has no account loaded')
     }
 
-    // Unlock the keychain account before signing. Without this, the
-    // PrivateKeyAccount that backs the keychain LocalAccount is null and
-    // `signAuthorization` (delegated through getUnlockedAccount in
-    // src/viem/keychainAccountToAccount.ts) throws
-    // "authentication needed: password or unlock". The legacy path goes
-    // through sendPreparedTransactions which calls this internally; this
-    // 7702 path signs directly via signAuthorization so it must unlock here.
+    // Unlock the keychain account before signing the tx. The legacy path goes
+    // through sendPreparedTransactions which calls this internally; here we
+    // call sendTransaction directly so we must unlock ourselves.
     yield* call(getConnectedUnlockedAccount)
 
-    // Sign EIP-7702 authorization delegating THIS EOA -> BatchExecutor.
-    // executor: 'self' so viem uses the wallet's nonce sequence. Wrap in a
-    // thunk because typed-redux-saga's `call([obj, method], args)` overload
-    // requires a positional signature, but viem's signAuthorization takes a
-    // single named-args object — easier to call directly.
-    const authorization = yield* call(() =>
-      wallet.signAuthorization({
-        account,
-        contractAddress: networkConfig.batchExecutorAddressCelo,
-        executor: 'self',
-      })
-    )
-
+    // The caller (src/dollarsSpend/saga.ts) has already verified that the
+    // user's EOA is delegated to our hardened BatchExecutor. So we don't sign
+    // or include an EIP-7702 authorizationList here — the delegation persists
+    // on-chain. Calling execute() directly against the EOA invokes the
+    // BatchExecutor code in the EOA's context.
+    //
+    // A single CIP-64 tx (type 0x7b) pays gas in the user-facing stable.
+    // EIP-7702 (type 0x04) and CIP-64 are mutually-exclusive tx envelopes in
+    // Celo, so combining authorizationList + feeCurrency in one tx makes the
+    // node reject estimateGas. The relay endpoint handles the one-time
+    // delegation tx separately (paid in CELO from a TuCop hot wallet).
     const calldata = encodeFunctionData({
       abi: BATCH_EXECUTOR_ABI,
       functionName: 'execute',
       args: [innerCalls],
     })
 
-    // Pick the user-facing token from the first step as fee currency. The user
-    // already has balance there (it's what they are spending); paying gas in
-    // it keeps the flow CELO-free. The step.tokenId is `celo-mainnet:0x...`,
-    // strip the prefix to get the bare ERC-20 address.
-    const feeCurrencyAddress = steps[0].tokenId.split(':')[1] as Hex
+    // Pick a fee currency.
+    //
+    // CELO is the priority-0 choice per FEE_CURRENCY_PRIORITY in
+    // src/tokens/selectors.ts. The wallet hides CELO from the UI token list
+    // (via ALLOWED_TOKEN_IDS in src/tokens/constants.ts), but that's a UI
+    // decision; if the user happens to have CELO on-chain, we should still
+    // use it for gas (it doesn't require any CIP-64 fee-adapter approval and
+    // is the simplest path). So we read CELO native balance directly here
+    // rather than relying on the wallet's Redux token registry.
+    //
+    // Fallback: when CELO balance is zero, iterate the wallet's stable fee
+    // currency candidates in priority order (COPm > USDm > USDC > USDT) and
+    // skip any token that is in the spending set — paying gas in a token
+    // that's capped-to-balance leaves zero CIP-64 reserve and the outer tx
+    // reverts.
+    const celoNativeBalance = yield* call(() =>
+      publicClient[Network.Celo].getBalance({ address: walletAddress as Address })
+    )
+    const spendingTokenAddresses = new Set(steps.map((s) => s.tokenId.split(':')[1].toLowerCase()))
 
-    // sendTransaction args are typed via SendTransactionParameters which
-    // expects `chain` when not hoisted on the client. Cast through unknown
-    // because we additionally pass `authorizationList` + CIP-64 `feeCurrency`
-    // which viem permits at runtime but its generic type narrowing trips on
-    // when mixing 7702 with CIP-64 in one call.
+    let feeCurrencyArg: Hex | undefined
+    let pickedSymbol: string
+    if (celoNativeBalance > BigInt(0)) {
+      // CELO native: use type 0x02 (eip1559), no feeCurrency field.
+      feeCurrencyArg = undefined
+      pickedSymbol = 'CELO'
+    } else {
+      const feeCurrencyCandidates = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+
+      // Two kinds of CIP-64 fee currency:
+      //   - Native (isFeeCurrency=true): Mento stables registered with the
+      //     protocol. Gas is debited natively, no allowance required.
+      //   - Adapter-based (feeCurrencyAdapterAddress set): the protocol pulls
+      //     the underlying token via transferFrom on the adapter, which
+      //     requires a prior approve(adapter, allowance) from the user.
+      //
+      // We prefer native fee currencies first because they always work. For
+      // adapter-based ones we verify on-chain allowance before committing,
+      // since the protocol's pre-tx gas debit happens BEFORE the batch
+      // executes, so we can't bootstrap allowance inside this same tx.
+      // 1e30 wei: ~1T units of an 18-decimal token, far above any single tx's
+      // gas cost. We treat allowance above this as "infinite" so we don't
+      // bother re-approving. Built via repeated multiplication because the
+      // current tsconfig target rejects BigInt exponentiation.
+      let ALLOWANCE_THRESHOLD = BigInt(1)
+      for (let _i = 0; _i < 30; _i++) ALLOWANCE_THRESHOLD = ALLOWANCE_THRESHOLD * BigInt(10)
+      let chosen: { token: (typeof feeCurrencyCandidates)[number]; txAddress: Address } | undefined
+
+      for (const candidate of feeCurrencyCandidates) {
+        if (!candidate.balance.gt(0)) continue
+        if (!candidate.address) continue
+        if (spendingTokenAddresses.has(candidate.address.toLowerCase())) continue
+
+        if (candidate.isFeeCurrency) {
+          chosen = { token: candidate, txAddress: candidate.address as Address }
+          break
+        }
+
+        if (candidate.feeCurrencyAdapterAddress) {
+          const allowance = yield* call(() =>
+            publicClient[Network.Celo].readContract({
+              address: candidate.address as Address,
+              abi: erc20Abi,
+              functionName: 'allowance',
+              args: [walletAddress as Address, candidate.feeCurrencyAdapterAddress as Address],
+            })
+          )
+          if (allowance >= ALLOWANCE_THRESHOLD) {
+            chosen = { token: candidate, txAddress: candidate.feeCurrencyAdapterAddress }
+            break
+          }
+          Logger.info(
+            TAG,
+            `skipping ${candidate.symbol} as fee currency: adapter allowance insufficient (${allowance.toString()})`
+          )
+        }
+      }
+
+      if (!chosen) {
+        throw new Error(
+          'No usable fee currency: need CELO native, a native Mento fee currency, or a pre-approved adapter outside the spending set'
+        )
+      }
+      feeCurrencyArg = chosen.txAddress as Hex
+      pickedSymbol = chosen.token.symbol
+    }
+    Logger.info(TAG, `picked fee currency: ${pickedSymbol} (${feeCurrencyArg ?? 'native CELO'})`)
+
     const sendArgs = {
       account,
       to: walletAddress as Address,
       data: calldata,
-      authorizationList: [authorization],
-      feeCurrency: feeCurrencyAddress,
+      ...(feeCurrencyArg && { feeCurrency: feeCurrencyArg }),
     } as unknown as Parameters<typeof wallet.sendTransaction>[0]
 
     const hash = yield* call(() => wallet.sendTransaction(sendArgs))
 
     Logger.info(TAG, `Submitted 7702 dollarsSpend batch: ${hash}`)
+
+    // Aggregate the planned outcomes across all legs:
+    //   - totalInAmount: COPm received (sum of per-leg quote.swapAmount.TO)
+    //   - totalOutUsd:   USD value spent (sum of per-leg usd contributions)
+    //
+    // Atomic batches consume multiple from-tokens (USDm + USDC + USDT) but the
+    // SwapTransaction shape only has ONE outAmount. We aggregate by USD value
+    // (1:1 across stables) and pin the display tokenId to USDm, which the feed
+    // renders as "Dolares" via SwapFeedItem.getTokenName(). That matches what
+    // the user spent ("$3") instead of showing only the largest leg ("$1.02").
+    const totalInAmount = stepOutcomes.reduce(
+      (acc, o) => acc.plus(o.inAmountTokenWhole),
+      new BigNumber(0)
+    )
+    const totalOutUsd = stepOutcomes.reduce((acc, o) => acc.plus(o.usd), new BigNumber(0))
+
+    // Optimistic standby tx so the feed shows the swap immediately, before the
+    // indexer (Valora or TuCop backend WRI Track C) classifies the type 0x02
+    // self-to-self execute() call. The standby is auto-deduped from
+    // transactions/slice when the real feed brings the same hash.
+    if (stepOutcomes.length > 0) {
+      // feeCurrencyId is omitted when paying gas in CELO native — the wallet's
+      // tokens registry excludes CELO (ALLOWED_TOKEN_IDS), so setting it would
+      // make handleTransactionReceiptReceived log a noisy "No information found
+      // for fee currency" error when the receipt enriches the standby. For
+      // adapter / non-CELO fee currencies, pass the tokenId so the UI can show
+      // the fee in the correct token.
+      const feeCurrencyId = feeCurrencyArg
+        ? `celo-mainnet:${feeCurrencyArg.toLowerCase()}`
+        : undefined
+      // Value convention: whole tokens with decimal (Valora-compatible). The
+      // wallet's UI assumes whole-token strings; emitting wei here would
+      // display amounts 10^decimals too large.
+      yield* put(
+        addStandbyTransaction({
+          context: newTransactionContext(TAG, 'Dolares -> Pesos atomic batch'),
+          networkId: NetworkId['celo-mainnet'],
+          type: TokenTransactionTypeV2.SwapTransaction,
+          transactionHash: hash,
+          inAmount: {
+            tokenId: toTokenId,
+            value: totalInAmount.toFixed(),
+          },
+          outAmount: {
+            tokenId: networkConfig.usdmTokenId,
+            value: totalOutUsd.toFixed(),
+          },
+          ...(feeCurrencyId && { feeCurrencyId }),
+        })
+      )
+    }
 
     // Mark each step as succeeded optimistically — the batch is atomic, so
     // once submitted the user-facing progress reaches 100%. A production
@@ -217,6 +409,27 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       yield* put(multiSwapStepSucceeded({ index: i }))
     }
     yield* put(multiSwapCompleted())
+
+    // Navigate to TransactionSuccessScreen, mirroring the legacy swap saga
+    // (src/swap/saga.ts), the gold saga, the send saga, and the earn saga.
+    // The success screen renders a StateCard with title + amounts + explorer
+    // link, and its "Continuar" button takes the user to TabActivity (the
+    // activity / history tab). Previously the saga called navigateHome()
+    // directly, skipping the success screen entirely and breaking parity
+    // with every other transaction flow in the wallet.
+    //
+    // Aggregate amounts: fromAmount is total USD spent (1:1 USDm), toAmount
+    // is total COPm received, fromTokenId is pinned to USDm (renders as
+    // "Dolares" via the brand label resolver).
+    navigate(Screens.TransactionSuccessScreen, {
+      fromTokenId: networkConfig.usdmTokenId,
+      toTokenId,
+      fromAmount: totalOutUsd.toFixed(),
+      toAmount: totalInAmount.toFixed(),
+      transactionHash: hash,
+      networkId: NetworkId['celo-mainnet'],
+      type: 'swap' as const,
+    })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     Logger.warn(TAG, `7702 batch failed: ${message}`)

--- a/src/dollarsSpend/slice.ts
+++ b/src/dollarsSpend/slice.ts
@@ -6,6 +6,10 @@ interface InFlight {
   completedSteps: number
   failedAtIndex: number | null
   lastError: string | null
+  // When the 7702 atomic path runs, the entire plan resolves in a single tx.
+  // The progress sheet hides the "Paso X de N" counter and shows a single
+  // "Procesando tu cambio" copy because the per-step granularity is meaningless.
+  isAtomic: boolean
 }
 
 export interface State {
@@ -25,12 +29,13 @@ const slice = createSlice({
   name: 'dollarsSpend',
   initialState,
   reducers: {
-    multiSwapStarted(state, action: PayloadAction<{ steps: SpendStep[] }>) {
+    multiSwapStarted(state, action: PayloadAction<{ steps: SpendStep[]; isAtomic?: boolean }>) {
       state.inFlight = {
         plannedSteps: action.payload.steps,
         completedSteps: 0,
         failedAtIndex: null,
         lastError: null,
+        isAtomic: action.payload.isAtomic ?? false,
       }
       state.transitioning = false
     },

--- a/src/dollarsSpend/useMultiSwapQuote.ts
+++ b/src/dollarsSpend/useMultiSwapQuote.ts
@@ -8,6 +8,12 @@ import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'dollarsSpend/useMultiSwapQuote'
 
+// Wait this long after the user's last input before firing N parallel quotes.
+// Squid enforces a 10 RPS per-wallet limit; for a 3-token Dolares plan we hit
+// it with 3 simultaneous requests per change. Debouncing collapses keystroke
+// bursts into a single batch and keeps headroom for retries.
+const MULTI_QUOTE_DEBOUNCE_MS = 500
+
 interface UseMultiSwapQuoteResult {
   loading: boolean
   totalInUsd: BigNumber
@@ -16,6 +22,11 @@ interface UseMultiSwapQuoteResult {
   // USD value of the planned steps that could NOT be quoted (no Squid route
   // for that fromToken -> toToken pair, etc.). 0 when all steps resolve.
   unquotedUsd: BigNumber
+  // Sum of (step.amountUsd * stepQuote.appFeePercentageIncludedInPrice / 100)
+  // across fulfilled quotes. Surfaced so the SwapScreen can show a real
+  // "Tarifa de TuCop" for the aggregate Dolares -> Pesos path instead of
+  // falling back to "Desconocido".
+  aggregateAppFeeUsd: BigNumber
   error?: Error
 }
 
@@ -34,6 +45,7 @@ export function useMultiSwapQuote(
   const [perStepQuotes, setPerStepQuotes] = useState<FetchSwapQuoteResult[]>([])
   const [totalOutToken, setTotalOutToken] = useState<BigNumber>(new BigNumber(0))
   const [unquotedUsd, setUnquotedUsd] = useState<BigNumber>(new BigNumber(0))
+  const [aggregateAppFeeUsd, setAggregateAppFeeUsd] = useState<BigNumber>(new BigNumber(0))
 
   const totalInUsd = steps.reduce((sum, s) => sum.plus(s.amountUsd), new BigNumber(0))
 
@@ -47,68 +59,103 @@ export function useMultiSwapQuote(
       setPerStepQuotes([])
       setTotalOutToken(new BigNumber(0))
       setUnquotedUsd(new BigNumber(0))
+      setAggregateAppFeeUsd(new BigNumber(0))
       setError(undefined)
       return
     }
 
-    let cancelled = false
+    // Mark loading while debouncing too — UI should show spinner the whole
+    // time, not flicker between idle and loading on each keystroke.
     setLoading(true)
     setError(undefined)
 
-    // Use allSettled instead of all: one missing Squid route shouldn't zero
-    // out the whole aggregated quote. The UI still surfaces the missing USD
-    // amount via `unquotedUsd` so callers can show a partial-coverage banner.
-    void Promise.allSettled(
-      steps.map((step) => {
-        // The /getSwapQuote endpoint expects the sell amount in the token's
-        // smallest unit (wei). The planner carries the amount in whole units,
-        // so shift by the token's decimals here. ROUND_DOWN avoids ever
-        // requesting more than the user actually holds.
-        const amountInWei = step.amountTokenWhole
-          .shiftedBy(step.decimals)
-          .toFixed(0, BigNumber.ROUND_DOWN)
-        return fetchSwapQuote({
-          fromTokenId: step.tokenId,
-          toTokenId,
-          amount: amountInWei,
-          walletAddress,
-        })
-      })
-    ).then((settled) => {
+    // AbortController is shared across all N parallel quotes for this effect
+    // cycle. When the user keeps typing (or unmounts), the cleanup function
+    // aborts every in-flight quote so we don't write stale data to state and,
+    // critically, don't keep the user's per-wallet Squid bucket overdrawn.
+    const controller = new AbortController()
+    let cancelled = false
+
+    const debounceTimer = setTimeout(() => {
       if (cancelled) return
-      const fulfilled: FetchSwapQuoteResult[] = []
-      let missingUsd = new BigNumber(0)
-      let lastError: Error | undefined
-      settled.forEach((result, index) => {
-        if (result.status === 'fulfilled') {
-          fulfilled.push(result.value)
-        } else {
-          const step = steps[index]
-          missingUsd = missingUsd.plus(step.amountUsd)
-          const reason =
-            result.reason instanceof Error ? result.reason : new Error(String(result.reason))
-          lastError = reason
-          Logger.warn(
-            TAG,
-            `Quote unavailable for step ${index} (${step.symbol}, $${step.amountUsd.toFormat(2)}): ${reason.message}`
-          )
-        }
+      void Promise.allSettled(
+        steps.map((step) => {
+          // The /getSwapQuote endpoint expects the sell amount in the token's
+          // smallest unit (wei). The planner carries the amount in whole units,
+          // so shift by the token's decimals here. ROUND_DOWN avoids ever
+          // requesting more than the user actually holds.
+          const amountInWei = step.amountTokenWhole
+            .shiftedBy(step.decimals)
+            .toFixed(0, BigNumber.ROUND_DOWN)
+          return fetchSwapQuote({
+            fromTokenId: step.tokenId,
+            toTokenId,
+            amount: amountInWei,
+            walletAddress,
+            signal: controller.signal,
+            // Planning fan-out: N parallel quotes for the same wallet that
+            // would otherwise drain the Squid 10 RPS bucket. quoteOnly=true
+            // tells Squid to skip the executable tx build (no rate-limit
+            // charge), and the saga later refetches with quoteOnly=false at
+            // commit time via fetchSwapQuoteForExecution.
+            quoteOnly: true,
+          })
+        })
+      ).then((settled) => {
+        if (cancelled) return
+        const fulfilled: FetchSwapQuoteResult[] = []
+        let missingUsd = new BigNumber(0)
+        let lastError: Error | undefined
+        settled.forEach((result, index) => {
+          if (result.status === 'fulfilled') {
+            fulfilled.push(result.value)
+          } else {
+            const step = steps[index]
+            missingUsd = missingUsd.plus(step.amountUsd)
+            const reason =
+              result.reason instanceof Error ? result.reason : new Error(String(result.reason))
+            // AbortError is expected when inputs change mid-flight; don't
+            // surface it as an error to the UI or to logs.
+            if (reason.name === 'AbortError') {
+              return
+            }
+            lastError = reason
+            Logger.warn(
+              TAG,
+              `Quote unavailable for step ${index} (${step.symbol}, $${step.amountUsd.toFormat(2)}): ${reason.message}`
+            )
+          }
+        })
+        // q.swapAmount.TO is the API's `buyAmount` in wei. Sum in wei (exact),
+        // then shift once to whole units for display.
+        const sumOutWei = fulfilled.reduce((sum, q) => sum.plus(q.swapAmount.TO), new BigNumber(0))
+        const sumOutWhole = sumOutWei.shiftedBy(-toTokenDecimals)
+        // Aggregate app-fee in USD: sum across legs of
+        //   step.amountUsd * (stepQuote.appFeePercentageIncludedInPrice / 100).
+        // Squid returns appFeePercentageIncludedInPrice as a string decimal
+        // (e.g. "0.6" for 0.6%); legs without the field contribute 0.
+        const sumAppFeeUsd = fulfilled.reduce((sum, q, i) => {
+          const pct = new BigNumber(q.appFeePercentageIncludedInPrice ?? 0)
+          if (!pct.isFinite() || pct.lte(0)) return sum
+          const step = steps[i]
+          if (!step) return sum
+          return sum.plus(step.amountUsd.multipliedBy(pct).dividedBy(100))
+        }, new BigNumber(0))
+        setPerStepQuotes(fulfilled)
+        setTotalOutToken(sumOutWhole)
+        setUnquotedUsd(missingUsd)
+        setAggregateAppFeeUsd(sumAppFeeUsd)
+        // Only surface error when nothing could be quoted; partial success
+        // is a recoverable state for the UI.
+        setError(fulfilled.length === 0 ? lastError : undefined)
+        setLoading(false)
       })
-      // q.swapAmount.TO is the API's `buyAmount` in wei. Sum in wei (exact),
-      // then shift once to whole units for display.
-      const sumOutWei = fulfilled.reduce((sum, q) => sum.plus(q.swapAmount.TO), new BigNumber(0))
-      const sumOutWhole = sumOutWei.shiftedBy(-toTokenDecimals)
-      setPerStepQuotes(fulfilled)
-      setTotalOutToken(sumOutWhole)
-      setUnquotedUsd(missingUsd)
-      // Only surface error when nothing could be quoted; partial success
-      // is a recoverable state for the UI.
-      setError(fulfilled.length === 0 ? lastError : undefined)
-      setLoading(false)
-    })
+    }, MULTI_QUOTE_DEBOUNCE_MS)
 
     return () => {
       cancelled = true
+      clearTimeout(debounceTimer)
+      controller.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stepsKey, toTokenId, walletAddress])
@@ -119,6 +166,7 @@ export function useMultiSwapQuote(
     totalOutToken,
     perStepQuotes,
     unquotedUsd,
+    aggregateAppFeeUsd,
     error,
   }
 }

--- a/src/earn/EarnConfirmationScreen.test.tsx
+++ b/src/earn/EarnConfirmationScreen.test.tsx
@@ -155,7 +155,7 @@ describe('EarnConfirmationScreen', () => {
       pool: { ...mockEarnPositions[0], balance: '10.75' },
       rewardsPositions: [mockRewardsPositions[1]],
       walletAddress: mockAccount.toLowerCase(),
-      hooksApiUrl: 'https://api.mainnet.valora.xyz/hooks-api',
+      hooksApiUrl: 'https://tucop-backend-production.up.railway.app/hooks-api',
       amount: '10.75',
       useMax: true,
     })
@@ -201,7 +201,7 @@ describe('EarnConfirmationScreen', () => {
       pool: { ...mockEarnPositions[0], balance: '10.75' },
       rewardsPositions: [mockRewardsPositions[1]],
       walletAddress: mockAccount.toLowerCase(),
-      hooksApiUrl: 'https://api.mainnet.valora.xyz/hooks-api',
+      hooksApiUrl: 'https://tucop-backend-production.up.railway.app/hooks-api',
       amount: txAmount,
     })
     expect(queryByText('earnFlow.collect.reward')).toBeFalsy()
@@ -246,7 +246,7 @@ describe('EarnConfirmationScreen', () => {
       feeCurrencies: mockStoreBalancesToTokenBalances([mockTokenBalances[mockArbEthTokenId]]),
       pool: { ...mockEarnPositions[0], balance: '10.75' },
       walletAddress: mockAccount.toLowerCase(),
-      hooksApiUrl: 'https://api.mainnet.valora.xyz/hooks-api',
+      hooksApiUrl: 'https://tucop-backend-production.up.railway.app/hooks-api',
       amount: '10.75',
       useMax: true,
       rewardsPositions: [mockRewardsPositions[1]],

--- a/src/earn/EarnHome.test.tsx
+++ b/src/earn/EarnHome.test.tsx
@@ -8,10 +8,11 @@ import { Status } from 'src/earn/slice'
 import { EarnTabType } from 'src/earn/types'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
+import { NetworkId } from 'src/transactions/types'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
-import { mockEarnPositions, mockTokenBalances } from 'test/values'
+import { mockCusdAddress, mockCusdTokenId, mockEarnPositions, mockTokenBalances } from 'test/values'
 
 jest.mock('src/statsig')
 
@@ -126,16 +127,27 @@ describe('EarnHome', () => {
   describe('Neeru Vaults gate', () => {
     const neeruPool = {
       ...mockEarnPositions[0],
-      positionId:
-        'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
+      positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
       address: '0xd05cdf2dc56d97333c547519df58d56145766294',
-      networkId: 'celo-mainnet',
+      networkId: NetworkId['celo-mainnet'],
       appId: 'neeru-vaults',
       appName: 'Neeru Vaults',
       displayProps: {
         ...mockEarnPositions[0].displayProps,
         title: 'NEERU_TEST_TITLE_30D',
       },
+      // EarnHome filters out pools whose tokens aren't in the user's tokenList.
+      // mockEarnPositions[0] inherits arbitrum tokens, which a Celo-only app
+      // strips. Pin to a Celo token present in mockTokenBalances so the gate
+      // assertions actually exercise the filter.
+      tokens: [
+        {
+          ...mockEarnPositions[0].tokens[0],
+          tokenId: mockCusdTokenId,
+          networkId: NetworkId['celo-mainnet'],
+          address: mockCusdAddress,
+        },
+      ],
     }
 
     const storeWithNeeru = createMockStore({
@@ -152,17 +164,16 @@ describe('EarnHome', () => {
       },
     })
 
+    const neeruPoolCardTestId = `PoolCard/${neeruPool.positionId}`
+
     it('hides neeru-vaults pools when SHOW_NEERU_VAULTS gate is off (default)', () => {
       // beforeEach already mocks gate so only SHOW_POSITIONS is true.
-      const { queryByText } = render(
+      const { queryByTestId } = render(
         <Provider store={storeWithNeeru}>
-          <MockedNavigator
-            component={EarnHome}
-            params={{ activeEarnTab: EarnTabType.AllPools }}
-          />
+          <MockedNavigator component={EarnHome} params={{ activeEarnTab: EarnTabType.AllPools }} />
         </Provider>
       )
-      expect(queryByText('NEERU_TEST_TITLE_30D')).toBeNull()
+      expect(queryByTestId(neeruPoolCardTestId)).toBeNull()
     })
 
     it('shows neeru-vaults pools when SHOW_NEERU_VAULTS gate is on', () => {
@@ -170,18 +181,14 @@ describe('EarnHome', () => {
         .mocked(getFeatureGate)
         .mockImplementation(
           (g) =>
-            g === StatsigFeatureGates.SHOW_POSITIONS ||
-            g === StatsigFeatureGates.SHOW_NEERU_VAULTS
+            g === StatsigFeatureGates.SHOW_POSITIONS || g === StatsigFeatureGates.SHOW_NEERU_VAULTS
         )
-      const { getByText } = render(
+      const { getByTestId } = render(
         <Provider store={storeWithNeeru}>
-          <MockedNavigator
-            component={EarnHome}
-            params={{ activeEarnTab: EarnTabType.AllPools }}
-          />
+          <MockedNavigator component={EarnHome} params={{ activeEarnTab: EarnTabType.AllPools }} />
         </Provider>
       )
-      expect(getByText('NEERU_TEST_TITLE_30D')).toBeTruthy()
+      expect(getByTestId(neeruPoolCardTestId)).toBeTruthy()
     })
   })
 })

--- a/src/home/saga.ts
+++ b/src/home/saga.ts
@@ -1,4 +1,5 @@
 import { Actions as AccountActions } from 'src/account/actions'
+import { multiSwapCompleted } from 'src/dollarsSpend/slice'
 import { depositSuccess, withdrawSuccess } from 'src/earn/slice'
 import { createFiatConnectTransferCompleted } from 'src/fiatconnect/slice'
 import { notificationsChannel } from 'src/firebase/firebase'
@@ -63,6 +64,10 @@ export function* watchRefreshBalances() {
       createFiatConnectTransferCompleted.type,
       depositTransactionSucceeded.type,
       swapSuccess.type,
+      // 7702 atomic batch (Dolares -> Pesos) marks completion without
+      // emitting per-step swapSuccess actions, so we need its own trigger
+      // here for the home screen balances to refresh.
+      multiSwapCompleted.type,
     ],
     safely(withLoading(withTimeout(REFRESH_TIMEOUT, refreshAllBalances)))
   )

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -2090,4 +2090,19 @@ export const migrations = {
       },
     }
   },
+  251: (state: any) => {
+    // Track C: dollarsSpend `inFlight.isAtomic` flag. If a user persisted an
+    // in-flight from before the migration, default to false (legacy multi-step).
+    if (!state.dollarsSpend?.inFlight) return state
+    return {
+      ...state,
+      dollarsSpend: {
+        ...state.dollarsSpend,
+        inFlight: {
+          ...state.dollarsSpend.inFlight,
+          isAtomic: false,
+        },
+      },
+    }
+  },
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -143,7 +143,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 250,
+          "version": 251,
         },
         "account": {
           "acceptedTerms": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -63,7 +63,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 250,
+  version: 251,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -231,6 +231,10 @@ const preparedTransactions: SerializableTransactionRequest[] = [
     data: '0x095ea7b3000000000000000000000000000000000000000000000000000000000000012300000000000000000000000000000000000000000000000011200c7644d50000',
     from: '0x0000000000000000000000000000000000007E57',
     gas: '21000',
+    // 21000 * 60 / 100 = 12600 (matches the calibration added in
+    // src/viem/prepareTransactions.ts:tryEstimateTransaction to make
+    // getEstimatedGasFee reflect realistic on-chain usage instead of LIMIT)
+    _estimatedGasUse: '12600',
     maxFeePerGas: '12000000000',
     maxPriorityFeePerGas: '2000000000',
     _baseFeePerGas: '6000000000',
@@ -240,6 +244,9 @@ const preparedTransactions: SerializableTransactionRequest[] = [
     data: '0x0',
     from: '0x0000000000000000000000000000000000007E57',
     gas: '1800000',
+    // The swap (second) tx has no fresh estimateGas call in this fixture so
+    // _estimatedGasUse stays undefined, matching the actual saga output.
+    _estimatedGasUse: undefined,
     maxFeePerGas: '12000000000',
     maxPriorityFeePerGas: '2000000000',
     _baseFeePerGas: '6000000000',
@@ -1279,8 +1286,14 @@ describe('SwapScreen', () => {
       gas: 1821000,
       maxGasFee: 0.021852,
       maxGasFeeUsd: 0.28529642665785426,
-      estimatedGasFee: 0.014568,
-      estimatedGasFeeUsd: 0.19019761777190283,
+      // _estimatedGasUse calibration: approval tx has 21000 * 0.6 = 12600,
+      // swap tx falls back to its 1.8M gas limit (no fresh estimateGas in
+      // the fixture). Total estimated gas = 12600 + 1800000 = 1812600.
+      // estimatedGasFee = 1812600 * (6 + 2) Gwei = 14_500_800_000_000_000 wei
+      //                 = 0.0145008 CELO (vs 0.014568 pre-calibration)
+      estimatedGasFee: 0.0145008,
+      estimatedGasFeeUsd: 0.1893202646750967,
+      appFeePercentageIncludedInPrice: undefined,
       feeCurrency: undefined,
       feeCurrencySymbol: 'CELO',
       txCount: 2,
@@ -1620,7 +1633,7 @@ describe('SwapScreen', () => {
     fireEvent.press(confirmDecrease)
 
     expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '1.2165184' // 1.234 minus the max fee calculated for the swap
+      '1.21659904' // 1.234 minus the max fee calculated for the swap (uses calibrated _estimatedGasUse = gas * 0.6)
     )
 
     await act(() => {
@@ -1673,7 +1686,7 @@ describe('SwapScreen', () => {
     fireEvent.press(confirmDecrease)
 
     expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '1.2165184' // 1.234 (max balance) minus the max fee calculated for the swap
+      '1.21659904' // 1.234 (max balance) minus the max fee calculated for the swap (calibrated _estimatedGasUse = gas * 0.6)
     )
 
     await act(() => {

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -54,7 +54,11 @@ import { currentSwapSelector, priceImpactWarningThresholdSelector } from 'src/sw
 import { swapStart } from 'src/swap/slice'
 import { AppFeeAmount, Field, SwapAmount, SwapFeeAmount } from 'src/swap/types'
 import useFilterChips from 'src/swap/useFilterChips'
-import useSwapQuote, { NO_QUOTE_ERROR_MESSAGE, QuoteResult } from 'src/swap/useSwapQuote'
+import useSwapQuote, {
+  NO_QUOTE_ERROR_MESSAGE,
+  QuoteResult,
+  SWAP_UPSTREAM_TRANSIENT_ERROR,
+} from 'src/swap/useSwapQuote'
 import { useSwappableTokens, useTokenInfo } from 'src/tokens/hooks'
 import {
   feeCurrenciesSelector,
@@ -75,7 +79,28 @@ import { v4 as uuidv4 } from 'uuid'
 
 const TAG = 'SwapScreen'
 
-const FETCH_UPDATED_QUOTE_DEBOUNCE_TIME = 200
+// Bumped from 200ms to 500ms after measuring 429 amplification in prod:
+// Squid enforces a 10 RPS per-wallet limit, and 200ms allows up to 5 hits per
+// second on typing. 500ms collapses keystroke bursts into a single quote call
+// while still feeling responsive. See useMultiSwapQuote for the matching
+// debounce on the multi-step Dolares -> Pesos path.
+const FETCH_UPDATED_QUOTE_DEBOUNCE_TIME = 500
+
+// Hard floor for any swap leg. Below this, Squid's routes for stablecoin /
+// COPm pairs hit minimum-input or slippage failures and the tx reverts on
+// chain (verified with 1000 COPm -> USDC at ~$0.29 USD, tx
+// 0xec65f5d042014201173a4e90204ddf4f2f0db89fdf871998172ea7a0885cfece).
+// We gate the Confirm button when the requested USD value falls below this
+// threshold so the user is never asked to spend gas on a doomed swap.
+//
+// Threshold = $0.50, not $1.00, because user-facing token amounts come from
+// real on-chain priceUsd which deviates from a perfect peg (USDT typically
+// ~$0.998, USDC ~$1.001). "1 USDT" looks like a dollar to the user but the
+// USD value math is $0.998. A $1 threshold would block "1 of any stable"
+// most of the time, which is hostile UX. $0.50 still blocks the actual
+// failure cases without surprising the user.
+const MIN_SWAP_USD = 0.5
+
 const DEFAULT_INPUT_SWAP_AMOUNT: SwapAmount = {
   [Field.FROM]: '',
   [Field.TO]: '',
@@ -428,9 +453,20 @@ export function SwapScreen({ route }: Props) {
     AppAnalytics.track(SwapEvents.swap_screen_open)
   }, [])
 
+  const isTransientUpstreamError =
+    !!fetchSwapQuoteError?.message?.includes(SWAP_UPSTREAM_TRANSIENT_ERROR) ||
+    !!multiSwapQuote.error?.message?.includes(SWAP_UPSTREAM_TRANSIENT_ERROR)
+
   useEffect(() => {
     if (fetchSwapQuoteError) {
-      if (!fetchSwapQuoteError.message.includes(NO_QUOTE_ERROR_MESSAGE)) {
+      if (
+        !fetchSwapQuoteError.message.includes(NO_QUOTE_ERROR_MESSAGE) &&
+        // Transient upstream errors (429 exhausted / 502 squid down) show as
+        // an inline notification below the swap inputs so the user can just
+        // try again. Surfacing them in the generic "Algo no salio" sheet
+        // makes a recoverable backend hiccup look like the app is broken.
+        !isTransientUpstreamError
+      ) {
         showErrorMessage({
           error: fetchSwapQuoteError,
           context: { screen: 'SwapScreen', action: 'fetchSwapQuote' },
@@ -438,7 +474,7 @@ export function SwapScreen({ route }: Props) {
         })
       }
     }
-  }, [fetchSwapQuoteError])
+  }, [fetchSwapQuoteError, isTransientUpstreamError])
 
   useEffect(() => {
     // since we use the quote to update the parsedSwapAmount,
@@ -746,6 +782,15 @@ export function SwapScreen({ route }: Props) {
   ).find((token) => token.isNative)
   const crossChainFee = getCrossChainFee(quote, crossChainFeeCurrency)
 
+  // Compute the swap value in USD so we can gate against the wallet-wide
+  // MIN_SWAP_USD floor regardless of whether the user is on the legacy
+  // single-token path or the virtual Dolares aggregate path.
+  const swapValueUsd = useMemo(() => {
+    if (isVirtualDolares) return fromAmountUsd
+    if (!fromToken || !fromToken.priceUsd) return new BigNumber(0)
+    return parsedSwapAmount[Field.FROM].multipliedBy(fromToken.priceUsd)
+  }, [isVirtualDolares, fromAmountUsd, fromToken, parsedSwapAmount])
+
   const getWarningStatuses = () => {
     // NOTE: If a new condition is added here, make sure to update `allowSwap` below if
     // the condition should prevent the user from swapping.
@@ -753,6 +798,12 @@ export function SwapScreen({ route }: Props) {
       showSwitchedToNetworkWarning: !!switchedToNetworkId,
       showUnsupportedTokensWarning:
         !quoteUpdatePending && fetchSwapQuoteError?.message.includes(NO_QUOTE_ERROR_MESSAGE),
+      // Block any swap below MIN_SWAP_USD. Squid's per-route minimums (e.g.
+      // 1000 COPm ~= $0.29) would otherwise let the user confirm a tx that
+      // reverts on chain (gas wasted). Surfaced as a banner before the
+      // "Confirmar intercambio" button.
+      showBelowMinSwapWarning:
+        parsedSwapAmount[Field.FROM].gt(0) && swapValueUsd.gt(0) && swapValueUsd.lt(MIN_SWAP_USD),
       showInsufficientBalanceWarning:
         !isVirtualDolares && parsedSwapAmount[Field.FROM].gt(fromTokenBalance),
       showCrossChainFeeWarning:
@@ -797,9 +848,15 @@ export function SwapScreen({ route }: Props) {
     showPriceImpactWarning,
     showUnsupportedTokensWarning,
     showMissingPriceImpactWarning,
+    showBelowMinSwapWarning,
   } = getWarningStatuses()
 
   const allowSwap = useMemo(() => {
+    if (showBelowMinSwapWarning) return false
+    // No quote was obtained because Squid returned 429/502. The saga would
+    // hit the same upstream and fail, so disable Confirmar until the next
+    // refresh succeeds (the banner above tells the user to retry).
+    if (isTransientUpstreamError) return false
     if (isVirtualDolares) {
       return (
         !!toTokenId &&
@@ -830,14 +887,68 @@ export function SwapScreen({ route }: Props) {
     showDecreaseSpendForGasWarning,
     showNotEnoughBalanceForGasWarning,
     showCrossChainFeeWarning,
+    showBelowMinSwapWarning,
+    isTransientUpstreamError,
   ])
+  // For the Dolares -> Pesos aggregate path the single `quote` is undefined
+  // (the wallet runs N parallel quotes via useMultiSwapQuote). Synthesize the
+  // fee components from the multi-step aggregate so the FeeInfoBottomSheet
+  // shows real values instead of falling back to "Desconocido".
+  //
+  // - Network fee: rough flat estimate per step expressed in USDm (~Celo L2
+  //   gas cost for a swap leg). USDm is in the wallet's token registry so the
+  //   FeeAmount component can display it; CELO native, the real payer, is
+  //   intentionally absent from the registry.
+  // - App fee: the real per-step aggregated Squid app-fee summed in USD,
+  //   surfaced via useMultiSwapQuote.aggregateAppFeeUsd. Also expressed in
+  //   USDm (1:1 with USD for display).
+  //
+  // Calibration: on-chain measurement from tx 0xb7aa617c... showed a 3-step
+  // atomic 7702 batch consumed 793,860 gas at 202 Gwei effective price. At
+  // CELO ~ $0.30 that is $0.048 USD total, i.e. $0.016 per step. We round up
+  // slightly to $0.020 to stay conservative under gas-price spikes; the user
+  // never pays more on-chain than the max anyway.
+  const NETWORK_FEE_USD_PER_STEP_ESTIMATE = new BigNumber(0.02)
+  const NETWORK_FEE_MAX_MULTIPLIER = 1.5 // matches Celo L2 maxFee buffer
+  const usdmTokenForFeeDisplay = useMemo(() => {
+    return tokensById[networkConfig.usdmTokenId]
+  }, [tokensById])
+
   const networkFee: SwapFeeAmount | undefined = useMemo(() => {
+    if (isVirtualDolares) {
+      if (!usdmTokenForFeeDisplay || multiSwapQuote.loading) return undefined
+      const stepCount = multiSwapPlan?.steps.length ?? 0
+      if (stepCount === 0) return undefined
+      const estimateUsd = NETWORK_FEE_USD_PER_STEP_ESTIMATE.multipliedBy(stepCount)
+      return {
+        token: usdmTokenForFeeDisplay,
+        amount: estimateUsd,
+        maxAmount: estimateUsd.multipliedBy(NETWORK_FEE_MAX_MULTIPLIER),
+      }
+    }
     return getNetworkFee(quote)
-  }, [fromToken, quote])
+  }, [isVirtualDolares, multiSwapQuote.loading, multiSwapPlan, usdmTokenForFeeDisplay, quote])
 
   const feeToken = networkFee?.token ? tokensById[networkFee.token.tokenId] : undefined
 
   const appFee: AppFeeAmount | undefined = useMemo(() => {
+    if (isVirtualDolares) {
+      if (!usdmTokenForFeeDisplay || multiSwapQuote.loading) return undefined
+      // Average percentage across the legs that contributed to the aggregate.
+      const fulfilledWithFee = multiSwapQuote.perStepQuotes.filter(
+        (q) => q.appFeePercentageIncludedInPrice
+      )
+      const avgPercentage = fulfilledWithFee.length
+        ? fulfilledWithFee
+            .reduce((sum, q) => sum.plus(q.appFeePercentageIncludedInPrice ?? 0), new BigNumber(0))
+            .dividedBy(fulfilledWithFee.length)
+        : new BigNumber(0)
+      return {
+        amount: multiSwapQuote.aggregateAppFeeUsd,
+        token: usdmTokenForFeeDisplay,
+        percentage: avgPercentage,
+      }
+    }
     if (!quote || !fromToken) {
       return undefined
     }
@@ -849,7 +960,16 @@ export function SwapScreen({ route }: Props) {
       token: fromToken,
       percentage,
     }
-  }, [quote, parsedSwapAmount, fromToken])
+  }, [
+    isVirtualDolares,
+    multiSwapQuote.loading,
+    multiSwapQuote.perStepQuotes,
+    multiSwapQuote.aggregateAppFeeUsd,
+    usdmTokenForFeeDisplay,
+    quote,
+    parsedSwapAmount,
+    fromToken,
+  ])
 
   useEffect(() => {
     if (showPriceImpactWarning || showMissingPriceImpactWarning) {
@@ -1146,6 +1266,24 @@ export function SwapScreen({ route }: Props) {
               variant={NotificationVariant.Warning}
               title={t('swapScreen.missingSwapImpactWarning.title')}
               description={t('swapScreen.missingSwapImpactWarning.body')}
+              style={styles.warning}
+            />
+          )}
+          {showBelowMinSwapWarning && (
+            <InLineNotification
+              variant={NotificationVariant.Warning}
+              title={t('swapScreen.belowMinSwapWarning.title')}
+              description={t('swapScreen.belowMinSwapWarning.body', {
+                minSwapUsd: MIN_SWAP_USD.toFixed(2),
+              })}
+              style={styles.warning}
+            />
+          )}
+          {isTransientUpstreamError && (
+            <InLineNotification
+              variant={NotificationVariant.Warning}
+              title={t('swapScreen.upstreamUnavailableWarning.title')}
+              description={t('swapScreen.upstreamUnavailableWarning.body')}
               style={styles.warning}
             />
           )}

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -28,6 +28,12 @@ const DECREASED_SWAP_AMOUNT_GAS_FEE_MULTIPLIER = 1.2
 
 export const NO_QUOTE_ERROR_MESSAGE = 'No quote available'
 
+// Marker for upstream errors that are transient by nature (429 rate limit
+// exhausted, 502 squid upstream unavailable). SwapScreen recognizes this
+// prefix and shows a friendlier inline "try again" notification instead of
+// the generic crash sheet.
+export const SWAP_UPSTREAM_TRANSIENT_ERROR = 'SWAP_UPSTREAM_TRANSIENT'
+
 export interface FetchSwapQuoteArgs {
   fromTokenId: string
   toTokenId: string
@@ -35,6 +41,19 @@ export interface FetchSwapQuoteArgs {
   amount: string
   walletAddress: string
   slippagePercentage?: string
+  /** Optional signal to cancel an in-flight quote when inputs become stale. */
+  signal?: AbortSignal
+  /**
+   * When true, Squid skips the transactionRequest build and the per-wallet
+   * 10 RPS rate-limit bucket is NOT charged. Use for planning / route-
+   * selection fan-out (e.g. useMultiSwapQuote running N parallel previews).
+   *
+   * The response has empty `to`, `data`, `value`, `gas`, `allowanceTarget`
+   * fields — it is NOT executable. Use false (the default) when the user
+   * commits to a route and the wallet needs the prepared transactions to
+   * actually submit on-chain.
+   */
+  quoteOnly?: boolean
 }
 
 export interface FetchSwapQuoteResult {
@@ -45,6 +64,96 @@ export interface FetchSwapQuoteResult {
   price: string
   provider: string
   estimatedPriceImpact: string | null
+  /** Squid's app-fee percentage included in the price, as decimal string. */
+  appFeePercentageIncludedInPrice?: string
+}
+
+// Fetch `/api/swap/quote` against the TuCop backend (proxy over Squid Router).
+// Squid enforces a per-wallet rate limit of 10 RPS keyed by the userAddress we
+// forward upstream. The backend passes 429 / 502 through unchanged so the
+// wallet can react appropriately:
+//
+//   - 429 (rate limit): respect Retry-After (capped at 5s), otherwise
+//     exponential 0.5s -> 1s -> 2s, up to 3 retries.
+//   - 502 (squid upstream unavailable): single 1s retry, then give up.
+//   - 400 (validation): NEVER retry.
+//   - other: pass through.
+//
+// Two protections against amplifying the user's per-wallet bucket:
+//   1. In-flight dedupe: identical concurrent requests (same query URL, which
+//      encodes every param affecting the upstream answer) share one promise.
+//   2. AbortSignal support: callers cancel in-flight fetches when their
+//      inputs become stale (e.g. user keeps typing in the amount field).
+const SWAP_QUOTE_429_MAX_RETRIES = 3
+const SWAP_QUOTE_429_RETRY_CAP_MS = 5_000
+const SWAP_QUOTE_502_MAX_RETRIES = 1
+const SWAP_QUOTE_502_RETRY_DELAY_MS = 1_000
+
+const inFlightQuoteRequests = new Map<string, Promise<Response>>()
+
+async function fetchSwapQuoteWithBackoff(
+  requestUrl: string,
+  signal?: AbortSignal
+): Promise<Response> {
+  // Share an in-flight request for the same URL. Every caller gets a Response
+  // clone — never the original — so each can independently call .json() or
+  // .text() without competing for the single Response body stream.
+  const existing = inFlightQuoteRequests.get(requestUrl)
+  if (existing) {
+    const shared = await existing
+    return shared.clone()
+  }
+
+  const promise = (async (): Promise<Response> => {
+    let attempts429 = 0
+    let attempts502 = 0
+    while (true) {
+      const response = await fetch(requestUrl, signal ? { signal } : undefined)
+
+      if (response.status === 429) {
+        if (attempts429 >= SWAP_QUOTE_429_MAX_RETRIES) return response
+        const retryAfterRaw = response.headers.get('retry-after')
+        const retryAfterSec = retryAfterRaw ? Number(retryAfterRaw) : NaN
+        const backoffMs = Number.isFinite(retryAfterSec)
+          ? Math.min(retryAfterSec * 1000, SWAP_QUOTE_429_RETRY_CAP_MS)
+          : Math.min(500 * 2 ** attempts429, SWAP_QUOTE_429_RETRY_CAP_MS)
+        attempts429 += 1
+        await new Promise((resolve) => setTimeout(resolve, backoffMs))
+        continue
+      }
+
+      if (response.status === 502) {
+        if (attempts502 >= SWAP_QUOTE_502_MAX_RETRIES) return response
+        attempts502 += 1
+        await new Promise((resolve) => setTimeout(resolve, SWAP_QUOTE_502_RETRY_DELAY_MS))
+        continue
+      }
+
+      // 2xx, 3xx, 400, other 5xx: never retry.
+      return response
+    }
+  })()
+
+  inFlightQuoteRequests.set(requestUrl, promise)
+  // .finally() returns a derived promise that rethrows any rejection from the
+  // original. Without an explicit .catch, the derived promise becomes an
+  // unhandled rejection (Node logs it, jest fails the test). Swallowing here
+  // only affects this side-channel; the real consumer still awaits `promise`
+  // below and handles the error normally.
+  promise
+    .finally(() => {
+      if (inFlightQuoteRequests.get(requestUrl) === promise) {
+        inFlightQuoteRequests.delete(requestUrl)
+      }
+    })
+    .catch(() => {
+      /* cleanup-only side-channel; the real consumer awaits `promise` below */
+    })
+
+  // First caller gets a clone too so the cached promise still has a readable
+  // body for subsequent in-flight callers.
+  const settled = await promise
+  return settled.clone()
 }
 
 /**
@@ -52,7 +161,15 @@ export interface FetchSwapQuoteResult {
  * Used by useMultiSwapQuote to fetch N parallel quotes without React state.
  */
 export async function fetchSwapQuote(args: FetchSwapQuoteArgs): Promise<FetchSwapQuoteResult> {
-  const { fromTokenId, toTokenId, amount, walletAddress, slippagePercentage = '0.5' } = args
+  const {
+    fromTokenId,
+    toTokenId,
+    amount,
+    walletAddress,
+    slippagePercentage = '0.5',
+    signal,
+    quoteOnly,
+  } = args
 
   // Token IDs are in the form "networkId:0xaddress"
   const fromAddress = fromTokenId.split(':')[1]
@@ -70,13 +187,27 @@ export async function fetchSwapQuote(args: FetchSwapQuoteArgs): Promise<FetchSwa
     sellAmount: amount,
     userAddress: walletAddress,
     slippagePercentage,
+    // quoteOnly=true asks Squid to skip the executable transactionRequest
+    // build, which keeps the per-wallet 10 RPS rate-limit bucket idle. The
+    // response is for planning only (empty to/data/value/gas/allowanceTarget).
+    // The wallet calls a fresh quote with quoteOnly=false at commit time to
+    // get the real prepared transactions.
+    ...(quoteOnly && { quoteOnly: 'true' }),
   }
   const queryParams = new URLSearchParams(params).toString()
   const requestUrl = `${networkConfig.getSwapQuoteUrl}?${queryParams}`
-  const response = await fetch(requestUrl)
+  const response = await fetchSwapQuoteWithBackoff(requestUrl, signal)
 
   if (!response.ok) {
-    throw new Error(await response.text())
+    const bodyText = await response.text()
+    // Tag transient upstream errors (429 rate-limit exhausted, 502 squid
+    // down) so callers (useMultiSwapQuote, SwapScreen) can show a softer
+    // "try again" notification instead of the generic crash sheet. The
+    // legacy refreshQuote path tags the same way; keep them in sync.
+    if (response.status === 429 || response.status === 502) {
+      throw new Error(`${SWAP_UPSTREAM_TRANSIENT_ERROR}:${response.status}:${bodyText}`)
+    }
+    throw new Error(bodyText)
   }
 
   const quote: FetchQuoteResponse = await response.json()
@@ -96,6 +227,10 @@ export async function fetchSwapQuote(args: FetchSwapQuoteArgs): Promise<FetchSwa
     price: tx.price,
     provider: quote.details.swapProvider,
     estimatedPriceImpact: tx.estimatedPriceImpact,
+    // Exposed so multi-step previews can aggregate appFee across legs without
+    // having to call the heavier fetchSwapQuoteForExecution path. May be
+    // undefined when Squid does not return an app-fee field for the route.
+    appFeePercentageIncludedInPrice: tx.appFeePercentageIncludedInPrice,
   }
 }
 
@@ -279,10 +414,19 @@ function useSwapQuote({
       }
       const queryParams = new URLSearchParams({ ...params }).toString()
       const requestUrl = `${networkConfig.getSwapQuoteUrl}?${queryParams}`
-      const response = await fetch(requestUrl)
+      const response = await fetchSwapQuoteWithBackoff(requestUrl)
 
       if (!response.ok) {
-        throw new Error(await response.text())
+        const bodyText = await response.text()
+        // Tag transient upstream errors so the SwapScreen can show a softer
+        // "try again" inline notification instead of the generic "Algo no
+        // salio como esperabamos" sheet that the wallet uses for unexpected
+        // failures. 429 reaches here only after the in-flight wrapper has
+        // exhausted its 3 retries; 502 only after the wrapper's single retry.
+        if (response.status === 429 || response.status === 502) {
+          throw new Error(`${SWAP_UPSTREAM_TRANSIENT_ERROR}:${response.status}:${bodyText}`)
+        }
+        throw new Error(bodyText)
       }
 
       const quote: FetchQuoteResponse = await response.json()
@@ -402,7 +546,7 @@ export async function fetchSwapQuoteForExecution(
   }
   const queryParams = new URLSearchParams(params).toString()
   const requestUrl = `${networkConfig.getSwapQuoteUrl}?${queryParams}`
-  const response = await fetch(requestUrl)
+  const response = await fetchSwapQuoteWithBackoff(requestUrl)
 
   if (!response.ok) {
     throw new Error(await response.text())
@@ -415,6 +559,15 @@ export async function fetchSwapQuoteForExecution(
   }
 
   const tx = quote.unvalidatedSwapTransaction
+  // Defensive: a planning quote (quoteOnly=true) returns empty to/data/from
+  // and is NOT executable. This branch should only ever see a commit quote
+  // (quoteOnly=false). If we somehow got a planning response here it means
+  // a caller wired the wrong endpoint and we'd silently broadcast garbage.
+  if (!tx.from || !tx.to || !tx.data) {
+    throw new Error(
+      `fetchSwapQuoteForExecution received a non-executable quote (likely a planning quoteOnly=true response). Refusing to build transactions.`
+    )
+  }
   const preparedTransactions = await prepareSwapTransactions(
     fromToken,
     Field.FROM,

--- a/src/viem/keychainAccountToAccount.ts
+++ b/src/viem/keychainAccountToAccount.ts
@@ -44,6 +44,15 @@ export function keychainAccountToAccount({
   return {
     ...account,
     source: 'keychain',
+    // EIP-7702 support. viem's toAccount() factory only exposes signMessage /
+    // signTransaction / signTypedData on the returned LocalAccount, so the
+    // wallet's signAuthorization Action throws AccountTypeNotSupportedError
+    // ("The signAuthorization Action does not support JSON-RPC Accounts"
+    // — misleading; the underlying check is `if (!account.signAuthorization)`).
+    // Delegate to the unlocked PrivateKeyAccount, which implements it natively.
+    async signAuthorization(...args: Parameters<PrivateKeyAccount['signAuthorization']>) {
+      return getUnlockedAccount().signAuthorization(...args)
+    },
     // This is meant to be called by KeychainAccounts
     unlock: (privateKey: Hex) => {
       const privateKeyAccount = privateKeyToAccount(privateKey)

--- a/src/viem/prepareTransactions.test.ts
+++ b/src/viem/prepareTransactions.test.ts
@@ -189,9 +189,16 @@ describe('prepareTransactions module', () => {
         maxPriorityFeePerGas: BigInt(2),
         baseFeePerGas: BigInt(80),
       })
-      mocked(estimateGas).mockResolvedValue(BigInt(1_000))
+      // Bumped from 1_000 to 1_500 after introducing the realistic
+      // _estimatedGasUse = gas * 0.60 calibration in tryEstimateTransaction.
+      // With gas=1000 the realistic estimate of 600 * 82 = 49,200 fits in
+      // fee currency 2's 70k balance, which would defeat this test's intent.
+      // gas=1500 keeps the realistic estimate (900 * 82 = 73,800) above the
+      // 70k balance limit.
+      mocked(estimateGas).mockResolvedValue(BigInt(1_500))
 
-      // estimated gas fee (80+2)*1k = 82k units, too high for either fee currency
+      // estimated gas fee using _estimatedGasUse (900) * (80+2) = 73.8k units,
+      // too high for either fee currency
 
       const result = await prepareTransactions({
         feeCurrencies: mockFeeCurrencies,
@@ -255,6 +262,7 @@ describe('prepareTransactions module', () => {
             data: '0xdata',
 
             gas: BigInt(1000),
+            _estimatedGasUse: BigInt(600),
             maxFeePerGas: BigInt(100),
             maxPriorityFeePerGas: BigInt(2),
             _baseFeePerGas: BigInt(50),
@@ -522,6 +530,7 @@ describe('prepareTransactions module', () => {
             data: '0xdata',
 
             gas: BigInt(500),
+            _estimatedGasUse: BigInt(300),
             maxFeePerGas: BigInt(1),
             maxPriorityFeePerGas: BigInt(2),
             _baseFeePerGas: BigInt(1),
@@ -584,6 +593,7 @@ describe('prepareTransactions module', () => {
             data: '0xdata',
 
             gas: BigInt(500),
+            _estimatedGasUse: BigInt(300),
             maxFeePerGas: BigInt(1),
             maxPriorityFeePerGas: BigInt(2),
             feeCurrency: mockFeeCurrencies[1].address,
@@ -647,6 +657,7 @@ describe('prepareTransactions module', () => {
             data: '0xdata',
 
             gas: BigInt(500),
+            _estimatedGasUse: BigInt(300),
             maxFeePerGas: BigInt(1),
             maxPriorityFeePerGas: BigInt(2),
             _baseFeePerGas: BigInt(1),
@@ -704,6 +715,7 @@ describe('prepareTransactions module', () => {
             data: '0xdata',
 
             gas: BigInt(500),
+            _estimatedGasUse: BigInt(300),
             maxFeePerGas: BigInt(1),
             maxPriorityFeePerGas: BigInt(2),
             _baseFeePerGas: BigInt(1),
@@ -808,6 +820,7 @@ describe('prepareTransactions module', () => {
       expect(estimateTransactionOutput).toStrictEqual({
         from: '0x123',
         gas: BigInt(123),
+        _estimatedGasUse: BigInt(73), // 123 * 60 / 100 = 73.8 -> 73 (BigInt floor)
         maxFeePerGas: BigInt(456),
         maxPriorityFeePerGas: BigInt(2),
         _baseFeePerGas: BigInt(200),
@@ -828,6 +841,7 @@ describe('prepareTransactions module', () => {
       expect(estimateTransactionOutput).toStrictEqual({
         from: '0x123',
         gas: BigInt(123),
+        _estimatedGasUse: BigInt(73), // 123 * 60 / 100 = 73.8 -> 73 (BigInt floor)
         maxFeePerGas: BigInt(456),
         feeCurrency: '0xabc',
         maxPriorityFeePerGas: BigInt(789),
@@ -907,6 +921,7 @@ describe('prepareTransactions module', () => {
         {
           from: '0x123',
           gas: BigInt(123),
+          _estimatedGasUse: BigInt(73), // 123 * 60 / 100 = 73.8 -> 73 (BigInt floor)
           maxFeePerGas: BigInt(10),
           maxPriorityFeePerGas: BigInt(2),
           _baseFeePerGas: BigInt(5),

--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -168,9 +168,24 @@ export async function tryEstimateTransaction({
       account: tx.from,
     })
     tx._baseFeePerGas = baseFeePerGas
+    // Celo's eth_estimateGas returns a conservative gas LIMIT (the maximum the
+    // tx could consume), produced via a binary search. In practice the gas
+    // USED on-chain for swaps + CIP-64 txs is ~55-65% of that limit (verified
+    // via tx 0xd29dc1d8... and 0xb7aa617c... receipts). Without an explicit
+    // _estimatedGasUse, the wallet's getEstimatedGasFee() falls back to
+    // `tx.gas` (the LIMIT), which makes the displayed "Tarifa de red estimada"
+    // basically equal to "Tarifa máxima de red" — both 2x the real cost.
+    //
+    // Setting _estimatedGasUse to ~60% of the limit aligns the displayed
+    // estimate with the real on-chain cost while keeping getMaxGasFee()
+    // (which uses tx.gas) as a true upper bound. The user is never charged
+    // more than the max, so this is a UI-only improvement.
+    const REALISTIC_GAS_USED_RATIO = BigInt(60) // 60% of limit
+    tx._estimatedGasUse = (tx.gas * REALISTIC_GAS_USED_RATIO) / BigInt(100)
     Logger.info(TAG, `estimateGas results`, {
       feeCurrency: tx.feeCurrency,
       gas: tx.gas,
+      _estimatedGasUse: tx._estimatedGasUse,
       maxFeePerGas,
       maxPriorityFeePerGas,
       baseFeePerGas,

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -95,6 +95,7 @@ interface NetworkConfig {
   getExchangeRateUrl: string
   getXautPriceUrl: string
   blockscoutProxyBase: string
+  wriDelegateRelayUrl: string
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_MAINNET = 'https://eth-mainnet.g.alchemy.com/v2/'
@@ -296,6 +297,7 @@ const CROSS_CHAIN_EXPLORER_URL = 'https://axelarscan.io/gmp/'
 // - /api/v2/...            -> Blockscout passthrough (replaces direct Blockscout calls + key)
 const TUCOP_BACKEND_BASE = 'https://tucop-backend-production.up.railway.app'
 const GET_XAUT_PRICE_URL = `${TUCOP_BACKEND_BASE}/api/prices/xaut?vs=usd`
+const WRI_DELEGATE_RELAY_URL = `${TUCOP_BACKEND_BASE}/api/wri/delegate-relay`
 const BLOCKSCOUT_PROXY_BASE = `${TUCOP_BACKEND_BASE}/api/v2`
 
 const networkConfig: NetworkConfig = {
@@ -412,6 +414,7 @@ const networkConfig: NetworkConfig = {
   getExchangeRateUrl: GET_EXCHANGE_RATE_MAINNET,
   getXautPriceUrl: GET_XAUT_PRICE_URL,
   blockscoutProxyBase: BLOCKSCOUT_PROXY_BASE,
+  wriDelegateRelayUrl: WRI_DELEGATE_RELAY_URL,
 }
 
 const CELOSCAN_BASE_URL_MAINNET = 'https://celoscan.io'

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2240,6 +2240,9 @@
                         "number"
                     ]
                 },
+                "isAtomic": {
+                    "type": "boolean"
+                },
                 "lastError": {
                     "type": [
                         "null",
@@ -2256,6 +2259,7 @@
             "required": [
                 "completedSteps",
                 "failedAtIndex",
+                "isAtomic",
                 "lastError",
                 "plannedSteps"
             ],

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3733,6 +3733,19 @@ export const v250Schema = {
   },
 }
 
+// Migration 251 adds `inFlight.isAtomic` to dollarsSpend so the
+// MultiSwapProgressSheet can differentiate the atomic 7702 path ("Cambiando
+// tus Dolares a Pesos...") from the legacy multi-step path ("Paso X de N")
+// without breaking persisted in-flight state. Only applies when a user has
+// an in-flight multi-swap when the app updates; otherwise no-op.
+export const v251Schema = {
+  ...v250Schema,
+  _persist: {
+    ...v250Schema._persist,
+    version: 251,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v250Schema as Partial<RootState>
+  return v251Schema as Partial<RootState>
 }


### PR DESCRIPTION
## Summary

Completes WRI Track C (atomic EIP-7702 Dolares → Pesos swap) end-to-end and ships related ecosystem hygiene that surfaced during the three-day dogfooding cycle on the v2 spike wallet against Celo mainnet.

9 single-purpose commits — review bottom-up tells the why-story (build infra → patches → wallet-wide gas calibration → relay integration → saga hardening → UI uniformity → balance refresh → swap hygiene).

**8 atomic 7702 batches verified on-chain** (hashes in commit message of `feat(7702/saga)` and in JOURNAL.md). All status 0x1, 14-35 logs each.

## Commits (in dependency order)

1. `chore(env)`: restore `DEFAULT_TESTNET=mainnet` (PR #162 broke iOS build from clean DerivedData)
2. `fix(viem)`: patch `waitForTransactionReceipt` `_unwatch` race (app crash post-revert)
3. `fix(react-native-screens)`: downgrade `attachToAncestor` transient warning (RCTLogError → RCTLogInfo)
4. `fix(viem/prepareTransactions)`: calibrate `_estimatedGasUse = gas * 0.6` (wallet-wide; "Tarifa estimada" was ~2× actual)
5. `feat(wri/saga)`: integrate sponsored EIP-7702 delegate-relay (4 spec gaps closed: no `executor:'self'`, 20s timeout, 429 backoff, 502 with on-chain getCode recheck)
6. `feat(7702/saga)`: harden atomic batch path (on-chain balance cap, CELO native fee currency, removed `authorizationList`, optimistic standby tx, `navigate(TransactionSuccessScreen)`)
7. `feat(dollarsSpend/ui)`: atomic UI uniformity (shared `StateCard`, `isAtomic` flag, migration 251)
8. `feat(home/saga)`: refresh balances on `multiSwapCompleted` (atomic path skips per-step `swapSuccess`)
9. `feat(swap)`: rate-limit hygiene + `quoteOnly` + `MIN_SWAP_USD` gate + transient error banner (4-piece protection: debounce 500ms / in-flight dedupe / AbortController / 429-502-400 backoff)

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/\`: 4147 passed, 2 failed (pre-existing TZ flake in \`src/utils/time.test.ts\`, not introduced here; CI runs UTC and passes)
- [x] Manual: 8 successful atomic 7702 batches against v2 spike wallet on Celo mainnet
- [x] Manual: 502 from backend surfaces as inline banner + disabled Confirm (not generic crash sheet)
- [x] Manual: typing fast in amount input fires ≤1 quote per 500ms of typing-quiet
- [x] Manual: "1 USDT" allowed (was blocked at \$1 threshold); "1000 COPm" (\$0.29) blocked with "Monto muy pequeño" banner
- [x] Manual: saga7702 success navigates to \`TransactionSuccessScreen\` → user tap Continuar → \`TabActivity\` (parity with all other sagas)
- [x] Manual: "Tarifa de TuCop" and "Tarifa de red" no longer "Desconocido" for Dolares→Pesos aggregate path

## Deferred (NOT in this PR)

1. Backend feed indexer (WRI Track C Option C plan at \`TuCOPWallet-Backend/tasks/plans/wri-transaction-feed-indexer.md\`). Atomic 7702 batches not yet visible in feed.
2. Bug E for legacy swap (CELO native preference). Multi-hour selector + saga refactor. Doesn't affect 7702 atomic path.
3. COPm CIP-64 fee-adapter pre-approval bootstrap for users without CELO AND only Mento stables.
4. \`NETWORK_FEE_USD_PER_STEP_ESTIMATE\` dynamic (vs flat \$0.020). Cosmetic, deferable.
5. \`src/utils/time.test.ts formatFeedTime\` pre-existing TZ flake.