### PR TITLE
feat(earn/neeru): phase 2 i18n strings + TS fix

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2907,6 +2907,74 @@
       "noStakes": "You don't have any active stakes"
     }
   },
+  "neeruVaults": {
+    "tranches": {
+      "flexible": "Flexible",
+      "thirtyDays": "30 days",
+      "sixtyDays": "60 days",
+      "ninetyDays": "90 days"
+    },
+    "detail": {
+      "header": "Your {{trancheLabel}} positions",
+      "aggregateBalance": "Total in {{trancheLabel}}",
+      "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% monthly",
+      "depositCta": "Deposit",
+      "noPositions": "You don't have positions in this option yet",
+      "descriptionByTranche": {
+        "flexible": "Withdraw anytime with no minimum lock",
+        "thirtyDays": "Lock your Pesos for 30 days at a higher rate",
+        "sixtyDays": "Lock your Pesos for 60 days at a higher rate",
+        "ninetyDays": "Lock your Pesos for 90 days at the highest rate"
+      },
+      "transparency": {
+        "title": "Transparency",
+        "sourceLine": "Source code",
+        "contractLine": "Contract",
+        "sourceUrl": "https://github.com/NeeruFi/neeru-vaults"
+      }
+    },
+    "positionRow": {
+      "principal": "Principal: {{amount}}",
+      "interest": "Earned: {{amount}}",
+      "maturity": "Available {{date}}",
+      "flexible": "No minimum time",
+      "depositedAt": "Deposited on {{date}}",
+      "manageCta": "Manage"
+    },
+    "closeSheet": {
+      "title": "Withdraw your deposit",
+      "currentPayout": "You will receive",
+      "principalLabel": "Principal",
+      "interestLabel": "Interest earned",
+      "penaltyLabel": "Early withdrawal fee ({{percentage}}%)",
+      "totalLabel": "Total",
+      "earlyWarning": "You are withdrawing before {{date}}. The fee applies only to the interest, never to your principal.",
+      "confirmCta": "Confirm withdrawal"
+    },
+    "emergencyCloseSheet": {
+      "title": "Emergency withdrawal",
+      "subtitle": "The fund cannot pay interest right now",
+      "explanation": "You can recover your principal of {{principal}} now, but you will forfeit the {{interest}} of interest you earned. This is irreversible.",
+      "alternative": "If you can wait, the fund usually recovers within a few hours.",
+      "primaryCta": "Wait and try again later",
+      "secondaryCta": "Withdraw principal only"
+    },
+    "errors": {
+      "fetchPositionsFailed": "We couldn't load your positions. Pull down to retry.",
+      "closeFailed": "We couldn't process the withdrawal. Try again.",
+      "unknown": "Something went wrong. Try again.",
+      "invalidTranche": "Invalid tranche selected.",
+      "invalidAmount": "Invalid amount.",
+      "amountBelowMin": "Minimum deposit: {{minAmount}} Pesos.",
+      "depositsPaused": "Deposits are temporarily paused.",
+      "globalCapExceeded": "The fund is full. Try later.",
+      "trancheCapExceeded": "This option is full. Try another or come back later.",
+      "rateNotSet": "This option is not available right now.",
+      "positionStale": "Refresh your positions and try again.",
+      "positionAlreadyClosed": "This position is already closed.",
+      "serviceUnavailable": "The service is temporarily unavailable. Try later."
+    }
+  },
   "global": {
     "ok": "OK",
     "cancel": "Cancel",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2914,6 +2914,74 @@
       "noStakes": "No tienes ningún stake activo"
     }
   },
+  "neeruVaults": {
+    "tranches": {
+      "flexible": "Flexible",
+      "thirtyDays": "30 dias",
+      "sixtyDays": "60 dias",
+      "ninetyDays": "90 dias"
+    },
+    "detail": {
+      "header": "Tus depositos {{trancheLabel}}",
+      "aggregateBalance": "Total en {{trancheLabel}}",
+      "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% mensual",
+      "depositCta": "Depositar",
+      "noPositions": "Todavia no tienes depositos en esta opcion",
+      "descriptionByTranche": {
+        "flexible": "Retira en cualquier momento, sin tiempo minimo",
+        "thirtyDays": "Bloquea tus Pesos 30 dias a una tasa mas alta",
+        "sixtyDays": "Bloquea tus Pesos 60 dias a una tasa mas alta",
+        "ninetyDays": "Bloquea tus Pesos 90 dias a la tasa mas alta"
+      },
+      "transparency": {
+        "title": "Transparencia",
+        "sourceLine": "Codigo fuente",
+        "contractLine": "Contrato",
+        "sourceUrl": "https://github.com/NeeruFi/neeru-vaults"
+      }
+    },
+    "positionRow": {
+      "principal": "Capital: {{amount}}",
+      "interest": "Ganado: {{amount}}",
+      "maturity": "Disponible el {{date}}",
+      "flexible": "Sin tiempo minimo",
+      "depositedAt": "Depositado el {{date}}",
+      "manageCta": "Gestionar"
+    },
+    "closeSheet": {
+      "title": "Retira tu deposito",
+      "currentPayout": "Recibiras",
+      "principalLabel": "Capital",
+      "interestLabel": "Intereses ganados",
+      "penaltyLabel": "Comision por retiro temprano ({{percentage}}%)",
+      "totalLabel": "Total",
+      "earlyWarning": "Estas retirando antes del {{date}}. La comision se aplica solo al interes, nunca al capital.",
+      "confirmCta": "Confirmar retiro"
+    },
+    "emergencyCloseSheet": {
+      "title": "Retiro de emergencia",
+      "subtitle": "El fondo no puede pagar intereses en este momento",
+      "explanation": "Puedes recuperar tu capital de {{principal}} ahora, pero perderas los {{interest}} de interes que generaste. Esta accion no se puede revertir.",
+      "alternative": "Si puedes esperar, el fondo se recupera generalmente en unas horas.",
+      "primaryCta": "Esperar e intentar despues",
+      "secondaryCta": "Retirar solo el capital"
+    },
+    "errors": {
+      "fetchPositionsFailed": "No pudimos cargar tus depositos. Desliza hacia abajo para reintentar.",
+      "closeFailed": "No pudimos procesar el retiro. Intenta de nuevo.",
+      "unknown": "Algo salio mal. Intenta de nuevo.",
+      "invalidTranche": "Opcion invalida.",
+      "invalidAmount": "Monto invalido.",
+      "amountBelowMin": "Deposito minimo: {{minAmount}} Pesos.",
+      "depositsPaused": "Los depositos estan temporalmente pausados.",
+      "globalCapExceeded": "El fondo esta lleno. Intenta mas tarde.",
+      "trancheCapExceeded": "Esta opcion esta llena. Prueba otra o intenta mas tarde.",
+      "rateNotSet": "Esta opcion no esta disponible en este momento.",
+      "positionStale": "Actualiza tus depositos y reintenta.",
+      "positionAlreadyClosed": "Este deposito ya fue cerrado.",
+      "serviceUnavailable": "El servicio no esta disponible en este momento. Intenta mas tarde."
+    }
+  },
   "global": {
     "ok": "Aceptar",
     "cancel": "Cancelar",

--- a/src/earn/EarnHome.test.tsx
+++ b/src/earn/EarnHome.test.tsx
@@ -8,6 +8,7 @@ import { Status } from 'src/earn/slice'
 import { EarnTabType } from 'src/earn/types'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
+import { NetworkId } from 'src/transactions/types'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
@@ -126,10 +127,9 @@ describe('EarnHome', () => {
   describe('Neeru Vaults gate', () => {
     const neeruPool = {
       ...mockEarnPositions[0],
-      positionId:
-        'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
+      positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
       address: '0xd05cdf2dc56d97333c547519df58d56145766294',
-      networkId: 'celo-mainnet',
+      networkId: NetworkId['celo-mainnet'],
       appId: 'neeru-vaults',
       appName: 'Neeru Vaults',
       displayProps: {
@@ -156,10 +156,7 @@ describe('EarnHome', () => {
       // beforeEach already mocks gate so only SHOW_POSITIONS is true.
       const { queryByText } = render(
         <Provider store={storeWithNeeru}>
-          <MockedNavigator
-            component={EarnHome}
-            params={{ activeEarnTab: EarnTabType.AllPools }}
-          />
+          <MockedNavigator component={EarnHome} params={{ activeEarnTab: EarnTabType.AllPools }} />
         </Provider>
       )
       expect(queryByText('NEERU_TEST_TITLE_30D')).toBeNull()
@@ -170,15 +167,11 @@ describe('EarnHome', () => {
         .mocked(getFeatureGate)
         .mockImplementation(
           (g) =>
-            g === StatsigFeatureGates.SHOW_POSITIONS ||
-            g === StatsigFeatureGates.SHOW_NEERU_VAULTS
+            g === StatsigFeatureGates.SHOW_POSITIONS || g === StatsigFeatureGates.SHOW_NEERU_VAULTS
         )
       const { getByText } = render(
         <Provider store={storeWithNeeru}>
-          <MockedNavigator
-            component={EarnHome}
-            params={{ activeEarnTab: EarnTabType.AllPools }}
-          />
+          <MockedNavigator component={EarnHome} params={{ activeEarnTab: EarnTabType.AllPools }} />
         </Provider>
       )
       expect(getByText('NEERU_TEST_TITLE_30D')).toBeTruthy()


### PR DESCRIPTION
## Summary

Phase 2 of the Neeru Vaults wallet plan + carried-over fix.

- `locales/base/translation.json` and `locales/es-419/translation.json`: full `neeruVaults` namespace covering tranche labels, detail screen, position row, close sheet, emergency-close sheet, transparency disclaimer block, per-tranche descriptions, and 13 error code keys.
- `src/earn/EarnHome.test.tsx`: fix TS error from PR #205 by importing `NetworkId` enum instead of bare string literal in the Neeru gate test.

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 5-6 + Deltas B/C/E)

## Test plan

- [ ] CI green
- [ ] JSON validity for both translation files
- [ ] `yarn build:ts` no longer reports EarnHome.test.tsx error