### PR TITLE
fix(earn): remove transparency block, drop network subtitle, brand Neeru as 'By: Neeru Finance'

### DIFF
--- a/src/earn/PoolCard.test.tsx
+++ b/src/earn/PoolCard.test.tsx
@@ -45,7 +45,6 @@ describe('PoolCard', () => {
 
     // USDC -> "Dólares" via getTokenDisplayName per wallet manual; ETH stays as-is
     expect(getByText('Dólares / ETH')).toBeTruthy()
-    expect(getByText('earnFlow.poolCard.onNetwork, {"networkName":"Arbitrum One"}')).toBeTruthy()
     expect(getByText('earnFlow.poolCard.percentage, {"percentage":"1.92"}')).toBeTruthy()
     expect(getByText('COP$1,808,800.00')).toBeTruthy()
   })

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -15,7 +15,6 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { EarnPosition } from 'src/positions/types'
 import { useSelector } from 'src/redux/hooks'
-import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -129,9 +128,6 @@ export default function PoolCard({
             ))}
             <View style={styles.titleTextContainer}>
               <Text style={styles.titleTokens}>{cardTitle}</Text>
-              <Text style={styles.titleNetwork}>
-                {t('earnFlow.poolCard.onNetwork', { networkName: NETWORK_NAMES[networkId] })}
-              </Text>
             </View>
           </View>
           <View style={styles.keyValueContainer}>
@@ -157,7 +153,9 @@ export default function PoolCard({
             </View>
           )}
           <Text style={styles.poweredByText}>
-            {t('earnFlow.poolCard.poweredBy', { providerName: appName })}
+            {pool.appId === 'neeru-vaults'
+              ? 'By: Neeru Finance'
+              : t('earnFlow.poolCard.poweredBy', { providerName: appName })}
           </Text>
         </View>
       </Touchable>
@@ -187,10 +185,6 @@ const styles = StyleSheet.create({
   titleTokens: {
     color: Colors.black,
     ...typeScale.labelSemiBoldSmall,
-  },
-  titleNetwork: {
-    color: Colors.black,
-    ...typeScale.bodyXSmall,
   },
   keyValueContainer: {
     gap: Spacing.Smallest8,

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -3,13 +3,10 @@ import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getAddress } from 'viem'
-import { Linking, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import Touchable from 'src/components/Touchable'
 import {
-  FONDO_COPM_MVP_ADDRESS,
   NEERU_TRANCHE_LABEL_KEYS,
   NeeruTrancheId,
   trancheIdFromPositionId,
@@ -82,7 +79,6 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
   const positions = byTranche[trancheId]
   const trancheLabel = t(NEERU_TRANCHE_LABEL_KEYS[trancheId])
   const description = t(DESCRIPTION_KEY_BY_TRANCHE[trancheId])
-  const sourceUrl = t('neeruVaults.detail.transparency.sourceUrl')
   const total = positions
     .reduce((acc, p) => acc.plus(p.currentPayoutIfClosed.total), new BigNumber(0))
     .toFixed(2)
@@ -126,22 +122,6 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
           testID="NeeruVaultDetail.DepositCta"
           style={styles.cta}
         />
-
-        <View style={styles.transparency}>
-          <Text style={styles.transparencyTitle}>{t('neeruVaults.detail.transparency.title')}</Text>
-          <Touchable
-            testID="NeeruVaultDetail.SourceLink"
-            onPress={() => Linking.openURL(sourceUrl)}
-          >
-            <Text style={styles.transparencyLink}>
-              {t('neeruVaults.detail.transparency.sourceLine')}: {sourceUrl}
-            </Text>
-          </Touchable>
-          <Text style={styles.transparencyText}>
-            {t('neeruVaults.detail.transparency.contractLine')}:{' '}
-            {getAddress(FONDO_COPM_MVP_ADDRESS)}
-          </Text>
-        </View>
       </ScrollView>
       {selectedPosition && (
         <NeeruCloseSheet position={selectedPosition} onClose={() => setSelectedPosition(null)} />
@@ -174,24 +154,4 @@ const styles = StyleSheet.create({
   },
   positionsList: { gap: Spacing.Smallest8 },
   cta: { marginTop: Spacing.Large32 },
-  transparency: {
-    marginTop: Spacing.Large32,
-    padding: Spacing.Regular16,
-    backgroundColor: Colors.gray1,
-    borderRadius: 12,
-    gap: Spacing.Tiny4,
-  },
-  transparencyTitle: {
-    ...typeScale.labelSmall,
-    color: Colors.gray3,
-    marginBottom: Spacing.Smallest8,
-  },
-  transparencyLink: {
-    ...typeScale.bodySmall,
-    color: Colors.accent,
-  },
-  transparencyText: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-  },
 })

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -91,18 +91,17 @@ describe('NeeruVaultDetailScreen', () => {
     expect(getByText('neeruVaults.detail.noPositions')).toBeTruthy()
   })
 
-  it('renders transparency disclaimer block with contract address', () => {
+  it('does not render the legacy transparency block', () => {
     const store = createMockStore({
       neeru: { ...initialNeeruState, fetchStatus: 'success' },
     } as any)
-    const { getByText } = render(
+    const { queryByText } = render(
       <Provider store={store}>
         <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
       </Provider>
     )
-    expect(getByText('neeruVaults.detail.transparency.title')).toBeTruthy()
-    // Full contract address must NOT be truncated
-    expect(getByText(/0xD05CDF2DC56D97333c547519dF58D56145766294/)).toBeTruthy()
+    expect(queryByText('neeruVaults.detail.transparency.title')).toBeNull()
+    expect(queryByText(/0xD05CDF2DC56D97333c547519dF58D56145766294/)).toBeNull()
   })
 
   it('opens NeeruCloseSheet when a position row Manage is pressed', () => {


### PR DESCRIPTION
## Summary

Three copy/layout fixes from the simulator smoke test:

1. **Remove transparency block** from NeeruVaultDetailScreen (source code link + contract address). User did not request; I added it unprompted based on a backend handoff note.
2. **Drop "en Celo" subtitle** universally from PoolCard. TuCop is Celo-only so this was redundant noise on every card (Allbridge included).
3. **Rebrand Neeru footer** from "Con tecnología de Neeru Vaults" to "By: Neeru Finance". Branched only for `appId === 'neeru-vaults'`; other providers keep the existing `earnFlow.poolCard.poweredBy` i18n.

Also drops unused imports (NETWORK_NAMES, Linking, Touchable, getAddress, FONDO_COPM_MVP_ADDRESS) and styles.

No persist version change.

## Test plan

- [ ] CI green (49/49 Neeru + PoolCard tests pass locally)
- [ ] Manual smoke: rebuild + relaunch, confirm: no "en Celo" subtitle, Neeru cards say "By: Neeru Finance", detail screen has no transparency block