### PR TITLE
fix(scripts): unblock run_app.sh and xcode pre-build after testnet removal

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -55,7 +55,7 @@ echo "**************************"
 echo "Current directory: $(pwd)"
 echo "Machine type: $MACHINE"
 echo "Environment: $ENV_FILENAME"
-echo "Network: $DEFAULT_TESTNET"
+echo "Network: Celo mainnet (chain 42220)"
 echo "Platform: $PLATFORM"
 echo "**************************"
 
@@ -69,7 +69,7 @@ startPackager() {
       fi
       echo "Packager server already running"
     else
-      terminal="${RCT_TERMINAL-${REACT_TERMINAL-$TERM_PROGRAM}}"
+      terminal="${RCT_TERMINAL:-${REACT_TERMINAL:-${TERM_PROGRAM:-Terminal}}}"
       echo "Starting packager in new terminal..."
 
       if [ "$MACHINE" = "Mac" ]; then

--- a/scripts/xcode_scheme_build_pre_action.sh
+++ b/scripts/xcode_scheme_build_pre_action.sh
@@ -18,7 +18,10 @@ eval "$(grep -v -e '^#' /tmp/.env-xcode | xargs -I {} echo export \'{}\')"
 # See https://newbedev.com/how-to-convert-a-json-object-to-key-value-format-in-jq
 # Check if jq exists in the path or use the absolute path
 JQ_CMD=$(command -v jq || echo "/opt/homebrew/bin/jq")
-$JQ_CMD -r ".${DEFAULT_TESTNET}|to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" "${SRCROOT}/../secrets.json" >> /tmp/.env-xcode
+# secrets.json only has a single top-level key, `mainnet`, since Celo Sepolia
+# / testnet builds were removed (see Track D of the WRI). All env variants
+# (mainnet + mainnetdev) read from the same key.
+$JQ_CMD -r ".mainnet|to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" "${SRCROOT}/../secrets.json" >> /tmp/.env-xcode
 
 # This makes the scheme use the specified envfile
 # See https://github.com/luggit/react-native-config#ios-1


### PR DESCRIPTION
## Summary

Two fixes for shell scripts that broke after the Sepolia/testnet removal earlier this sprint:

1. **`scripts/run_app.sh`**: removed `${DEFAULT_TESTNET}` reference and added a safe default so the script no longer trips `set -u` in fresh terminals.
2. **`scripts/xcode_scheme_build_pre_action.sh`**: hardcoded the `mainnet` key for reading secrets.json (the only top-level key after testnet removal). Unblocks iOS builds via `xcodebuild MobileStack-mainnetdev` from any environment.

Both fixes were sitting on local Development as unpushed work from the team before the Neeru sprint. Pushing now so they can land.

## Test plan

- [ ] CI green
- [ ] Smoke test: `yarn dev:ios` succeeds from a fresh shell
- [ ] Smoke test: `xcodebuild ... MobileStack-mainnetdev` succeeds with default settings