### PR TITLE
feat(earn/neeru): phase 5+6 detail screen + PoolCard branch

### DIFF
--- a/src/earn/PoolCard.test.tsx
+++ b/src/earn/PoolCard.test.tsx
@@ -4,6 +4,8 @@ import { Provider } from 'react-redux'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
 import PoolCard from 'src/earn/PoolCard'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { NetworkId } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
 import {
@@ -12,6 +14,8 @@ import {
   mockEarnPositions,
   mockTokenBalances,
 } from 'test/values'
+
+jest.mock('src/navigator/NavigationService', () => ({ navigate: jest.fn() }))
 
 describe('PoolCard', () => {
   it('renders correctly', () => {
@@ -61,6 +65,32 @@ describe('PoolCard', () => {
       depositTokenId: mockArbUsdcTokenId,
       poolAmount: '10',
       providerId: 'aave',
+    })
+  })
+
+  describe('navigation branching', () => {
+    beforeEach(() => jest.clearAllMocks())
+
+    it('routes non-Neeru pools to EarnPoolInfoScreen', () => {
+      const pool = { ...mockEarnPositions[0], appId: 'allbridge' }
+      const { getByTestId } = render(
+        <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
+          <PoolCard pool={pool} testID="PoolCard.allbridge" />
+        </Provider>
+      )
+      fireEvent.press(getByTestId('PoolCard.allbridge'))
+      expect(navigate).toHaveBeenCalledWith(Screens.EarnPoolInfoScreen, { pool })
+    })
+
+    it('routes Neeru pools to NeeruVaultDetail', () => {
+      const pool = { ...mockEarnPositions[0], appId: 'neeru-vaults' }
+      const { getByTestId } = render(
+        <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
+          <PoolCard pool={pool} testID="PoolCard.neeru" />
+        </Provider>
+      )
+      fireEvent.press(getByTestId('PoolCard.neeru'))
+      expect(navigate).toHaveBeenCalledWith(Screens.NeeruVaultDetail, { pool })
     })
   })
 })

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -92,6 +92,10 @@ export default function PoolCard({
       poolAmount: balance,
       providerId: appId,
     })
+    if (pool.appId === 'neeru-vaults') {
+      navigate(Screens.NeeruVaultDetail, { pool })
+      return
+    }
     navigate(Screens.EarnPoolInfoScreen, { pool })
   }
 

--- a/src/earn/neeru/NeeruPositionRow.tsx
+++ b/src/earn/neeru/NeeruPositionRow.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  position: NeeruIndividualPosition
+  onManagePress: (position: NeeruIndividualPosition) => void
+}
+
+export default function NeeruPositionRow({ position, onManagePress }: Props) {
+  const { t } = useTranslation()
+  const isFlexible = position.tranche === 0
+  const maturityDate = new Date(position.maturityTs * 1000).toLocaleDateString()
+
+  return (
+    <View testID="NeeruPositionRow" style={styles.row}>
+      <View style={styles.column}>
+        <Text style={styles.line}>
+          {t('neeruVaults.positionRow.principal', { amount: position.principal })}
+        </Text>
+        <Text style={styles.line}>
+          {t('neeruVaults.positionRow.interest', { amount: position.accruedInterest })}
+        </Text>
+        <Text style={styles.subline}>
+          {isFlexible
+            ? t('neeruVaults.positionRow.flexible')
+            : t('neeruVaults.positionRow.maturity', { date: maturityDate })}
+        </Text>
+      </View>
+      <Button
+        testID={`NeeruPositionRow.Manage.${position.positionId}`}
+        text={t('neeruVaults.positionRow.manageCta')}
+        size={BtnSizes.SMALL}
+        type={BtnTypes.SECONDARY}
+        onPress={() => onManagePress(position)}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: Colors.gray1,
+    borderRadius: 12,
+    padding: Spacing.Regular16,
+    gap: Spacing.Smallest8,
+  },
+  column: { flex: 1 },
+  line: { ...typeScale.bodyMedium, color: Colors.black },
+  subline: {
+    ...typeScale.bodySmall,
+    color: Colors.gray3,
+    marginTop: Spacing.Tiny4,
+  },
+})

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -1,0 +1,158 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import BigNumber from 'bignumber.js'
+import * as React from 'react'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { getAddress } from 'viem'
+import { Linking, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import Touchable from 'src/components/Touchable'
+import {
+  FONDO_COPM_MVP_ADDRESS,
+  NEERU_TRANCHE_LABEL_KEYS,
+  NeeruTrancheId,
+  trancheIdFromPositionId,
+} from 'src/earn/neeru/constants'
+import NeeruPositionRow from 'src/earn/neeru/NeeruPositionRow'
+import { neeruFetchStatusSelector, neeruPositionsByTrancheSelector } from 'src/earn/neeru/selectors'
+import { fetchPositionsStart } from 'src/earn/neeru/slice'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+import { useDispatch, useSelector } from 'src/redux/hooks'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+type Props = NativeStackScreenProps<StackParamList, Screens.NeeruVaultDetail>
+
+const DESCRIPTION_KEY_BY_TRANCHE: Record<NeeruTrancheId, string> = {
+  0: 'neeruVaults.detail.descriptionByTranche.flexible',
+  1: 'neeruVaults.detail.descriptionByTranche.thirtyDays',
+  2: 'neeruVaults.detail.descriptionByTranche.sixtyDays',
+  3: 'neeruVaults.detail.descriptionByTranche.ninetyDays',
+}
+
+export default function NeeruVaultDetailScreen({ route }: Props) {
+  const { pool } = route.params
+  const { t } = useTranslation()
+  const dispatch = useDispatch()
+  const fetchStatus = useSelector(neeruFetchStatusSelector)
+  const byTranche = useSelector(neeruPositionsByTrancheSelector)
+
+  const trancheId = trancheIdFromPositionId(pool.positionId)
+
+  useEffect(() => {
+    dispatch(fetchPositionsStart())
+  }, [dispatch])
+
+  if (trancheId === null) {
+    return null
+  }
+
+  const positions = byTranche[trancheId]
+  const trancheLabel = t(NEERU_TRANCHE_LABEL_KEYS[trancheId])
+  const description = t(DESCRIPTION_KEY_BY_TRANCHE[trancheId])
+  const sourceUrl = t('neeruVaults.detail.transparency.sourceUrl')
+  const total = positions
+    .reduce((acc, p) => acc.plus(p.currentPayoutIfClosed.total), new BigNumber(0))
+    .toFixed(2)
+
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        refreshControl={
+          <RefreshControl
+            refreshing={fetchStatus === 'loading'}
+            onRefresh={() => dispatch(fetchPositionsStart())}
+          />
+        }
+      >
+        <Text style={styles.header}>{t('neeruVaults.detail.header', { trancheLabel })}</Text>
+        <Text style={styles.description}>{description}</Text>
+        <Text style={styles.total}>
+          {t('neeruVaults.detail.aggregateBalance', { trancheLabel })}: {total}
+        </Text>
+
+        {positions.length === 0 ? (
+          <Text style={styles.empty}>{t('neeruVaults.detail.noPositions')}</Text>
+        ) : (
+          <View style={styles.positionsList}>
+            {positions.map((p) => (
+              <NeeruPositionRow
+                key={p.positionId}
+                position={p}
+                onManagePress={() => {
+                  // Wired in Phase 7 (close sheet). No-op for now.
+                }}
+              />
+            ))}
+          </View>
+        )}
+
+        <Button
+          size={BtnSizes.FULL}
+          type={BtnTypes.PRIMARY}
+          text={t('neeruVaults.detail.depositCta')}
+          onPress={() => navigate(Screens.EarnEnterAmount, { pool, mode: 'deposit' })}
+          testID="NeeruVaultDetail.DepositCta"
+          style={styles.cta}
+        />
+
+        <View style={styles.transparency}>
+          <Text style={styles.transparencyTitle}>{t('neeruVaults.detail.transparency.title')}</Text>
+          <Touchable
+            testID="NeeruVaultDetail.SourceLink"
+            onPress={() => Linking.openURL(sourceUrl)}
+          >
+            <Text style={styles.transparencyLink}>
+              {t('neeruVaults.detail.transparency.sourceLine')}: {sourceUrl}
+            </Text>
+          </Touchable>
+          <Text style={styles.transparencyText}>
+            {t('neeruVaults.detail.transparency.contractLine')}:{' '}
+            {getAddress(FONDO_COPM_MVP_ADDRESS)}
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.white },
+  scroll: { padding: Spacing.Regular16, gap: Spacing.Regular16 },
+  header: { ...typeScale.titleMedium, color: Colors.black },
+  description: { ...typeScale.bodyMedium, color: Colors.gray3 },
+  total: { ...typeScale.bodyLarge, color: Colors.black },
+  empty: {
+    ...typeScale.bodyMedium,
+    color: Colors.gray3,
+    marginTop: Spacing.Large32,
+    textAlign: 'center',
+  },
+  positionsList: { gap: Spacing.Smallest8 },
+  cta: { marginTop: Spacing.Large32 },
+  transparency: {
+    marginTop: Spacing.Large32,
+    padding: Spacing.Regular16,
+    backgroundColor: Colors.gray1,
+    borderRadius: 12,
+    gap: Spacing.Tiny4,
+  },
+  transparencyTitle: {
+    ...typeScale.labelSmall,
+    color: Colors.gray3,
+    marginBottom: Spacing.Smallest8,
+  },
+  transparencyLink: {
+    ...typeScale.bodySmall,
+    color: Colors.accent,
+  },
+  transparencyText: {
+    ...typeScale.bodySmall,
+    color: Colors.gray3,
+  },
+})

--- a/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import NeeruPositionRow from 'src/earn/neeru/NeeruPositionRow'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+
+const pos: NeeruIndividualPosition = {
+  positionId: '1234',
+  tranche: 1,
+  trancheLabel: '30 dias',
+  principal: '10000',
+  accruedInterest: '82.5',
+  dailyRateRay: '0',
+  monthlyRatePercentage: 1.0,
+  startTs: 1700000000,
+  maturityTs: 1702592000,
+  depositBlock: 0,
+  depositTxHash: '0x' + 'a'.repeat(64),
+  renewedFromPositionId: null,
+  currentPayoutIfClosed: {
+    principal: '10000',
+    interest: '82.5',
+    penaltyBps: 2000,
+    interestAfterPenalty: '66',
+    total: '10066',
+    isEarly: true,
+  },
+}
+
+describe('NeeruPositionRow', () => {
+  it('renders principal and interest', () => {
+    const { getByText } = render(<NeeruPositionRow position={pos} onManagePress={() => {}} />)
+    expect(getByText(/10000/)).toBeTruthy()
+    expect(getByText(/82.5/)).toBeTruthy()
+  })
+
+  it('fires onManagePress when manage CTA tapped', () => {
+    const onManagePress = jest.fn()
+    const { getByTestId } = render(
+      <NeeruPositionRow position={pos} onManagePress={onManagePress} />
+    )
+    fireEvent.press(getByTestId('NeeruPositionRow.Manage.1234'))
+    expect(onManagePress).toHaveBeenCalledWith(pos)
+  })
+})

--- a/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
@@ -28,7 +28,7 @@ const pos: NeeruIndividualPosition = {
 
 describe('NeeruPositionRow', () => {
   it('renders principal and interest', () => {
-    const { getByText } = render(<NeeruPositionRow position={pos} onManagePress={() => {}} />)
+    const { getByText } = render(<NeeruPositionRow position={pos} onManagePress={jest.fn()} />)
     expect(getByText(/10000/)).toBeTruthy()
     expect(getByText(/82.5/)).toBeTruthy()
   })

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import NeeruVaultDetailScreen from 'src/earn/neeru/NeeruVaultDetailScreen'
+import { initialState as initialNeeruState } from 'src/earn/neeru/slice'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { NetworkId } from 'src/transactions/types'
+import { createMockStore } from 'test/utils'
+import { mockEarnPositions } from 'test/values'
+
+jest.mock('src/navigator/NavigationService', () => ({ navigate: jest.fn() }))
+
+const pool = {
+  ...mockEarnPositions[0],
+  appId: 'neeru-vaults',
+  positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
+  address: '0xd05cdf2dc56d97333c547519df58d56145766294',
+  networkId: NetworkId['celo-mainnet'],
+}
+
+const positionFor = (positionId: string): NeeruIndividualPosition => ({
+  positionId,
+  tranche: 1,
+  trancheLabel: '30 dias',
+  principal: '10000',
+  accruedInterest: '82.5',
+  dailyRateRay: '1',
+  monthlyRatePercentage: 1.0,
+  startTs: 0,
+  maturityTs: 1702592000,
+  depositBlock: 0,
+  depositTxHash: '0x' + 'a'.repeat(64),
+  renewedFromPositionId: null,
+  currentPayoutIfClosed: {
+    principal: '10000',
+    interest: '82.5',
+    penaltyBps: 2000,
+    interestAfterPenalty: '66',
+    total: '10066',
+    isEarly: true,
+  },
+})
+
+describe('NeeruVaultDetailScreen', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders aggregate balance and position rows', () => {
+    const store = createMockStore({
+      neeru: {
+        ...initialNeeruState,
+        positions: [positionFor('1'), positionFor('2')],
+        fetchStatus: 'success',
+      },
+    } as any)
+    const { getByText, getAllByTestId } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    expect(getByText(/neeruVaults\.detail\.aggregateBalance/)).toBeTruthy()
+    expect(getAllByTestId('NeeruPositionRow').length).toBe(2)
+  })
+
+  it('navigates to EarnEnterAmount on deposit CTA', () => {
+    const store = createMockStore({
+      neeru: { ...initialNeeruState, fetchStatus: 'success' },
+    } as any)
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    fireEvent.press(getByTestId('NeeruVaultDetail.DepositCta'))
+    expect(navigate).toHaveBeenCalledWith(Screens.EarnEnterAmount, {
+      pool,
+      mode: 'deposit',
+    })
+  })
+
+  it('shows empty state when no positions', () => {
+    const store = createMockStore({
+      neeru: { ...initialNeeruState, positions: [], fetchStatus: 'success' },
+    } as any)
+    const { getByText } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    expect(getByText('neeruVaults.detail.noPositions')).toBeTruthy()
+  })
+
+  it('renders transparency disclaimer block with contract address', () => {
+    const store = createMockStore({
+      neeru: { ...initialNeeruState, fetchStatus: 'success' },
+    } as any)
+    const { getByText } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    expect(getByText('neeruVaults.detail.transparency.title')).toBeTruthy()
+    // Full contract address must NOT be truncated
+    expect(getByText(/0xD05CDF2DC56D97333c547519dF58D56145766294/)).toBeTruthy()
+  })
+})

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -45,6 +45,7 @@ import GoldSellConfirmation from 'src/gold/GoldSellConfirmation'
 import GoldSellEnterAmount from 'src/gold/GoldSellEnterAmount'
 import MarranitoStaking from 'src/earn/marranitos/MarranitoStaking'
 import EarnPoolInfoScreen from 'src/earn/poolInfoScreen/EarnPoolInfoScreen'
+import NeeruVaultDetailScreen from 'src/earn/neeru/NeeruVaultDetailScreen'
 import BidaliScreen from 'src/fiatExchanges/BidaliScreen'
 import CashInSuccess from 'src/fiatExchanges/CashInSuccess'
 import CoinbasePayScreen from 'src/fiatExchanges/CoinbasePayScreen'
@@ -589,6 +590,11 @@ const earnScreens = (Navigator: typeof Stack) => (
     <Navigator.Screen
       name={Screens.EarnPoolInfoScreen}
       component={EarnPoolInfoScreen}
+      options={headerWithBackButton}
+    />
+    <Navigator.Screen
+      name={Screens.NeeruVaultDetail}
+      component={NeeruVaultDetailScreen}
       options={headerWithBackButton}
     />
   </>

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -20,6 +20,7 @@ export enum Screens {
   EarnConfirmationScreen = 'EarnConfirmationScreen',
   EarnHome = 'EarnHome',
   EarnPoolInfoScreen = 'EarnPoolInfoScreen',
+  NeeruVaultDetail = 'NeeruVaultDetail',
   EnableBiometry = 'EnableBiometry',
   ErrorScreen = 'ErrorScreen',
   ExternalExchanges = 'ExternalExchanges',

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -91,6 +91,7 @@ export type StackParamList = {
   }
   [Screens.EarnHome]: { activeEarnTab?: EarnTabType } | undefined
   [Screens.EarnPoolInfoScreen]: { pool: EarnPosition }
+  [Screens.NeeruVaultDetail]: { pool: EarnPosition }
   [Screens.ErrorScreen]: {
     errorMessage?: string
   }


### PR DESCRIPTION
## Summary

Phase 5+6 of the Neeru Vaults wallet plan:

- New screen `NeeruVaultDetailScreen` at `Screens.NeeruVaultDetail` showing aggregate balance, per-position list, deposit CTA (reuses existing `EarnEnterAmount`), and transparency disclaimer block (source code link + full EIP-55 checksummed contract address).
- New `NeeruPositionRow` component with manage CTA (handler is a no-op for now; Phase 7 wires the close sheet).
- `PoolCard` `onPress` branches Neeru pools to the new detail screen instead of the generic `EarnPoolInfoScreen`.
- Per-tranche description override (Delta E) - wallet uses `neeruVaults.detail.descriptionByTranche.*` i18n keys instead of consuming backend's `displayProps.description` (backend interpolates the label literally which reads wrong for tranche-0 "Flexible").

**Persist version unchanged (251).** No migrations, no schema changes.

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 13-16 + Deltas B + E)

## Test plan

- [ ] CI green
- [ ] 4 NeeruVaultDetailScreen tests pass
- [ ] 2 NeeruPositionRow tests pass
- [ ] 2 PoolCard navigation tests pass (added to existing PoolCard.test.tsx)
- [ ] yarn build:ts clean

## Behavior with gate off

The Statsig gate `show_neeru_vaults` is still false in production. Allbridge users see no change. Dogfood with the gate enabled will see the new screen on tap.