### PR TITLE
feat(earn/neeru): phase 3 Redux slice + migration 252 + selectors

### DIFF
--- a/src/earn/neeru/__tests__/selectors.test.ts
+++ b/src/earn/neeru/__tests__/selectors.test.ts
@@ -1,0 +1,52 @@
+import {
+  neeruClosingPositionIdSelector,
+  neeruFetchStatusSelector,
+  neeruPositionsByTrancheSelector,
+} from 'src/earn/neeru/selectors'
+import { initialState as initialNeeruState } from 'src/earn/neeru/slice'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+
+const make = (id: string, tranche: 0 | 1 | 2 | 3): NeeruIndividualPosition => ({
+  positionId: id,
+  tranche,
+  trancheLabel: '',
+  principal: '100',
+  accruedInterest: '1',
+  dailyRateRay: '0',
+  monthlyRatePercentage: 0,
+  startTs: 0,
+  maturityTs: 0,
+  depositBlock: 0,
+  depositTxHash: '0x' + 'a'.repeat(64),
+  renewedFromPositionId: null,
+  currentPayoutIfClosed: {
+    principal: '100',
+    interest: '1',
+    penaltyBps: 0,
+    interestAfterPenalty: '1',
+    total: '101',
+    isEarly: false,
+  },
+})
+
+const buildState = (overrides: Partial<typeof initialNeeruState>) =>
+  ({ neeru: { ...initialNeeruState, ...overrides } }) as any
+
+describe('neeru selectors', () => {
+  it('returns fetch status', () => {
+    expect(neeruFetchStatusSelector(buildState({ fetchStatus: 'loading' }))).toBe('loading')
+  })
+  it('groups positions by tranche', () => {
+    const state = buildState({
+      positions: [make('1', 0), make('2', 1), make('3', 1)],
+    })
+    const grouped = neeruPositionsByTrancheSelector(state)
+    expect(grouped[0]).toHaveLength(1)
+    expect(grouped[1]).toHaveLength(2)
+    expect(grouped[2]).toHaveLength(0)
+    expect(grouped[3]).toHaveLength(0)
+  })
+  it('returns closingPositionId', () => {
+    expect(neeruClosingPositionIdSelector(buildState({ closingPositionId: '99' }))).toBe('99')
+  })
+})

--- a/src/earn/neeru/__tests__/slice.test.ts
+++ b/src/earn/neeru/__tests__/slice.test.ts
@@ -1,0 +1,88 @@
+import reducer, {
+  closePositionFailure,
+  closePositionStart,
+  closePositionSuccess,
+  fetchPositionsFailure,
+  fetchPositionsStart,
+  fetchPositionsSuccess,
+  initialState,
+} from 'src/earn/neeru/slice'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+
+const fixturePosition: NeeruIndividualPosition = {
+  positionId: '1234',
+  tranche: 1,
+  trancheLabel: '30 dias',
+  principal: '10000',
+  accruedInterest: '82.5',
+  dailyRateRay: '1000003290000000000000000000',
+  monthlyRatePercentage: 1.0,
+  startTs: 1700000000,
+  maturityTs: 1702592000,
+  depositBlock: 70594027,
+  depositTxHash: '0x' + 'a'.repeat(64),
+  renewedFromPositionId: null,
+  currentPayoutIfClosed: {
+    principal: '10000',
+    interest: '82.5',
+    penaltyBps: 2000,
+    interestAfterPenalty: '66',
+    total: '10066',
+    isEarly: true,
+  },
+}
+
+describe('neeru slice', () => {
+  it('starts in idle state', () => {
+    expect(initialState.fetchStatus).toBe('idle')
+    expect(initialState.positions).toEqual([])
+    expect(initialState.closingPositionId).toBeNull()
+  })
+
+  it('handles fetchPositionsStart -> fetchPositionsSuccess', () => {
+    let state = reducer(initialState, fetchPositionsStart())
+    expect(state.fetchStatus).toBe('loading')
+    state = reducer(
+      state,
+      fetchPositionsSuccess({
+        positions: [fixturePosition],
+        lastSyncedBlock: 70750000,
+        lastSyncedAt: '2026-06-26T00:00:00Z',
+      })
+    )
+    expect(state.fetchStatus).toBe('success')
+    expect(state.positions).toEqual([fixturePosition])
+    expect(state.lastSyncedBlock).toBe(70750000)
+  })
+
+  it('handles fetchPositionsFailure', () => {
+    const state = reducer(initialState, fetchPositionsFailure({ error: 'network' }))
+    expect(state.fetchStatus).toBe('error')
+    expect(state.lastError).toBe('network')
+  })
+
+  it('handles close flow lifecycle - success removes closed position from cache', () => {
+    const withPosition = reducer(
+      initialState,
+      fetchPositionsSuccess({
+        positions: [fixturePosition],
+        lastSyncedBlock: 70750000,
+        lastSyncedAt: '2026-06-26T00:00:00Z',
+      })
+    )
+    let state = reducer(withPosition, closePositionStart({ positionId: '1234' }))
+    expect(state.closingPositionId).toBe('1234')
+    expect(state.closeStatus).toBe('loading')
+    state = reducer(state, closePositionSuccess({ positionId: '1234' }))
+    expect(state.closingPositionId).toBeNull()
+    expect(state.closeStatus).toBe('success')
+    expect(state.positions).toEqual([])
+  })
+
+  it('handles closePositionFailure', () => {
+    let state = reducer(initialState, closePositionStart({ positionId: '1234' }))
+    state = reducer(state, closePositionFailure({ positionId: '1234', error: 'InterestPoolLow' }))
+    expect(state.closeStatus).toBe('error')
+    expect(state.lastError).toBe('InterestPoolLow')
+  })
+})

--- a/src/earn/neeru/selectors.ts
+++ b/src/earn/neeru/selectors.ts
@@ -1,0 +1,27 @@
+import { createSelector } from '@reduxjs/toolkit'
+import { NeeruTrancheId } from 'src/earn/neeru/constants'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import { RootState } from 'src/redux/store'
+
+const neeruSlice = (state: RootState) => state.neeru
+
+export const neeruFetchStatusSelector = (state: RootState) => neeruSlice(state).fetchStatus
+export const neeruCloseStatusSelector = (state: RootState) => neeruSlice(state).closeStatus
+export const neeruClosingPositionIdSelector = (state: RootState) =>
+  neeruSlice(state).closingPositionId
+export const neeruLastErrorSelector = (state: RootState) => neeruSlice(state).lastError
+export const neeruPositionsSelector = (state: RootState) => neeruSlice(state).positions
+
+export const neeruPositionsByTrancheSelector = createSelector(
+  [neeruPositionsSelector],
+  (positions): Record<NeeruTrancheId, NeeruIndividualPosition[]> => {
+    const acc: Record<NeeruTrancheId, NeeruIndividualPosition[]> = {
+      0: [],
+      1: [],
+      2: [],
+      3: [],
+    }
+    for (const p of positions) acc[p.tranche].push(p)
+    return acc
+  }
+)

--- a/src/earn/neeru/slice.ts
+++ b/src/earn/neeru/slice.ts
@@ -1,0 +1,76 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { NeeruCloseStatus, NeeruFetchStatus, NeeruIndividualPosition } from 'src/earn/neeru/types'
+
+export interface NeeruState {
+  fetchStatus: NeeruFetchStatus
+  positions: NeeruIndividualPosition[]
+  lastSyncedBlock: number | null
+  lastSyncedAt: string | null
+  closeStatus: NeeruCloseStatus
+  closingPositionId: string | null
+  lastError: string | null
+}
+
+export const initialState: NeeruState = {
+  fetchStatus: 'idle',
+  positions: [],
+  lastSyncedBlock: null,
+  lastSyncedAt: null,
+  closeStatus: 'idle',
+  closingPositionId: null,
+  lastError: null,
+}
+
+const slice = createSlice({
+  name: 'neeru',
+  initialState,
+  reducers: {
+    fetchPositionsStart: (state) => {
+      state.fetchStatus = 'loading'
+      state.lastError = null
+    },
+    fetchPositionsSuccess: (
+      state,
+      action: PayloadAction<{
+        positions: NeeruIndividualPosition[]
+        lastSyncedBlock: number
+        lastSyncedAt: string
+      }>
+    ) => {
+      state.fetchStatus = 'success'
+      state.positions = action.payload.positions
+      state.lastSyncedBlock = action.payload.lastSyncedBlock
+      state.lastSyncedAt = action.payload.lastSyncedAt
+    },
+    fetchPositionsFailure: (state, action: PayloadAction<{ error: string }>) => {
+      state.fetchStatus = 'error'
+      state.lastError = action.payload.error
+    },
+    closePositionStart: (state, action: PayloadAction<{ positionId: string }>) => {
+      state.closeStatus = 'loading'
+      state.closingPositionId = action.payload.positionId
+      state.lastError = null
+    },
+    closePositionSuccess: (state, action: PayloadAction<{ positionId: string }>) => {
+      state.closeStatus = 'success'
+      state.closingPositionId = null
+      state.positions = state.positions.filter((p) => p.positionId !== action.payload.positionId)
+    },
+    closePositionFailure: (state, action: PayloadAction<{ positionId: string; error: string }>) => {
+      state.closeStatus = 'error'
+      state.closingPositionId = null
+      state.lastError = action.payload.error
+    },
+  },
+})
+
+export const {
+  fetchPositionsStart,
+  fetchPositionsSuccess,
+  fetchPositionsFailure,
+  closePositionStart,
+  closePositionSuccess,
+  closePositionFailure,
+} = slice.actions
+
+export default slice.reducer

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -1900,4 +1900,21 @@ describe('Redux persist migrations', () => {
     expectedSchema.identity = _.omit(oldSchema.identity, 'hasSeenVerificationNux')
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
+
+  describe('migration 252', () => {
+    it('seeds the neeru slice with initial state', () => {
+      const oldState = { someOtherKey: 'preserved' } as any
+      const newState = migrations[252](oldState)
+      expect(newState.someOtherKey).toBe('preserved')
+      expect(newState.neeru).toEqual({
+        fetchStatus: 'idle',
+        positions: [],
+        lastSyncedBlock: null,
+        lastSyncedAt: null,
+        closeStatus: 'idle',
+        closingPositionId: null,
+        lastError: null,
+      })
+    })
+  })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -2105,4 +2105,16 @@ export const migrations = {
       },
     }
   },
+  252: (state: any) => ({
+    ...state,
+    neeru: {
+      fetchStatus: 'idle',
+      positions: [],
+      lastSyncedBlock: null,
+      lastSyncedAt: null,
+      closeStatus: 'idle',
+      closingPositionId: null,
+      lastError: null,
+    },
+  }),
 }

--- a/src/redux/reducersList.ts
+++ b/src/redux/reducersList.ts
@@ -6,6 +6,7 @@ import { appReducer as app } from 'src/app/reducers'
 import dappsReducer from 'src/dapps/slice'
 import dollarsSpendReducer from 'src/dollarsSpend/slice'
 import earnReducer from 'src/earn/slice'
+import neeruReducer from 'src/earn/neeru/slice'
 import { reducer as fiatExchanges } from 'src/fiatExchanges/reducer'
 import fiatConnectReducer from 'src/fiatconnect/slice'
 import { homeReducer as home } from 'src/home/reducers'
@@ -58,6 +59,7 @@ export const reducersList = {
   jumpstart: jumpstartReducer,
   points: pointsReducer,
   earn: earnReducer,
+  neeru: neeruReducer,
   buckspay: bucksPayReducer,
   gold: goldReducer,
   transactionInFlight: transactionInFlightReducer,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -63,7 +63,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 251,
+  version: 252,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2327,6 +2327,179 @@
             ],
             "type": "string"
         },
+        "NeeruCloseStatus": {
+            "enum": [
+                "error",
+                "idle",
+                "loading",
+                "success"
+            ],
+            "type": "string"
+        },
+        "NeeruFetchStatus": {
+            "enum": [
+                "error",
+                "idle",
+                "loading",
+                "success"
+            ],
+            "type": "string"
+        },
+        "NeeruIndividualPosition": {
+            "additionalProperties": false,
+            "properties": {
+                "accruedInterest": {
+                    "type": "string"
+                },
+                "currentPayoutIfClosed": {
+                    "$ref": "#/definitions/NeeruPositionPayout"
+                },
+                "dailyRateRay": {
+                    "type": "string"
+                },
+                "depositBlock": {
+                    "type": "number"
+                },
+                "depositTxHash": {
+                    "type": "string"
+                },
+                "maturityTs": {
+                    "type": "number"
+                },
+                "monthlyRatePercentage": {
+                    "type": "number"
+                },
+                "positionId": {
+                    "type": "string"
+                },
+                "principal": {
+                    "type": "string"
+                },
+                "renewedFromPositionId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "startTs": {
+                    "type": "number"
+                },
+                "tranche": {
+                    "$ref": "#/definitions/NeeruTrancheId"
+                },
+                "trancheLabel": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "accruedInterest",
+                "currentPayoutIfClosed",
+                "dailyRateRay",
+                "depositBlock",
+                "depositTxHash",
+                "maturityTs",
+                "monthlyRatePercentage",
+                "positionId",
+                "principal",
+                "renewedFromPositionId",
+                "startTs",
+                "tranche",
+                "trancheLabel"
+            ],
+            "type": "object"
+        },
+        "NeeruPositionPayout": {
+            "additionalProperties": false,
+            "properties": {
+                "interest": {
+                    "type": "string"
+                },
+                "interestAfterPenalty": {
+                    "type": "string"
+                },
+                "isEarly": {
+                    "type": "boolean"
+                },
+                "penaltyBps": {
+                    "type": "number"
+                },
+                "principal": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "interest",
+                "interestAfterPenalty",
+                "isEarly",
+                "penaltyBps",
+                "principal",
+                "total"
+            ],
+            "type": "object"
+        },
+        "NeeruState": {
+            "additionalProperties": false,
+            "properties": {
+                "closeStatus": {
+                    "$ref": "#/definitions/NeeruCloseStatus"
+                },
+                "closingPositionId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fetchStatus": {
+                    "$ref": "#/definitions/NeeruFetchStatus"
+                },
+                "lastError": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastSyncedAt": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastSyncedBlock": {
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                },
+                "positions": {
+                    "items": {
+                        "$ref": "#/definitions/NeeruIndividualPosition"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "closeStatus",
+                "closingPositionId",
+                "fetchStatus",
+                "lastError",
+                "lastSyncedAt",
+                "lastSyncedBlock",
+                "positions"
+            ],
+            "type": "object"
+        },
+        "NeeruTrancheId": {
+            "enum": [
+                0,
+                1,
+                2,
+                3
+            ],
+            "type": "number"
+        },
         "NetworkId": {
             "enum": [
                 "arbitrum-one",
@@ -8064,6 +8237,9 @@
         "localCurrency": {
             "$ref": "#/definitions/State_11"
         },
+        "neeru": {
+            "$ref": "#/definitions/NeeruState"
+        },
         "networkInfo": {
             "$ref": "#/definitions/State_2"
         },
@@ -8149,6 +8325,7 @@
         "jumpstart",
         "keylessBackup",
         "localCurrency",
+        "neeru",
         "networkInfo",
         "nfts",
         "points",


### PR DESCRIPTION
## Summary

Phase 3 of the Neeru Vaults wallet plan: Redux slice with positions cache and close-flow lifecycle, registration in store with persist version bump to 252, migration to seed initial state, and memoized selectors.

- `src/earn/neeru/slice.ts` - slice with fetch/close lifecycle
- `src/earn/neeru/selectors.ts` - selectors including `neeruPositionsByTrancheSelector` (memoized)
- `src/redux/reducersList.ts` - register slice
- `src/redux/store.ts` - persist version 251 -> 252
- `src/redux/migrations.ts` - migration 252 seeds neeru initial state for existing users
- `test/RootStateSchema.json` - regenerated

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 7-10)

## Test plan

- [ ] CI green
- [ ] 5 slice tests pass
- [ ] 3 selector tests pass
- [ ] migration 252 test passes
- [ ] yarn build:ts clean