### PR TITLE
fix(earn): Neeru card title = Pesos, subtitle = tranche-specific copy

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2922,6 +2922,12 @@
       "sixtyDays": "60 days",
       "ninetyDays": "90 days"
     },
+    "cardSubtitle": {
+      "flexible": "Flexible",
+      "thirtyDays": "30-day deposit",
+      "sixtyDays": "60-day deposit",
+      "ninetyDays": "90-day deposit"
+    },
     "detail": {
       "header": "Your {{trancheLabel}} positions",
       "aggregateBalance": "Total in {{trancheLabel}}: {{amount}} Pesos",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2929,6 +2929,12 @@
       "sixtyDays": "60 dias",
       "ninetyDays": "90 dias"
     },
+    "cardSubtitle": {
+      "flexible": "Flexible",
+      "thirtyDays": "Deposito a 30 dias",
+      "sixtyDays": "Deposito a 60 dias",
+      "ninetyDays": "Deposito a 90 dias"
+    },
     "detail": {
       "header": "Tus depositos {{trancheLabel}}",
       "aggregateBalance": "Total en {{trancheLabel}}: {{amount}} Pesos",

--- a/src/earn/PoolCard.test.tsx
+++ b/src/earn/PoolCard.test.tsx
@@ -50,24 +50,35 @@ describe('PoolCard', () => {
   })
 
   describe('card title display', () => {
-    it('renders Neeru pool with displayProps.title (tranche label) instead of token symbol', () => {
+    it('renders Neeru pool title as the token display name with tranche subtitle below', () => {
       const neeruPool = {
         ...mockEarnPositions[0],
         appId: 'neeru-vaults',
-        displayProps: {
-          ...mockEarnPositions[0].displayProps,
-          title: '30 dias',
-        },
+        positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
       }
       const { getByText, queryByText } = render(
         <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
           <PoolCard pool={neeruPool} testID="PoolCard.neeru-30d" />
         </Provider>
       )
-      expect(getByText('30 dias')).toBeTruthy()
-      // Should NOT show raw token symbol when Neeru
+      // Title is the token display name (USDC -> Dólares from getTokenDisplayName)
+      expect(getByText('Dólares')).toBeTruthy()
+      // Subtitle is the tranche-specific i18n key (mock returns key)
+      expect(getByText('neeruVaults.cardSubtitle.thirtyDays')).toBeTruthy()
+      // Raw token symbols never shown
       expect(queryByText('USDC')).toBeNull()
       expect(queryByText('cCOP')).toBeNull()
+    })
+
+    it('does not render a subtitle for non-Neeru pools', () => {
+      const allbridgePool = { ...mockEarnPositions[0], appId: 'allbridge' }
+      const { queryByText } = render(
+        <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
+          <PoolCard pool={allbridgePool} testID="PoolCard.allbridge" />
+        </Provider>
+      )
+      expect(queryByText('neeruVaults.cardSubtitle.thirtyDays')).toBeNull()
+      expect(queryByText('neeruVaults.cardSubtitle.flexible')).toBeNull()
     })
 
     it('maps token symbol via getTokenDisplayName for non-Neeru pools (cCOP -> Pesos)', () => {

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -21,6 +21,14 @@ import { Spacing } from 'src/styles/styles'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
+import { NeeruTrancheId, trancheIdFromPositionId } from 'src/earn/neeru/constants'
+
+const NEERU_CARD_SUBTITLE_KEY_BY_TRANCHE: Record<NeeruTrancheId, string> = {
+  0: 'neeruVaults.cardSubtitle.flexible',
+  1: 'neeruVaults.cardSubtitle.thirtyDays',
+  2: 'neeruVaults.cardSubtitle.sixtyDays',
+  3: 'neeruVaults.cardSubtitle.ninetyDays',
+}
 
 export default function PoolCard({
   pool,
@@ -84,15 +92,21 @@ export default function PoolCard({
 
   const totalYieldRate = getTotalYieldRate(pool).toFixed(2)
 
-  // For Neeru pools, prefer the per-tranche label from backend (Flexible / 30 dias / 60 dias / 90 dias)
-  // so the 4 Neeru cards are distinguishable. For other providers, fall back to user-friendly token
-  // display names (cCOP -> Pesos, USDT/USDC -> Dolares, etc.) per the wallet manual.
-  const cardTitle = useMemo(() => {
-    if (pool.appId === 'neeru-vaults' && pool.displayProps.title) {
-      return pool.displayProps.title
-    }
-    return tokensInfo.map((token) => getTokenDisplayName(token.symbol)).join(' / ')
-  }, [pool, tokensInfo])
+  // Card title is always the user-friendly token display name per the wallet manual
+  // (cCOP -> Pesos, USDT/USDC/USDm -> Dolares, etc).
+  const cardTitle = useMemo(
+    () => tokensInfo.map((token) => getTokenDisplayName(token.symbol)).join(' / '),
+    [tokensInfo]
+  )
+
+  // For Neeru pools, append a per-tranche subtitle so the 4 cards are distinguishable.
+  const cardSubtitle = useMemo(() => {
+    if (pool.appId !== 'neeru-vaults') return null
+    const trancheId = trancheIdFromPositionId(pool.positionId)
+    if (trancheId === null) return null
+    const key = NEERU_CARD_SUBTITLE_KEY_BY_TRANCHE[trancheId]
+    return t(key)
+  }, [pool, t])
 
   const onPress = () => {
     AppAnalytics.track(EarnEvents.earn_pool_card_press, {
@@ -128,6 +142,7 @@ export default function PoolCard({
             ))}
             <View style={styles.titleTextContainer}>
               <Text style={styles.titleTokens}>{cardTitle}</Text>
+              {cardSubtitle && <Text style={styles.cardSubtitle}>{cardSubtitle}</Text>}
             </View>
           </View>
           <View style={styles.keyValueContainer}>
@@ -185,6 +200,10 @@ const styles = StyleSheet.create({
   titleTokens: {
     color: Colors.black,
     ...typeScale.labelSemiBoldSmall,
+  },
+  cardSubtitle: {
+    color: Colors.gray3,
+    ...typeScale.bodyXSmall,
   },
   keyValueContainer: {
     gap: Spacing.Smallest8,


### PR DESCRIPTION
Per simulator smoke test: card title should be the user-friendly token name ('Pesos' / 'Dólares' / etc.) like Allbridge does. Tranche disambiguator goes as a subtitle below.

- PoolCard cardTitle always via getTokenDisplayName
- New cardSubtitle for Neeru pools, mapped per tranche via i18n
- i18n keys: neeruVaults.cardSubtitle.{flexible,thirtyDays,sixtyDays,ninetyDays} in both locales

Subtitles (es-419): 'Flexible' / 'Deposito a 30 dias' / 'Deposito a 60 dias' / 'Deposito a 90 dias'.

No persist version change. 50/50 tests pass.