### PR TITLE
revert(redux): roll back persist version 252 to 251

### DIFF
--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -1900,21 +1900,4 @@ describe('Redux persist migrations', () => {
     expectedSchema.identity = _.omit(oldSchema.identity, 'hasSeenVerificationNux')
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
-
-  describe('migration 252', () => {
-    it('seeds the neeru slice with initial state', () => {
-      const oldState = { someOtherKey: 'preserved' } as any
-      const newState = migrations[252](oldState)
-      expect(newState.someOtherKey).toBe('preserved')
-      expect(newState.neeru).toEqual({
-        fetchStatus: 'idle',
-        positions: [],
-        lastSyncedBlock: null,
-        lastSyncedAt: null,
-        closeStatus: 'idle',
-        closingPositionId: null,
-        lastError: null,
-      })
-    })
-  })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -2105,16 +2105,4 @@ export const migrations = {
       },
     }
   },
-  252: (state: any) => ({
-    ...state,
-    neeru: {
-      fetchStatus: 'idle',
-      positions: [],
-      lastSyncedBlock: null,
-      lastSyncedAt: null,
-      closeStatus: 'idle',
-      closingPositionId: null,
-      lastError: null,
-    },
-  }),
 }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -63,7 +63,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 252,
+  version: 251,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],


### PR DESCRIPTION
## Summary

Reverts the persist version bump from PR #208 (251 -> 252) and removes migration 252. Keeps the Neeru slice operational via Redux Toolkit's `initialState` default.

## Why

Live binary is 1.118.5 on persist version 246. No production users on 251 or beyond. The bump in PR #208 was defensive ceremony following codebase convention but adds nothing for actual users. Dogfood users who already ran 252 will have their state purged on next hydration (acceptable: they can clear data anyway).

## What stays

- `src/earn/neeru/slice.ts` - slice + reducer with initialState
- `src/earn/neeru/{selectors,types,constants,abi}.ts`
- i18n keys in both translation files
- Registration in `reducersList.ts` / `reducersForSchemaGeneration.ts`

## What's reverted

- `src/redux/store.ts` - version 251
- `src/redux/migrations.ts` - migration 252 removed
- `src/redux/migrations.test.ts` - migration 252 test removed
- `test/RootStateSchema.json` - regenerated

## Test plan

- [ ] CI green
- [ ] All neeru slice/selectors tests still pass
- [ ] yarn build:ts clean