### PR TITLE
fix(earn): pool card title + Pesos unit per manual

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2924,7 +2924,7 @@
     },
     "detail": {
       "header": "Your {{trancheLabel}} positions",
-      "aggregateBalance": "Total in {{trancheLabel}}",
+      "aggregateBalance": "Total in {{trancheLabel}}: {{amount}} Pesos",
       "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% monthly",
       "depositCta": "Deposit",
       "noPositions": "You don't have positions in this option yet",
@@ -2942,8 +2942,8 @@
       }
     },
     "positionRow": {
-      "principal": "Principal: {{amount}}",
-      "interest": "Earned: {{amount}}",
+      "principal": "Principal: {{amount}} Pesos",
+      "interest": "Earned: {{amount}} Pesos",
       "maturity": "Available {{date}}",
       "flexible": "No minimum time",
       "depositedAt": "Deposited on {{date}}",
@@ -2962,7 +2962,7 @@
     "emergencyCloseSheet": {
       "title": "Emergency withdrawal",
       "subtitle": "The fund cannot pay interest right now",
-      "explanation": "You can recover your principal of {{principal}} now, but you will forfeit the {{interest}} of interest you earned. This is irreversible.",
+      "explanation": "You can recover your principal of {{principal}} Pesos now, but you will forfeit the {{interest}} Pesos of interest you earned. This is irreversible.",
       "alternative": "If you can wait, the fund usually recovers within a few hours.",
       "primaryCta": "Wait and try again later",
       "secondaryCta": "Withdraw principal only",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2931,7 +2931,7 @@
     },
     "detail": {
       "header": "Tus depositos {{trancheLabel}}",
-      "aggregateBalance": "Total en {{trancheLabel}}",
+      "aggregateBalance": "Total en {{trancheLabel}}: {{amount}} Pesos",
       "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% mensual",
       "depositCta": "Depositar",
       "noPositions": "Todavia no tienes depositos en esta opcion",
@@ -2949,8 +2949,8 @@
       }
     },
     "positionRow": {
-      "principal": "Capital: {{amount}}",
-      "interest": "Ganado: {{amount}}",
+      "principal": "Capital: {{amount}} Pesos",
+      "interest": "Ganado: {{amount}} Pesos",
       "maturity": "Disponible el {{date}}",
       "flexible": "Sin tiempo minimo",
       "depositedAt": "Depositado el {{date}}",
@@ -2969,7 +2969,7 @@
     "emergencyCloseSheet": {
       "title": "Retiro de emergencia",
       "subtitle": "El fondo no puede pagar intereses en este momento",
-      "explanation": "Puedes recuperar tu capital de {{principal}} ahora, pero perderas los {{interest}} de interes que generaste. Esta accion no se puede revertir.",
+      "explanation": "Puedes recuperar tu capital de {{principal}} Pesos ahora, pero perderas los {{interest}} Pesos de interes que generaste. Esta accion no se puede revertir.",
       "alternative": "Si puedes esperar, el fondo se recupera generalmente en unas horas.",
       "primaryCta": "Esperar e intentar despues",
       "secondaryCta": "Retirar solo el capital",

--- a/src/earn/PoolCard.test.tsx
+++ b/src/earn/PoolCard.test.tsx
@@ -43,10 +43,67 @@ describe('PoolCard', () => {
       </Provider>
     )
 
-    expect(getByText('USDC / ETH')).toBeTruthy()
+    // USDC -> "Dólares" via getTokenDisplayName per wallet manual; ETH stays as-is
+    expect(getByText('Dólares / ETH')).toBeTruthy()
     expect(getByText('earnFlow.poolCard.onNetwork, {"networkName":"Arbitrum One"}')).toBeTruthy()
     expect(getByText('earnFlow.poolCard.percentage, {"percentage":"1.92"}')).toBeTruthy()
     expect(getByText('COP$1,808,800.00')).toBeTruthy()
+  })
+
+  describe('card title display', () => {
+    it('renders Neeru pool with displayProps.title (tranche label) instead of token symbol', () => {
+      const neeruPool = {
+        ...mockEarnPositions[0],
+        appId: 'neeru-vaults',
+        displayProps: {
+          ...mockEarnPositions[0].displayProps,
+          title: '30 dias',
+        },
+      }
+      const { getByText, queryByText } = render(
+        <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
+          <PoolCard pool={neeruPool} testID="PoolCard.neeru-30d" />
+        </Provider>
+      )
+      expect(getByText('30 dias')).toBeTruthy()
+      // Should NOT show raw token symbol when Neeru
+      expect(queryByText('USDC')).toBeNull()
+      expect(queryByText('cCOP')).toBeNull()
+    })
+
+    it('maps token symbol via getTokenDisplayName for non-Neeru pools (cCOP -> Pesos)', () => {
+      // Simulate a non-Neeru pool whose token symbol is the legacy cCOP
+      const poolWithLegacySymbol = {
+        ...mockEarnPositions[0],
+        appId: 'allbridge',
+        tokens: [
+          {
+            ...mockEarnPositions[0].tokens[0],
+            symbol: 'cCOP',
+          },
+        ],
+      }
+      // To make tokensByIdSelector resolve, override the token balance with cCOP symbol
+      const storeWithCCop = createMockStore({
+        tokens: {
+          tokenBalances: {
+            ...mockTokenBalances,
+            [poolWithLegacySymbol.tokens[0].tokenId]: {
+              ...mockTokenBalances[mockArbUsdcTokenId],
+              tokenId: poolWithLegacySymbol.tokens[0].tokenId,
+              symbol: 'cCOP',
+            },
+          },
+        },
+      })
+      const { getByText, queryByText } = render(
+        <Provider store={storeWithCCop}>
+          <PoolCard pool={poolWithLegacySymbol} testID="PoolCard.legacy" />
+        </Provider>
+      )
+      expect(getByText('Pesos')).toBeTruthy()
+      expect(queryByText('cCOP')).toBeNull()
+    })
   })
 
   it('correct behavior when tapping pool card', () => {

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -21,6 +21,7 @@ import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
+import { getTokenDisplayName } from 'src/tokens/utils'
 
 export default function PoolCard({
   pool,
@@ -84,6 +85,16 @@ export default function PoolCard({
 
   const totalYieldRate = getTotalYieldRate(pool).toFixed(2)
 
+  // For Neeru pools, prefer the per-tranche label from backend (Flexible / 30 dias / 60 dias / 90 dias)
+  // so the 4 Neeru cards are distinguishable. For other providers, fall back to user-friendly token
+  // display names (cCOP -> Pesos, USDT/USDC -> Dolares, etc.) per the wallet manual.
+  const cardTitle = useMemo(() => {
+    if (pool.appId === 'neeru-vaults' && pool.displayProps.title) {
+      return pool.displayProps.title
+    }
+    return tokensInfo.map((token) => getTokenDisplayName(token.symbol)).join(' / ')
+  }, [pool, tokensInfo])
+
   const onPress = () => {
     AppAnalytics.track(EarnEvents.earn_pool_card_press, {
       poolId: positionId,
@@ -117,9 +128,7 @@ export default function PoolCard({
               />
             ))}
             <View style={styles.titleTextContainer}>
-              <Text style={styles.titleTokens}>
-                {tokensInfo.map((token) => token.symbol).join(' / ')}
-              </Text>
+              <Text style={styles.titleTokens}>{cardTitle}</Text>
               <Text style={styles.titleNetwork}>
                 {t('earnFlow.poolCard.onNetwork', { networkName: NETWORK_NAMES[networkId] })}
               </Text>

--- a/src/earn/neeru/NeeruCloseSheet.tsx
+++ b/src/earn/neeru/NeeruCloseSheet.tsx
@@ -37,18 +37,21 @@ export default function NeeruCloseSheet({ position, onClose }: Props) {
     >
       <View style={styles.body}>
         <Text style={styles.subtitle}>{t('neeruVaults.closeSheet.currentPayout')}</Text>
-        <Row label={t('neeruVaults.closeSheet.principalLabel')} value={payout.principal} />
-        <Row label={t('neeruVaults.closeSheet.interestLabel')} value={payout.interest} />
+        <Row
+          label={t('neeruVaults.closeSheet.principalLabel')}
+          value={`${payout.principal} Pesos`}
+        />
+        <Row label={t('neeruVaults.closeSheet.interestLabel')} value={`${payout.interest} Pesos`} />
         {payout.isEarly && (
           <Row
             label={t('neeruVaults.closeSheet.penaltyLabel', {
               percentage: payout.penaltyBps / 100,
             })}
-            value={`-${penaltyAmount}`}
+            value={`-${penaltyAmount} Pesos`}
             negative
           />
         )}
-        <Row label={t('neeruVaults.closeSheet.totalLabel')} value={payout.total} bold />
+        <Row label={t('neeruVaults.closeSheet.totalLabel')} value={`${payout.total} Pesos`} bold />
         {payout.isEarly && (
           <Text style={styles.warning}>
             {t('neeruVaults.closeSheet.earlyWarning', { date: maturityDate })}

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -101,7 +101,7 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
         <Text style={styles.header}>{t('neeruVaults.detail.header', { trancheLabel })}</Text>
         <Text style={styles.description}>{description}</Text>
         <Text style={styles.total}>
-          {t('neeruVaults.detail.aggregateBalance', { trancheLabel })}: {total}
+          {t('neeruVaults.detail.aggregateBalance', { trancheLabel, amount: total })}
         </Text>
 
         {positions.length === 0 ? (


### PR DESCRIPTION
## Summary

Two display bugs found during the simulator smoke test:

1. **cCOP shown instead of Pesos.** `PoolCard` rendered `token.symbol` directly from the local token registry, which still has the legacy Valora-API symbol "cCOP" for COPm. The wallet manual says always show "Pesos" for COPm/cCOP. Existing helper `getTokenDisplayName()` handles the mapping but was not used by PoolCard.

2. **The 4 Neeru cards looked identical.** PoolCard ignored `pool.displayProps.title` (which carries "Flexible" / "30 dias" / "60 dias" / "90 dias") and only showed the token symbol, so all 4 Neeru cards rendered with the same primary text.

## Fixes

- `PoolCard.tsx`: derive a `cardTitle` that uses `displayProps.title` for Neeru pools and `getTokenDisplayName(symbol)` for all others. Existing test updated to assert the new behavior; 2 new test cases cover both branches.
- `NeeruCloseSheet.tsx`: suffix payout values with " Pesos" inline.
- `NeeruVaultDetailScreen.tsx`: pass `amount` to the `aggregateBalance` i18n interpolation.
- `locales/{base,es-419}/translation.json`: extend `positionRow.principal`, `positionRow.interest`, `detail.aggregateBalance`, and `emergencyCloseSheet.explanation` to include "Pesos" suffix on amounts.

Side effect: Allbridge USDC card now reads "Dolares" instead of "USDC" (also per the wallet manual rule).

No persist version change.

## Test plan

- [ ] CI green
- [ ] PoolCard tests: 6 pass
- [ ] Neeru tests: 49 pass
- [ ] yarn build:ts clean
- [ ] Manual smoke: rebuild + relaunch simulator + open Earn, confirm 4 Neeru cards show distinct tranche labels (90 / 60 / 30 / Flexible) and Allbridge shows "Dolares"