### PR TITLE
feat(earn/neeru): phase 4 API client + fetch saga

### DIFF
--- a/src/earn/neeru/__tests__/api.test.ts
+++ b/src/earn/neeru/__tests__/api.test.ts
@@ -1,0 +1,62 @@
+import { FetchMock } from 'jest-fetch-mock'
+import { fetchNeeruPositions } from 'src/earn/neeru/api'
+import { _resetForTests } from 'src/lib/circuitBreaker/circuitBreaker'
+
+const mockFetch = fetch as FetchMock
+
+const mockFixture = {
+  data: {
+    address: '0x' + 'a'.repeat(40),
+    positions: [],
+    lastSyncedBlock: 70750000,
+    lastSyncedAt: '2026-06-26T00:00:00Z',
+  },
+}
+
+const runWithTimers = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const p = fn()
+  // Drive backoff timers between retries without exhausting the abort timer.
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+    jest.advanceTimersByTime(2000)
+  }
+  return p
+}
+
+describe('fetchNeeruPositions', () => {
+  beforeEach(() => {
+    mockFetch.resetMocks()
+    _resetForTests()
+  })
+
+  it('returns parsed data on 200', async () => {
+    mockFetch.mockResponseOnce(JSON.stringify(mockFixture), { status: 200 })
+
+    const result = await runWithTimers(() =>
+      fetchNeeruPositions({
+        baseUrl: 'https://example.test',
+        walletAddress: '0x' + 'a'.repeat(40),
+      })
+    )
+    expect(result.address).toBe('0x' + 'a'.repeat(40))
+    expect(result.positions).toEqual([])
+    expect(result.lastSyncedBlock).toBe(70750000)
+  })
+
+  it('throws on non-2xx', async () => {
+    // 503 is treated as transient by fetchWithTimeout, so it retries 3 times
+    mockFetch
+      .mockResponseOnce('', { status: 503, statusText: 'Service Unavailable' })
+      .mockResponseOnce('', { status: 503, statusText: 'Service Unavailable' })
+      .mockResponseOnce('', { status: 503, statusText: 'Service Unavailable' })
+
+    await expect(
+      runWithTimers(() =>
+        fetchNeeruPositions({
+          baseUrl: 'https://example.test',
+          walletAddress: '0x' + 'b'.repeat(40),
+        })
+      )
+    ).rejects.toThrow(/503/)
+  })
+})

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -1,0 +1,61 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { fetchNeeruPositions } from 'src/earn/neeru/api'
+import { fetchNeeruPositionsSaga } from 'src/earn/neeru/saga'
+import {
+  fetchPositionsFailure,
+  fetchPositionsStart,
+  fetchPositionsSuccess,
+} from 'src/earn/neeru/slice'
+import { walletAddressSelector } from 'src/web3/selectors'
+
+describe('fetchNeeruPositionsSaga', () => {
+  const WALLET = '0x' + 'a'.repeat(40)
+  const RESPONSE = {
+    address: WALLET,
+    positions: [],
+    lastSyncedBlock: 70750000,
+    lastSyncedAt: '2026-06-26T00:00:00Z',
+  }
+
+  it('dispatches success on happy path', async () => {
+    await expectSaga(fetchNeeruPositionsSaga, fetchPositionsStart())
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.call.fn(fetchNeeruPositions), RESPONSE],
+      ])
+      .put(
+        fetchPositionsSuccess({
+          positions: [],
+          lastSyncedBlock: 70750000,
+          lastSyncedAt: '2026-06-26T00:00:00Z',
+        })
+      )
+      .run()
+  })
+
+  it('dispatches failure on API throw', async () => {
+    await expectSaga(fetchNeeruPositionsSaga, fetchPositionsStart())
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.call.fn(fetchNeeruPositions), Promise.reject(new Error('boom'))],
+      ])
+      .put(fetchPositionsFailure({ error: 'boom' }))
+      .run()
+  })
+
+  it('no-ops when no wallet address', async () => {
+    let dispatchedSuccess = false
+    await expectSaga(fetchNeeruPositionsSaga, fetchPositionsStart())
+      .provide([[matchers.select(walletAddressSelector), null]])
+      .run()
+      .then((res) => {
+        const successCalls = res.effects.put?.filter((p: any) =>
+          p.payload.action.type.includes('fetchPositionsSuccess')
+        )
+        dispatchedSuccess = !!(successCalls && successCalls.length > 0)
+      })
+      .catch(() => {})
+    expect(dispatchedSuccess).toBe(false)
+  })
+})

--- a/src/earn/neeru/api.ts
+++ b/src/earn/neeru/api.ts
@@ -1,0 +1,21 @@
+import { NeeruPositionsResponse } from 'src/earn/neeru/types'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+
+const NEERU_FETCH_TIMEOUT_MS = 15_000
+
+export async function fetchNeeruPositions({
+  baseUrl,
+  walletAddress,
+}: {
+  baseUrl: string
+  walletAddress: string
+}): Promise<NeeruPositionsResponse> {
+  const url = new URL('/api/earn/neeru/positions', baseUrl)
+  url.searchParams.set('address', walletAddress)
+  const response = await fetchWithTimeout(url.toString(), null, NEERU_FETCH_TIMEOUT_MS)
+  if (!response.ok) {
+    throw new Error(`fetchNeeruPositions failed: ${response.status} ${response.statusText}`)
+  }
+  const body = await response.json()
+  return body.data as NeeruPositionsResponse
+}

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -1,0 +1,46 @@
+import { fetchNeeruPositions } from 'src/earn/neeru/api'
+import {
+  fetchPositionsFailure,
+  fetchPositionsStart,
+  fetchPositionsSuccess,
+} from 'src/earn/neeru/slice'
+import Logger from 'src/utils/Logger'
+import { ensureError } from 'src/utils/ensureError'
+import networkConfig from 'src/web3/networkConfig'
+import { walletAddressSelector } from 'src/web3/selectors'
+import { call, put, select, spawn, takeLeading } from 'typed-redux-saga'
+
+const TAG = 'earn/neeru/saga'
+
+export function* fetchNeeruPositionsSaga(_action: ReturnType<typeof fetchPositionsStart>) {
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) {
+    Logger.warn(TAG, 'no wallet address, skipping fetch')
+    return
+  }
+  try {
+    const response = yield* call(fetchNeeruPositions, {
+      baseUrl: networkConfig.tucopBackendApiUrl,
+      walletAddress,
+    })
+    yield* put(
+      fetchPositionsSuccess({
+        positions: response.positions,
+        lastSyncedBlock: response.lastSyncedBlock,
+        lastSyncedAt: response.lastSyncedAt,
+      })
+    )
+  } catch (e) {
+    const error = ensureError(e)
+    Logger.error(TAG, 'fetchNeeruPositions failed', error)
+    yield* put(fetchPositionsFailure({ error: error.message }))
+  }
+}
+
+export function* watchFetchNeeruPositions() {
+  yield* takeLeading(fetchPositionsStart.type, fetchNeeruPositionsSaga)
+}
+
+export function* neeruSaga() {
+  yield* spawn(watchFetchNeeruPositions)
+}

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -17,6 +17,7 @@ import {
 import { dappsSaga } from 'src/dapps/saga'
 import { fetchDappsListCompleted } from 'src/dapps/slice'
 import { earnSaga } from 'src/earn/saga'
+import { neeruSaga } from 'src/earn/neeru/saga'
 import { goldSaga } from 'src/gold/saga'
 import { fiatExchangesSaga } from 'src/fiatExchanges/saga'
 import { fiatConnectSaga } from 'src/fiatconnect/saga'
@@ -151,6 +152,7 @@ export function* rootSaga() {
     yield* spawn(priceHistorySaga)
     yield* spawn(pointsSaga)
     yield* spawn(earnSaga)
+    yield* spawn(neeruSaga)
     yield* spawn(bucksPaySaga)
     yield* spawn(goldSaga)
   } catch (error) {

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -96,6 +96,7 @@ interface NetworkConfig {
   getXautPriceUrl: string
   blockscoutProxyBase: string
   wriDelegateRelayUrl: string
+  tucopBackendApiUrl: string
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_MAINNET = 'https://eth-mainnet.g.alchemy.com/v2/'
@@ -417,6 +418,7 @@ const networkConfig: NetworkConfig = {
   getXautPriceUrl: GET_XAUT_PRICE_URL,
   blockscoutProxyBase: BLOCKSCOUT_PROXY_BASE,
   wriDelegateRelayUrl: WRI_DELEGATE_RELAY_URL,
+  tucopBackendApiUrl: TUCOP_BACKEND_BASE,
 }
 
 const CELOSCAN_BASE_URL_MAINNET = 'https://celoscan.io'


### PR DESCRIPTION
## Summary

Phase 4 of the Neeru Vaults wallet plan: HTTP client for the detail endpoint and a Redux saga that ties it to the slice.

- `src/web3/networkConfig.ts` - add `tucopBackendApiUrl` field
- `src/earn/neeru/api.ts` - `fetchNeeruPositions` calling `GET /api/earn/neeru/positions`
- `src/earn/neeru/saga.ts` - `fetchNeeruPositionsSaga` + `watchFetchNeeruPositions` + `neeruSaga`
- `src/redux/sagas.ts` - spawn `neeruSaga` from root

**Persist version unchanged at 251.** No migrations, no schema changes.

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 11-12)

## Test plan

- [ ] CI green
- [ ] 2 API tests pass
- [ ] 3 saga tests pass
- [ ] yarn build:ts clean