### PR TITLE
chore: gitignore Foundry deployment broadcast logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ builds/
 
 # Kotlin compiler caches (Android)
 android/.kotlin/
+
+# Foundry deployment broadcast logs (local outputs of `forge script --broadcast`)
+contracts/broadcast/
+contracts-research/broadcast/


### PR DESCRIPTION
Excludes contracts/broadcast/ and contracts-research/broadcast/ from git tracking. These are forge script --broadcast outputs (tx hashes + deployment metadata, public on chain, nothing sensitive) that show up as untracked files in every team member's working tree.