### PR TITLE
feat(earn/neeru): phase 1 foundation (constants, ABI, types)

### DIFF
--- a/src/earn/neeru/__tests__/constants.test.ts
+++ b/src/earn/neeru/__tests__/constants.test.ts
@@ -1,0 +1,17 @@
+import { trancheIdFromPositionId } from 'src/earn/neeru/constants'
+
+describe('trancheIdFromPositionId', () => {
+  it('extracts tranche id from a valid Neeru positionId', () => {
+    expect(
+      trancheIdFromPositionId('celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-2')
+    ).toBe(2)
+  })
+  it('returns null for non-Neeru positionId', () => {
+    expect(trancheIdFromPositionId('celo-mainnet:0xabc:allbridge-pool-1')).toBeNull()
+  })
+  it('returns null for out-of-range tranche', () => {
+    expect(
+      trancheIdFromPositionId('celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-9')
+    ).toBeNull()
+  })
+})

--- a/src/earn/neeru/abi.ts
+++ b/src/earn/neeru/abi.ts
@@ -1,0 +1,31 @@
+// Minimal ABI for FondoCOPmMVP. The wallet only needs read paths for
+// defense-in-depth on the close signature; all writes are built by the
+// backend via hooks-api triggerShortcut.
+export const fondoCOPmMVPAbi = [
+  {
+    type: 'function',
+    name: 'positions',
+    stateMutability: 'view',
+    inputs: [{ name: '', type: 'uint256' }],
+    outputs: [
+      { name: 'owner', type: 'address' },
+      { name: 'tranche', type: 'uint8' },
+      { name: 'closed', type: 'bool' },
+      { name: 'principal', type: 'uint256' },
+      { name: 'startTs', type: 'uint256' },
+      { name: 'maturityTs', type: 'uint256' },
+      { name: 'lastAccrualTs', type: 'uint256' },
+      { name: 'dailyRateRay', type: 'uint256' },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'previewAccruedInterest',
+    stateMutability: 'view',
+    inputs: [{ name: 'positionId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  { type: 'error', name: 'InterestPoolLow', inputs: [] },
+  { type: 'error', name: 'AlreadyClosed', inputs: [] },
+  { type: 'error', name: 'NotOwner', inputs: [] },
+] as const

--- a/src/earn/neeru/constants.ts
+++ b/src/earn/neeru/constants.ts
@@ -1,0 +1,28 @@
+import { NetworkId } from 'src/transactions/types'
+
+export const NEERU_APP_ID = 'neeru-vaults'
+
+export const FONDO_COPM_MVP_ADDRESS = '0xd05cdf2dc56d97333c547519df58d56145766294' as const
+export const COPM_TOKEN_ADDRESS = '0x8a567e2ae79ca692bd748ab832081c45de4041ea' as const
+export const COPM_TOKEN_ID = `${NetworkId['celo-mainnet']}:${COPM_TOKEN_ADDRESS}` as const
+export const FONDO_DEPLOY_BLOCK = BigInt(70594026)
+
+export type NeeruTrancheId = 0 | 1 | 2 | 3
+
+// Display order on the Earn screen: highest APR (longest lock) first
+export const NEERU_TRANCHE_IDS: NeeruTrancheId[] = [3, 2, 1, 0]
+
+export const NEERU_TRANCHE_LABEL_KEYS: Record<NeeruTrancheId, string> = {
+  0: 'neeruVaults.tranches.flexible',
+  1: 'neeruVaults.tranches.thirtyDays',
+  2: 'neeruVaults.tranches.sixtyDays',
+  3: 'neeruVaults.tranches.ninetyDays',
+}
+
+export const trancheIdFromPositionId = (positionId: string): NeeruTrancheId | null => {
+  const match = positionId.match(/:tranche-(\d)$/)
+  if (!match) return null
+  const id = Number(match[1])
+  if (id < 0 || id > 3) return null
+  return id as NeeruTrancheId
+}

--- a/src/earn/neeru/types.ts
+++ b/src/earn/neeru/types.ts
@@ -1,0 +1,36 @@
+import { NeeruTrancheId } from 'src/earn/neeru/constants'
+
+export interface NeeruPositionPayout {
+  principal: string // decimal COPm
+  interest: string // decimal COPm
+  penaltyBps: number
+  interestAfterPenalty: string
+  total: string
+  isEarly: boolean
+}
+
+export interface NeeruIndividualPosition {
+  positionId: string
+  tranche: NeeruTrancheId
+  trancheLabel: string
+  principal: string
+  accruedInterest: string
+  dailyRateRay: string
+  monthlyRatePercentage: number
+  startTs: number
+  maturityTs: number
+  depositBlock: number
+  depositTxHash: string
+  renewedFromPositionId: string | null
+  currentPayoutIfClosed: NeeruPositionPayout
+}
+
+export interface NeeruPositionsResponse {
+  address: string
+  positions: NeeruIndividualPosition[]
+  lastSyncedBlock: number
+  lastSyncedAt: string
+}
+
+export type NeeruFetchStatus = 'idle' | 'loading' | 'success' | 'error'
+export type NeeruCloseStatus = 'idle' | 'loading' | 'success' | 'error'


### PR DESCRIPTION
## Summary

Phase 1 of the Neeru Vaults wallet plan: foundation files. No runtime behavior change.

- `src/earn/neeru/constants.ts` - contract address, deploy block, tranche metadata, positionId parser
- `src/earn/neeru/abi.ts` - minimal viem-typed ABI for FondoCOPmMVP (reads only; all writes go through backend triggerShortcut)
- `src/earn/neeru/types.ts` - `NeeruIndividualPosition`, `NeeruPositionPayout`, response shape

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 2-4)

## Test plan

- [ ] CI green
- [ ] Unit tests on constants.test.ts (3 cases, all pass)