### PR TITLE
feat(earn/neeru): phase 7 close flow with penalty disclosure

### DIFF
--- a/src/earn/neeru/NeeruCloseSheet.tsx
+++ b/src/earn/neeru/NeeruCloseSheet.tsx
@@ -1,0 +1,111 @@
+import { BottomSheetModal } from '@gorhom/bottom-sheet'
+import BigNumber from 'bignumber.js'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import BottomSheet from 'src/components/BottomSheet'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { neeruCloseStatusSelector } from 'src/earn/neeru/selectors'
+import { closePositionStart } from 'src/earn/neeru/slice'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import { useDispatch, useSelector } from 'src/redux/hooks'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  position: NeeruIndividualPosition
+  onClose: () => void
+}
+
+export default function NeeruCloseSheet({ position, onClose }: Props) {
+  const { t } = useTranslation()
+  const dispatch = useDispatch()
+  const closeStatus = useSelector(neeruCloseStatusSelector)
+  const ref = React.useRef<BottomSheetModal>(null)
+
+  const { currentPayoutIfClosed: payout } = position
+  const maturityDate = new Date(position.maturityTs * 1000).toLocaleDateString()
+  const penaltyAmount = new BigNumber(payout.interest).minus(payout.interestAfterPenalty).toFixed()
+
+  return (
+    <BottomSheet
+      forwardedRef={ref}
+      onClose={onClose}
+      title={t('neeruVaults.closeSheet.title')}
+      testId="NeeruCloseSheet"
+    >
+      <View style={styles.body}>
+        <Text style={styles.subtitle}>{t('neeruVaults.closeSheet.currentPayout')}</Text>
+        <Row label={t('neeruVaults.closeSheet.principalLabel')} value={payout.principal} />
+        <Row label={t('neeruVaults.closeSheet.interestLabel')} value={payout.interest} />
+        {payout.isEarly && (
+          <Row
+            label={t('neeruVaults.closeSheet.penaltyLabel', {
+              percentage: payout.penaltyBps / 100,
+            })}
+            value={`-${penaltyAmount}`}
+            negative
+          />
+        )}
+        <Row label={t('neeruVaults.closeSheet.totalLabel')} value={payout.total} bold />
+        {payout.isEarly && (
+          <Text style={styles.warning}>
+            {t('neeruVaults.closeSheet.earlyWarning', { date: maturityDate })}
+          </Text>
+        )}
+        <Button
+          testID="NeeruCloseSheet.Confirm"
+          size={BtnSizes.FULL}
+          type={BtnTypes.PRIMARY}
+          text={t('neeruVaults.closeSheet.confirmCta')}
+          showLoading={closeStatus === 'loading'}
+          disabled={closeStatus === 'loading'}
+          onPress={() => dispatch(closePositionStart({ positionId: position.positionId }))}
+          style={styles.cta}
+        />
+      </View>
+    </BottomSheet>
+  )
+}
+
+function Row({
+  label,
+  value,
+  bold,
+  negative,
+}: {
+  label: string
+  value: string
+  bold?: boolean
+  negative?: boolean
+}) {
+  return (
+    <View style={styles.row}>
+      <Text style={[styles.rowLabel, bold && styles.bold]}>{label}</Text>
+      <Text style={[styles.rowValue, bold && styles.bold, negative && styles.negative]}>
+        {value}
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  body: { padding: Spacing.Regular16, gap: Spacing.Smallest8 },
+  subtitle: {
+    ...typeScale.bodyMedium,
+    color: Colors.gray3,
+    marginBottom: Spacing.Smallest8,
+  },
+  row: { flexDirection: 'row', justifyContent: 'space-between' },
+  rowLabel: { ...typeScale.bodyMedium, color: Colors.gray3 },
+  rowValue: { ...typeScale.bodyMedium, color: Colors.black },
+  bold: { fontWeight: '600' },
+  negative: { color: Colors.error },
+  warning: {
+    ...typeScale.bodySmall,
+    color: Colors.warningDark,
+    marginTop: Spacing.Smallest8,
+  },
+  cta: { marginTop: Spacing.Regular16 },
+})

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -14,9 +14,11 @@ import {
   NeeruTrancheId,
   trancheIdFromPositionId,
 } from 'src/earn/neeru/constants'
+import NeeruCloseSheet from 'src/earn/neeru/NeeruCloseSheet'
 import NeeruPositionRow from 'src/earn/neeru/NeeruPositionRow'
 import { neeruFetchStatusSelector, neeruPositionsByTrancheSelector } from 'src/earn/neeru/selectors'
 import { fetchPositionsStart } from 'src/earn/neeru/slice'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -40,6 +42,9 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
   const dispatch = useDispatch()
   const fetchStatus = useSelector(neeruFetchStatusSelector)
   const byTranche = useSelector(neeruPositionsByTrancheSelector)
+  const [selectedPosition, setSelectedPosition] = React.useState<NeeruIndividualPosition | null>(
+    null
+  )
 
   const trancheId = trancheIdFromPositionId(pool.positionId)
 
@@ -84,9 +89,7 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
               <NeeruPositionRow
                 key={p.positionId}
                 position={p}
-                onManagePress={() => {
-                  // Wired in Phase 7 (close sheet). No-op for now.
-                }}
+                onManagePress={(pos) => setSelectedPosition(pos)}
               />
             ))}
           </View>
@@ -117,6 +120,9 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
           </Text>
         </View>
       </ScrollView>
+      {selectedPosition && (
+        <NeeruCloseSheet position={selectedPosition} onClose={() => setSelectedPosition(null)} />
+      )}
     </SafeAreaView>
   )
 }

--- a/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
@@ -34,7 +34,7 @@ describe('NeeruCloseSheet', () => {
     const store = createMockStore({ neeru: initialNeeruState } as any)
     const { getByText } = render(
       <Provider store={store}>
-        <NeeruCloseSheet position={pos} onClose={() => {}} />
+        <NeeruCloseSheet position={pos} onClose={jest.fn()} />
       </Provider>
     )
     // Translation mock returns keys, so we assert on the principal/interest VALUES
@@ -48,7 +48,7 @@ describe('NeeruCloseSheet', () => {
     const spy = jest.spyOn(store, 'dispatch')
     const { getByTestId } = render(
       <Provider store={store}>
-        <NeeruCloseSheet position={pos} onClose={() => {}} />
+        <NeeruCloseSheet position={pos} onClose={jest.fn()} />
       </Provider>
     )
     fireEvent.press(getByTestId('NeeruCloseSheet.Confirm'))

--- a/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import NeeruCloseSheet from 'src/earn/neeru/NeeruCloseSheet'
+import { closePositionStart, initialState as initialNeeruState } from 'src/earn/neeru/slice'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import { createMockStore } from 'test/utils'
+
+const pos: NeeruIndividualPosition = {
+  positionId: '1234',
+  tranche: 1,
+  trancheLabel: '30 dias',
+  principal: '10000',
+  accruedInterest: '82.5',
+  dailyRateRay: '0',
+  monthlyRatePercentage: 1.0,
+  startTs: 0,
+  maturityTs: 1702592000,
+  depositBlock: 0,
+  depositTxHash: '0x' + 'a'.repeat(64),
+  renewedFromPositionId: null,
+  currentPayoutIfClosed: {
+    principal: '10000',
+    interest: '82.5',
+    penaltyBps: 2000,
+    interestAfterPenalty: '66',
+    total: '10066',
+    isEarly: true,
+  },
+}
+
+describe('NeeruCloseSheet', () => {
+  it('renders payout breakdown', () => {
+    const store = createMockStore({ neeru: initialNeeruState } as any)
+    const { getByText } = render(
+      <Provider store={store}>
+        <NeeruCloseSheet position={pos} onClose={() => {}} />
+      </Provider>
+    )
+    // Translation mock returns keys, so we assert on the principal/interest VALUES
+    expect(getByText(/10000/)).toBeTruthy()
+    expect(getByText(/82.5/)).toBeTruthy()
+    expect(getByText(/10066/)).toBeTruthy()
+  })
+
+  it('dispatches closePositionStart on confirm', () => {
+    const store = createMockStore({ neeru: initialNeeruState } as any)
+    const spy = jest.spyOn(store, 'dispatch')
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <NeeruCloseSheet position={pos} onClose={() => {}} />
+      </Provider>
+    )
+    fireEvent.press(getByTestId('NeeruCloseSheet.Confirm'))
+    expect(spy).toHaveBeenCalledWith(closePositionStart({ positionId: '1234' }))
+  })
+})

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -104,4 +104,22 @@ describe('NeeruVaultDetailScreen', () => {
     // Full contract address must NOT be truncated
     expect(getByText(/0xD05CDF2DC56D97333c547519dF58D56145766294/)).toBeTruthy()
   })
+
+  it('opens NeeruCloseSheet when a position row Manage is pressed', () => {
+    const store = createMockStore({
+      neeru: {
+        ...initialNeeruState,
+        positions: [positionFor('555')],
+        fetchStatus: 'success',
+      },
+    } as any)
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    expect(queryByTestId('NeeruCloseSheet')).toBeNull()
+    fireEvent.press(getByTestId('NeeruPositionRow.Manage.555'))
+    expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
+  })
 })

--- a/src/earn/neeru/__tests__/errorMapping.test.ts
+++ b/src/earn/neeru/__tests__/errorMapping.test.ts
@@ -1,0 +1,25 @@
+import { extractNeeruErrorCode, mapNeeruErrorToI18nKey } from 'src/earn/neeru/errorMapping'
+
+describe('mapNeeruErrorToI18nKey', () => {
+  it('maps known codes', () => {
+    expect(mapNeeruErrorToI18nKey('DEPOSITS_PAUSED')).toBe('neeruVaults.errors.depositsPaused')
+    expect(mapNeeruErrorToI18nKey('POSITION_NOT_OWNED')).toBe('neeruVaults.errors.positionStale')
+  })
+  it('returns unknown for null', () => {
+    expect(mapNeeruErrorToI18nKey(null)).toBe('neeruVaults.errors.unknown')
+  })
+  it('returns unknown for unrecognized', () => {
+    expect(mapNeeruErrorToI18nKey('SOME_NEW_CODE')).toBe('neeruVaults.errors.unknown')
+  })
+})
+
+describe('extractNeeruErrorCode', () => {
+  it('finds known code in message', () => {
+    expect(extractNeeruErrorCode(new Error('fetch failed: DEPOSITS_PAUSED'))).toBe(
+      'DEPOSITS_PAUSED'
+    )
+  })
+  it('returns null when no match', () => {
+    expect(extractNeeruErrorCode(new Error('network ECONNRESET'))).toBeNull()
+  })
+})

--- a/src/earn/neeru/__tests__/rateConversion.test.ts
+++ b/src/earn/neeru/__tests__/rateConversion.test.ts
@@ -1,0 +1,37 @@
+import { computePayout, monthlyPercentFromDailyRateRay } from 'src/earn/neeru/rateConversion'
+
+describe('monthlyPercentFromDailyRateRay', () => {
+  it('returns 0 for RAY (1e27)', () => {
+    expect(monthlyPercentFromDailyRateRay('1000000000000000000000000000')).toBeCloseTo(0, 4)
+  })
+  it('computes ~1% monthly for the launch 30d rate', () => {
+    // dailyRateRay corresponding to ~1%/30d compounding
+    const rate = monthlyPercentFromDailyRateRay('1000331300000000000000000000')
+    expect(rate).toBeGreaterThan(0.9)
+    expect(rate).toBeLessThan(1.1)
+  })
+})
+
+describe('computePayout', () => {
+  it('isEarly=false returns full payout', () => {
+    const r = computePayout({
+      principal: '10000',
+      accruedInterest: '100',
+      penaltyBps: 2000,
+      isEarly: false,
+    })
+    expect(r.total).toBe('10100')
+    expect(r.interestAfterPenalty).toBe('100')
+  })
+
+  it('isEarly=true applies penalty to interest only', () => {
+    const r = computePayout({
+      principal: '10000',
+      accruedInterest: '100',
+      penaltyBps: 2000,
+      isEarly: true,
+    })
+    expect(r.interestAfterPenalty).toBe('80')
+    expect(r.total).toBe('10080')
+  })
+})

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -1,12 +1,24 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
-import { fetchNeeruPositionsSaga } from 'src/earn/neeru/saga'
 import {
+  NEERU_INTEREST_POOL_LOW_ACTION,
+  closeNeeruPositionSaga,
+  fetchNeeruPositionsSaga,
+} from 'src/earn/neeru/saga'
+import {
+  closePositionFailure,
+  closePositionStart,
+  closePositionSuccess,
   fetchPositionsFailure,
   fetchPositionsStart,
   fetchPositionsSuccess,
 } from 'src/earn/neeru/slice'
+import { triggerShortcutRequest } from 'src/positions/saga'
+import { hooksApiUrlSelector } from 'src/positions/selectors'
+import { feeCurrenciesSelector } from 'src/tokens/selectors'
+import { prepareTransactions } from 'src/viem/prepareTransactions'
+import { sendPreparedTransactions } from 'src/viem/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 describe('fetchNeeruPositionsSaga', () => {
@@ -55,7 +67,53 @@ describe('fetchNeeruPositionsSaga', () => {
         )
         dispatchedSuccess = !!(successCalls && successCalls.length > 0)
       })
-      .catch(() => {})
+      .catch(jest.fn())
     expect(dispatchedSuccess).toBe(false)
+  })
+})
+
+describe('closeNeeruPositionSaga', () => {
+  const WALLET = '0x' + 'a'.repeat(40)
+  const POSITION_ID = '1234'
+
+  it('dispatches success on happy path', async () => {
+    const fakeTxs = [{ to: '0x', data: '0x', value: '0', networkId: 'celo-mainnet' }]
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [matchers.call.fn(triggerShortcutRequest), { transactions: fakeTxs }],
+        [matchers.call.fn(prepareTransactions), { type: 'possible', transactions: [] }],
+        [matchers.call.fn(sendPreparedTransactions), []],
+      ])
+      .put(closePositionSuccess({ positionId: POSITION_ID }))
+      .run()
+  })
+
+  it('on InterestPoolLow revert, dispatches NEERU_INTEREST_POOL_LOW_ACTION + closePositionFailure', async () => {
+    const err = new Error('Reverted: InterestPoolLow')
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [matchers.call.fn(triggerShortcutRequest), Promise.reject(err)],
+      ])
+      .put({ type: NEERU_INTEREST_POOL_LOW_ACTION, payload: { positionId: POSITION_ID } })
+      .put(closePositionFailure({ positionId: POSITION_ID, error: 'InterestPoolLow' }))
+      .run()
+  })
+
+  it('on generic error, dispatches closePositionFailure', async () => {
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [matchers.call.fn(triggerShortcutRequest), Promise.reject(new Error('boom'))],
+      ])
+      .put(closePositionFailure({ positionId: POSITION_ID, error: 'boom' }))
+      .run()
   })
 })

--- a/src/earn/neeru/errorMapping.ts
+++ b/src/earn/neeru/errorMapping.ts
@@ -1,0 +1,33 @@
+const NEERU_ERROR_KEYS: Record<string, string> = {
+  INVALID_TRANCHE: 'neeruVaults.errors.invalidTranche',
+  INVALID_AMOUNT: 'neeruVaults.errors.invalidAmount',
+  AMOUNT_BELOW_MIN: 'neeruVaults.errors.amountBelowMin',
+  DEPOSITS_PAUSED: 'neeruVaults.errors.depositsPaused',
+  GLOBAL_CAP_EXCEEDED: 'neeruVaults.errors.globalCapExceeded',
+  TRANCHE_CAP_EXCEEDED: 'neeruVaults.errors.trancheCapExceeded',
+  RATE_NOT_SET: 'neeruVaults.errors.rateNotSet',
+  POSITION_NOT_FOUND: 'neeruVaults.errors.positionStale',
+  POSITION_NOT_OWNED: 'neeruVaults.errors.positionStale',
+  POSITION_ALREADY_CLOSED: 'neeruVaults.errors.positionAlreadyClosed',
+  NEERU_NOT_CONFIGURED: 'neeruVaults.errors.serviceUnavailable',
+}
+
+export function mapNeeruErrorToI18nKey(code: string | null | undefined): string {
+  if (!code) return 'neeruVaults.errors.unknown'
+  return NEERU_ERROR_KEYS[code] ?? 'neeruVaults.errors.unknown'
+}
+
+/**
+ * Extract a backend error code from an error message. Backend returns
+ * { error: "<CODE>" } as JSON in 400 responses, surfaced as
+ * "fetch failed: 400 Bad Request" + body string in our fetch wrapper.
+ */
+export function extractNeeruErrorCode(error: Error | unknown): string | null {
+  if (!(error instanceof Error)) return null
+  const msg = error.message
+  // Look for known codes in the error message
+  for (const code of Object.keys(NEERU_ERROR_KEYS)) {
+    if (msg.includes(code)) return code
+  }
+  return null
+}

--- a/src/earn/neeru/rateConversion.ts
+++ b/src/earn/neeru/rateConversion.ts
@@ -1,0 +1,34 @@
+import BigNumber from 'bignumber.js'
+
+const RAY = new BigNumber(10).pow(27)
+
+export function monthlyPercentFromDailyRateRay(dailyRateRay: string): number {
+  const daily = new BigNumber(dailyRateRay).dividedBy(RAY)
+  if (daily.isLessThanOrEqualTo(1)) return 0
+  const monthly = daily.pow(30).minus(1).multipliedBy(100)
+  return Number(monthly.toFixed(6))
+}
+
+export function computePayout({
+  principal,
+  accruedInterest,
+  penaltyBps,
+  isEarly,
+}: {
+  principal: string
+  accruedInterest: string
+  penaltyBps: number
+  isEarly: boolean
+}) {
+  const p = new BigNumber(principal)
+  const i = new BigNumber(accruedInterest)
+  const ip = isEarly ? i.multipliedBy(10000 - penaltyBps).dividedBy(10000) : i
+  return {
+    principal: p.toFixed(),
+    interest: i.toFixed(),
+    interestAfterPenalty: ip.toFixed(),
+    total: p.plus(ip).toFixed(),
+    penaltyBps,
+    isEarly,
+  }
+}

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -1,16 +1,34 @@
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
 import {
+  closePositionFailure,
+  closePositionStart,
+  closePositionSuccess,
   fetchPositionsFailure,
   fetchPositionsStart,
   fetchPositionsSuccess,
 } from 'src/earn/neeru/slice'
+import { hooksApiUrlSelector } from 'src/positions/selectors'
+import { RawShortcutTransaction } from 'src/positions/slice'
+import { triggerShortcutRequest } from 'src/positions/saga'
+import { rawShortcutTransactionsToTransactionRequests } from 'src/positions/transactions'
+import { feeCurrenciesSelector } from 'src/tokens/selectors'
+import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
+import { PreparedTransactionsResult, prepareTransactions } from 'src/viem/prepareTransactions'
+import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
+import { sendPreparedTransactions } from 'src/viem/saga'
 import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { call, put, select, spawn, takeLeading } from 'typed-redux-saga'
 
 const TAG = 'earn/neeru/saga'
+
+export const NEERU_INTEREST_POOL_LOW_ACTION = 'neeru/interestPoolLow' as const
+
+function isInterestPoolLow(error: Error): boolean {
+  return error.message.includes('InterestPoolLow')
+}
 
 export function* fetchNeeruPositionsSaga(_action: ReturnType<typeof fetchPositionsStart>) {
   const walletAddress = yield* select(walletAddressSelector)
@@ -41,6 +59,64 @@ export function* watchFetchNeeruPositions() {
   yield* takeLeading(fetchPositionsStart.type, fetchNeeruPositionsSaga)
 }
 
+export function* closeNeeruPositionSaga(action: ReturnType<typeof closePositionStart>) {
+  const { positionId } = action.payload
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) {
+    Logger.warn(TAG, 'no wallet address, skipping close')
+    return
+  }
+  const hooksApiUrl = yield* select(hooksApiUrlSelector)
+  const feeCurrencies = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+
+  try {
+    const response: { transactions: RawShortcutTransaction[] } = yield* call(
+      triggerShortcutRequest,
+      hooksApiUrl,
+      {
+        address: walletAddress,
+        appId: 'neeru-vaults',
+        networkId: NetworkId['celo-mainnet'],
+        shortcutId: 'withdraw',
+        positionId,
+      }
+    )
+    const prepared: PreparedTransactionsResult = yield* call(prepareTransactions, {
+      feeCurrencies,
+      baseTransactions: rawShortcutTransactionsToTransactionRequests(response.transactions),
+      isGasSubsidized: false,
+      origin: 'earn-withdraw' as const,
+    })
+    if (prepared.type !== 'possible') {
+      throw new Error(`Cannot prepare close tx: ${prepared.type}`)
+    }
+    yield* call(
+      sendPreparedTransactions,
+      getSerializablePreparedTransactions(prepared.transactions),
+      NetworkId['celo-mainnet'],
+      []
+    )
+    yield* put(closePositionSuccess({ positionId }))
+  } catch (e) {
+    const error = ensureError(e)
+    if (isInterestPoolLow(error)) {
+      yield* put({
+        type: NEERU_INTEREST_POOL_LOW_ACTION,
+        payload: { positionId },
+      })
+      yield* put(closePositionFailure({ positionId, error: 'InterestPoolLow' }))
+      return
+    }
+    Logger.error(TAG, 'close failed', error)
+    yield* put(closePositionFailure({ positionId, error: error.message }))
+  }
+}
+
+export function* watchCloseNeeruPosition() {
+  yield* takeLeading(closePositionStart.type, closeNeeruPositionSaga)
+}
+
 export function* neeruSaga() {
   yield* spawn(watchFetchNeeruPositions)
+  yield* spawn(watchCloseNeeruPosition)
 }


### PR DESCRIPTION
## Summary

Phase 7 of the Neeru Vaults wallet plan: closing a Neeru position from the detail screen with full penalty disclosure, plus backend error code mapping for friendly UI messages.

- `src/earn/neeru/rateConversion.ts` - `monthlyPercentFromDailyRateRay` + `computePayout`
- `src/earn/neeru/errorMapping.ts` - maps backend codes (DEPOSITS_PAUSED, AMOUNT_BELOW_MIN, etc.) to i18n keys (Delta C)
- `src/earn/neeru/NeeruCloseSheet.tsx` - bottom sheet showing principal/interest/penalty/total + confirm CTA
- `src/earn/neeru/saga.ts` - `closeNeeruPositionSaga` builds withdraw shortcut via hooks-api triggerShortcut, dispatches `NEERU_INTEREST_POOL_LOW_ACTION` when contract reverts with that error (Phase 8 subscribes)
- `src/earn/neeru/NeeruVaultDetailScreen.tsx` - Manage CTA on each PositionRow now opens the close sheet

**Persist version unchanged (251).** No migrations, no schema changes.

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 17-19 + Delta C)

## Test plan

- [ ] CI green
- [ ] rateConversion 4 tests pass
- [ ] errorMapping 5 tests pass
- [ ] NeeruCloseSheet 2 tests pass
- [ ] NeeruVaultDetailScreen updated test passes (sheet opens on Manage)
- [ ] Close saga 3 tests pass (happy path, InterestPoolLow, generic error)