### PR TITLE
feat(earn/neeru): phase 8 emergency close fallback

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2965,7 +2965,8 @@
       "explanation": "You can recover your principal of {{principal}} now, but you will forfeit the {{interest}} of interest you earned. This is irreversible.",
       "alternative": "If you can wait, the fund usually recovers within a few hours.",
       "primaryCta": "Wait and try again later",
-      "secondaryCta": "Withdraw principal only"
+      "secondaryCta": "Withdraw principal only",
+      "confirmAgain": "Tap again to confirm"
     },
     "errors": {
       "fetchPositionsFailed": "We couldn't load your positions. Pull down to retry.",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2972,7 +2972,8 @@
       "explanation": "Puedes recuperar tu capital de {{principal}} ahora, pero perderas los {{interest}} de interes que generaste. Esta accion no se puede revertir.",
       "alternative": "Si puedes esperar, el fondo se recupera generalmente en unas horas.",
       "primaryCta": "Esperar e intentar despues",
-      "secondaryCta": "Retirar solo el capital"
+      "secondaryCta": "Retirar solo el capital",
+      "confirmAgain": "Toca de nuevo para confirmar"
     },
     "errors": {
       "fetchPositionsFailed": "No pudimos cargar tus depositos. Desliza hacia abajo para reintentar.",

--- a/src/earn/neeru/NeeruEmergencyCloseSheet.tsx
+++ b/src/earn/neeru/NeeruEmergencyCloseSheet.tsx
@@ -1,0 +1,77 @@
+import { BottomSheetModal } from '@gorhom/bottom-sheet'
+import * as React from 'react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import BottomSheet from 'src/components/BottomSheet'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  position: NeeruIndividualPosition
+  onConfirm: (position: NeeruIndividualPosition) => void
+  onCancel: () => void
+}
+
+export default function NeeruEmergencyCloseSheet({ position, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation()
+  const [armed, setArmed] = useState(false)
+  const ref = React.useRef<BottomSheetModal>(null)
+
+  return (
+    <BottomSheet
+      forwardedRef={ref}
+      onClose={onCancel}
+      title={t('neeruVaults.emergencyCloseSheet.title')}
+      testId="NeeruEmergencyCloseSheet"
+    >
+      <View style={styles.body}>
+        <Text style={styles.subtitle}>{t('neeruVaults.emergencyCloseSheet.subtitle')}</Text>
+        <Text style={styles.bodyText}>
+          {t('neeruVaults.emergencyCloseSheet.explanation', {
+            principal: position.principal,
+            interest: position.accruedInterest,
+          })}
+        </Text>
+        <Text style={styles.bodyText}>{t('neeruVaults.emergencyCloseSheet.alternative')}</Text>
+        <Button
+          testID="NeeruEmergencyCloseSheet.Primary"
+          size={BtnSizes.FULL}
+          type={BtnTypes.PRIMARY}
+          text={t('neeruVaults.emergencyCloseSheet.primaryCta')}
+          onPress={onCancel}
+          style={styles.cta}
+        />
+        <Button
+          testID="NeeruEmergencyCloseSheet.Secondary"
+          size={BtnSizes.FULL}
+          type={armed ? BtnTypes.PRIMARY : BtnTypes.SECONDARY}
+          text={t(
+            armed
+              ? 'neeruVaults.emergencyCloseSheet.confirmAgain'
+              : 'neeruVaults.emergencyCloseSheet.secondaryCta'
+          )}
+          onPress={() => {
+            if (armed) onConfirm(position)
+            else setArmed(true)
+          }}
+          style={styles.cta}
+        />
+      </View>
+    </BottomSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  body: { padding: Spacing.Regular16, gap: Spacing.Smallest8 },
+  subtitle: {
+    ...typeScale.bodyMedium,
+    color: Colors.black,
+    marginBottom: Spacing.Smallest8,
+  },
+  bodyText: { ...typeScale.bodyMedium, color: Colors.gray3 },
+  cta: { marginTop: Spacing.Smallest8 },
+})

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -15,9 +15,15 @@ import {
   trancheIdFromPositionId,
 } from 'src/earn/neeru/constants'
 import NeeruCloseSheet from 'src/earn/neeru/NeeruCloseSheet'
+import NeeruEmergencyCloseSheet from 'src/earn/neeru/NeeruEmergencyCloseSheet'
 import NeeruPositionRow from 'src/earn/neeru/NeeruPositionRow'
-import { neeruFetchStatusSelector, neeruPositionsByTrancheSelector } from 'src/earn/neeru/selectors'
-import { fetchPositionsStart } from 'src/earn/neeru/slice'
+import {
+  neeruCloseStatusSelector,
+  neeruFetchStatusSelector,
+  neeruLastErrorSelector,
+  neeruPositionsByTrancheSelector,
+} from 'src/earn/neeru/selectors'
+import { emergencyCloseStart, fetchPositionsStart } from 'src/earn/neeru/slice'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -41,16 +47,33 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const fetchStatus = useSelector(neeruFetchStatusSelector)
+  const closeStatus = useSelector(neeruCloseStatusSelector)
+  const lastError = useSelector(neeruLastErrorSelector)
   const byTranche = useSelector(neeruPositionsByTrancheSelector)
   const [selectedPosition, setSelectedPosition] = React.useState<NeeruIndividualPosition | null>(
     null
   )
+  const [emergencyTarget, setEmergencyTarget] = React.useState<NeeruIndividualPosition | null>(null)
+  const lastSelectedRef = React.useRef<NeeruIndividualPosition | null>(null)
 
   const trancheId = trancheIdFromPositionId(pool.positionId)
 
   useEffect(() => {
     dispatch(fetchPositionsStart())
   }, [dispatch])
+
+  useEffect(() => {
+    if (selectedPosition) {
+      lastSelectedRef.current = selectedPosition
+    }
+  }, [selectedPosition])
+
+  useEffect(() => {
+    if (closeStatus === 'error' && lastError === 'InterestPoolLow' && lastSelectedRef.current) {
+      setEmergencyTarget(lastSelectedRef.current)
+      setSelectedPosition(null)
+    }
+  }, [closeStatus, lastError])
 
   if (trancheId === null) {
     return null
@@ -122,6 +145,16 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
       </ScrollView>
       {selectedPosition && (
         <NeeruCloseSheet position={selectedPosition} onClose={() => setSelectedPosition(null)} />
+      )}
+      {emergencyTarget && (
+        <NeeruEmergencyCloseSheet
+          position={emergencyTarget}
+          onCancel={() => setEmergencyTarget(null)}
+          onConfirm={(pos) => {
+            dispatch(emergencyCloseStart({ positionId: pos.positionId }))
+            setEmergencyTarget(null)
+          }}
+        />
       )}
     </SafeAreaView>
   )

--- a/src/earn/neeru/__tests__/NeeruEmergencyCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruEmergencyCloseSheet.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import NeeruEmergencyCloseSheet from 'src/earn/neeru/NeeruEmergencyCloseSheet'
+import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+
+const pos: NeeruIndividualPosition = {
+  positionId: '1234',
+  tranche: 1,
+  trancheLabel: '30 dias',
+  principal: '10000',
+  accruedInterest: '82.5',
+  dailyRateRay: '0',
+  monthlyRatePercentage: 1.0,
+  startTs: 0,
+  maturityTs: 1702592000,
+  depositBlock: 0,
+  depositTxHash: '0x' + 'a'.repeat(64),
+  renewedFromPositionId: null,
+  currentPayoutIfClosed: {
+    principal: '10000',
+    interest: '82.5',
+    penaltyBps: 2000,
+    interestAfterPenalty: '66',
+    total: '10066',
+    isEarly: true,
+  },
+}
+
+describe('NeeruEmergencyCloseSheet', () => {
+  it('renders principal and interest in the explanation', () => {
+    const { getByText } = render(
+      <NeeruEmergencyCloseSheet position={pos} onConfirm={() => {}} onCancel={() => {}} />
+    )
+    expect(getByText(/10000/)).toBeTruthy()
+    expect(getByText(/82.5/)).toBeTruthy()
+  })
+
+  it('requires two taps on the secondary CTA before firing onConfirm', () => {
+    const onConfirm = jest.fn()
+    const { getByTestId } = render(
+      <NeeruEmergencyCloseSheet position={pos} onConfirm={onConfirm} onCancel={() => {}} />
+    )
+    fireEvent.press(getByTestId('NeeruEmergencyCloseSheet.Secondary'))
+    expect(onConfirm).not.toHaveBeenCalled()
+    fireEvent.press(getByTestId('NeeruEmergencyCloseSheet.Secondary'))
+    expect(onConfirm).toHaveBeenCalledWith(pos)
+  })
+})

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -122,4 +122,41 @@ describe('NeeruVaultDetailScreen', () => {
     fireEvent.press(getByTestId('NeeruPositionRow.Manage.555'))
     expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
   })
+
+  it('opens NeeruEmergencyCloseSheet when close fails with InterestPoolLow', () => {
+    // Start with idle state so user can tap Manage to seed lastSelectedRef
+    const store = createMockStore({
+      neeru: {
+        ...initialNeeruState,
+        positions: [positionFor('789')],
+        fetchStatus: 'success',
+      },
+    } as any)
+    const { getByTestId, queryByTestId, rerender } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    // User taps Manage, seeding lastSelectedRef + opening close sheet
+    fireEvent.press(getByTestId('NeeruPositionRow.Manage.789'))
+    expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
+
+    // Backend / chain now reports InterestPoolLow via slice update
+    const failedStore = createMockStore({
+      neeru: {
+        ...initialNeeruState,
+        positions: [positionFor('789')],
+        fetchStatus: 'success',
+        closeStatus: 'error',
+        lastError: 'InterestPoolLow',
+      },
+    } as any)
+    rerender(
+      <Provider store={failedStore}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+
+    expect(queryByTestId('NeeruEmergencyCloseSheet')).toBeTruthy()
+  })
 })

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -4,12 +4,14 @@ import { fetchNeeruPositions } from 'src/earn/neeru/api'
 import {
   NEERU_INTEREST_POOL_LOW_ACTION,
   closeNeeruPositionSaga,
+  emergencyCloseNeeruPositionSaga,
   fetchNeeruPositionsSaga,
 } from 'src/earn/neeru/saga'
 import {
   closePositionFailure,
   closePositionStart,
   closePositionSuccess,
+  emergencyCloseStart,
   fetchPositionsFailure,
   fetchPositionsStart,
   fetchPositionsSuccess,
@@ -107,6 +109,44 @@ describe('closeNeeruPositionSaga', () => {
 
   it('on generic error, dispatches closePositionFailure', async () => {
     await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [matchers.call.fn(triggerShortcutRequest), Promise.reject(new Error('boom'))],
+      ])
+      .put(closePositionFailure({ positionId: POSITION_ID, error: 'boom' }))
+      .run()
+  })
+})
+
+describe('emergencyCloseNeeruPositionSaga', () => {
+  const WALLET = '0x' + 'a'.repeat(40)
+  const POSITION_ID = '5678'
+
+  it('happy path: dispatches closePositionSuccess', async () => {
+    const fakeTxs = [{ to: '0x', data: '0x', value: '0', networkId: 'celo-mainnet' }]
+    await expectSaga(
+      emergencyCloseNeeruPositionSaga,
+      emergencyCloseStart({ positionId: POSITION_ID })
+    )
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [matchers.call.fn(triggerShortcutRequest), { transactions: fakeTxs }],
+        [matchers.call.fn(prepareTransactions), { type: 'possible', transactions: [] }],
+        [matchers.call.fn(sendPreparedTransactions), []],
+      ])
+      .put(closePositionSuccess({ positionId: POSITION_ID }))
+      .run()
+  })
+
+  it('failure: dispatches closePositionFailure with error message', async () => {
+    await expectSaga(
+      emergencyCloseNeeruPositionSaga,
+      emergencyCloseStart({ positionId: POSITION_ID })
+    )
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],

--- a/src/earn/neeru/__tests__/slice.test.ts
+++ b/src/earn/neeru/__tests__/slice.test.ts
@@ -2,6 +2,7 @@ import reducer, {
   closePositionFailure,
   closePositionStart,
   closePositionSuccess,
+  emergencyCloseStart,
   fetchPositionsFailure,
   fetchPositionsStart,
   fetchPositionsSuccess,
@@ -84,5 +85,12 @@ describe('neeru slice', () => {
     state = reducer(state, closePositionFailure({ positionId: '1234', error: 'InterestPoolLow' }))
     expect(state.closeStatus).toBe('error')
     expect(state.lastError).toBe('InterestPoolLow')
+  })
+
+  it('emergencyCloseStart sets loading + closingPositionId', () => {
+    const state = reducer(initialState, emergencyCloseStart({ positionId: '99' }))
+    expect(state.closeStatus).toBe('loading')
+    expect(state.closingPositionId).toBe('99')
+    expect(state.lastError).toBeNull()
   })
 })

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -3,6 +3,7 @@ import {
   closePositionFailure,
   closePositionStart,
   closePositionSuccess,
+  emergencyCloseStart,
   fetchPositionsFailure,
   fetchPositionsStart,
   fetchPositionsSuccess,
@@ -116,7 +117,57 @@ export function* watchCloseNeeruPosition() {
   yield* takeLeading(closePositionStart.type, closeNeeruPositionSaga)
 }
 
+export function* emergencyCloseNeeruPositionSaga(action: ReturnType<typeof emergencyCloseStart>) {
+  const { positionId } = action.payload
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) {
+    Logger.warn(TAG, 'no wallet address, skipping emergency close')
+    return
+  }
+  const hooksApiUrl = yield* select(hooksApiUrlSelector)
+  const feeCurrencies = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+
+  try {
+    const response: { transactions: RawShortcutTransaction[] } = yield* call(
+      triggerShortcutRequest,
+      hooksApiUrl,
+      {
+        address: walletAddress,
+        appId: 'neeru-vaults',
+        networkId: NetworkId['celo-mainnet'],
+        shortcutId: 'withdraw-principal-only',
+        positionId,
+      }
+    )
+    const prepared: PreparedTransactionsResult = yield* call(prepareTransactions, {
+      feeCurrencies,
+      baseTransactions: rawShortcutTransactionsToTransactionRequests(response.transactions),
+      isGasSubsidized: false,
+      origin: 'earn-withdraw' as const,
+    })
+    if (prepared.type !== 'possible') {
+      throw new Error(`Cannot prepare emergency tx: ${prepared.type}`)
+    }
+    yield* call(
+      sendPreparedTransactions,
+      getSerializablePreparedTransactions(prepared.transactions),
+      NetworkId['celo-mainnet'],
+      []
+    )
+    yield* put(closePositionSuccess({ positionId }))
+  } catch (e) {
+    const error = ensureError(e)
+    Logger.error(TAG, 'emergency close failed', error)
+    yield* put(closePositionFailure({ positionId, error: error.message }))
+  }
+}
+
+export function* watchEmergencyCloseNeeruPosition() {
+  yield* takeLeading(emergencyCloseStart.type, emergencyCloseNeeruPositionSaga)
+}
+
 export function* neeruSaga() {
   yield* spawn(watchFetchNeeruPositions)
   yield* spawn(watchCloseNeeruPosition)
+  yield* spawn(watchEmergencyCloseNeeruPosition)
 }

--- a/src/earn/neeru/slice.ts
+++ b/src/earn/neeru/slice.ts
@@ -61,6 +61,11 @@ const slice = createSlice({
       state.closingPositionId = null
       state.lastError = action.payload.error
     },
+    emergencyCloseStart: (state, action: PayloadAction<{ positionId: string }>) => {
+      state.closeStatus = 'loading'
+      state.closingPositionId = action.payload.positionId
+      state.lastError = null
+    },
   },
 })
 
@@ -71,6 +76,7 @@ export const {
   closePositionStart,
   closePositionSuccess,
   closePositionFailure,
+  emergencyCloseStart,
 } = slice.actions
 
 export default slice.reducer


### PR DESCRIPTION
## Summary

Phase 8 (final functional phase) of the Neeru Vaults wallet plan: emergency-close fallback when the contract reverts with InterestPoolLow.

- emergencyCloseStart slice action with same close-status lifecycle as closePositionStart
- NeeruEmergencyCloseSheet with double-confirm on the destructive CTA (prevents accidental forfeit of accrued interest)
- emergencyCloseNeeruPositionSaga builds withdraw-principal-only shortcut via hooks-api
- NeeruVaultDetailScreen subscribes to closeStatus === 'error' and lastError === 'InterestPoolLow' and opens the emergency sheet for the position that was attempted
- i18n: confirmAgain key added for the armed-state button label

Persist version unchanged (251). No migrations, no schema changes.

Plan: tasks/plans/2026-06-26-neeru-vaults-wallet.md (Tasks 20-21)

## End-to-end feature scope after this PR

Feature is functionally complete behind show_neeru_vaults Statsig gate. Next step is the verification pass (build all, lint, full test suite, smoke test on iOS simulator with gate enabled in the dogfood wallet).

## Test plan

- [ ] CI green
- [ ] 6 slice tests (5 existing + 1 new for emergencyCloseStart)
- [ ] 2 NeeruEmergencyCloseSheet tests
- [ ] 2 new saga tests for emergencyCloseNeeruPositionSaga
- [ ] Updated detail screen test (sheet opens on InterestPoolLow)
- [ ] 43/43 neeru tests overall, yarn build:ts clean