### PR TITLE
feat(earn): gate Neeru Vaults card visibility on show_neeru_vaults

### DIFF
--- a/src/earn/EarnHome.test.tsx
+++ b/src/earn/EarnHome.test.tsx
@@ -122,4 +122,66 @@ describe('EarnHome', () => {
     expect(tabItems[0]).toHaveTextContent('earnFlow.poolFilters.allPools')
     expect(tabItems[1]).toHaveTextContent('earnFlow.poolFilters.myPools')
   })
+
+  describe('Neeru Vaults gate', () => {
+    const neeruPool = {
+      ...mockEarnPositions[0],
+      positionId:
+        'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
+      address: '0xd05cdf2dc56d97333c547519df58d56145766294',
+      networkId: 'celo-mainnet',
+      appId: 'neeru-vaults',
+      appName: 'Neeru Vaults',
+      displayProps: {
+        ...mockEarnPositions[0].displayProps,
+        title: 'NEERU_TEST_TITLE_30D',
+      },
+    }
+
+    const storeWithNeeru = createMockStore({
+      tokens: { tokenBalances: { ...mockTokenBalances } },
+      positions: {
+        positions: [mockEarnPositions[0], neeruPool, mockEarnPositions[1]],
+        earnPositionIds: [
+          mockEarnPositions[0].positionId,
+          neeruPool.positionId,
+          mockEarnPositions[1].positionId,
+        ],
+        status: 'success' as Status,
+        positionsFetchedAt: Date.now(),
+      },
+    })
+
+    it('hides neeru-vaults pools when SHOW_NEERU_VAULTS gate is off (default)', () => {
+      // beforeEach already mocks gate so only SHOW_POSITIONS is true.
+      const { queryByText } = render(
+        <Provider store={storeWithNeeru}>
+          <MockedNavigator
+            component={EarnHome}
+            params={{ activeEarnTab: EarnTabType.AllPools }}
+          />
+        </Provider>
+      )
+      expect(queryByText('NEERU_TEST_TITLE_30D')).toBeNull()
+    })
+
+    it('shows neeru-vaults pools when SHOW_NEERU_VAULTS gate is on', () => {
+      jest
+        .mocked(getFeatureGate)
+        .mockImplementation(
+          (g) =>
+            g === StatsigFeatureGates.SHOW_POSITIONS ||
+            g === StatsigFeatureGates.SHOW_NEERU_VAULTS
+        )
+      const { getByText } = render(
+        <Provider store={storeWithNeeru}>
+          <MockedNavigator
+            component={EarnHome}
+            params={{ activeEarnTab: EarnTabType.AllPools }}
+          />
+        </Provider>
+      )
+      expect(getByText('NEERU_TEST_TITLE_30D')).toBeTruthy()
+    })
+  })
 })

--- a/src/earn/EarnHome.tsx
+++ b/src/earn/EarnHome.tsx
@@ -34,6 +34,8 @@ import {
   positionsStatusSelector,
 } from 'src/positions/selectors'
 import { useDispatch, useSelector } from 'src/redux/hooks'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Shadow, Spacing, getShadowStyle } from 'src/styles/styles'
@@ -105,7 +107,15 @@ export default function EarnHome({ navigation, route }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
 
-  const pools = useSelector(earnPositionsSelector)
+  const allPoolsFromBackend = useSelector(earnPositionsSelector)
+  const neeruVaultsEnabled = getFeatureGate(StatsigFeatureGates.SHOW_NEERU_VAULTS)
+  const pools = useMemo(
+    () =>
+      neeruVaultsEnabled
+        ? allPoolsFromBackend
+        : allPoolsFromBackend.filter((p) => p.appId !== 'neeru-vaults'),
+    [allPoolsFromBackend, neeruVaultsEnabled]
+  )
 
   const activeTab = route.params?.activeEarnTab ?? EarnTabType.AllPools
 

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -41,6 +41,7 @@ export enum StatsigFeatureGates {
   ALLOW_EARN_PARTIAL_WITHDRAWAL = 'allow_earn_partial_withdrawal',
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
   SHOW_DIGITAL_GOLD = 'show_digital_gold',
+  SHOW_NEERU_VAULTS = 'show_neeru_vaults',
   WRI_PREFLIGHT_SWAP_SIMULATION = 'wri_preflight_swap_simulation',
   WRI_DOLLARS_SPEND_7702_V1 = 'wri_dollars_spend_7702_v1',
 }


### PR DESCRIPTION
## Summary

- Adds `SHOW_NEERU_VAULTS` to `StatsigFeatureGates` enum.
- Filters out `appId === 'neeru-vaults'` pools from `EarnHome` unless the gate is enabled.
- Default off, so Development build hides the Neeru cards until the rest of the Neeru screens (detail, close flow, emergency exit) ship.

## Why this is urgent

PR #203 already merged: the wallet now consumes `tucop-backend`, which returns 4 Neeru Vaults `EarnPosition` entries in `getEarnPositions`. Without this gate, Development builds would render those cards routed to the generic `EarnPoolInfoScreen` with broken UX (no per-position management, no penalty disclosure, no emergency exit).

Production users are unaffected (their binaries are pinned to the previous Valora URL).

## Companion plan

- `tasks/plans/2026-06-26-neeru-vaults-wallet.md` - Task 22 + Delta A (urgent reorder).

## Test plan

- [ ] CI green (yarn build:ts, yarn lint, yarn test).
- [ ] New `EarnHome.test.tsx` cases: gate off hides Neeru pool by title; gate on shows it.
- [ ] Manual: confirm Development build's Earn screen does NOT show Neeru cards (only Allbridge).

## Rollback

Single line revert in `src/earn/EarnHome.tsx`: remove the gate check, pass `allPoolsFromBackend` directly to `pools`. Statsig enum entry can stay.