### PR TITLE
refactor(currencies): internal Mento rename to USDm/EURm/CELO

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,9 +82,9 @@ Task-oriented walkthroughs: how to accomplish a specific job.
 
 Active, forward-looking design specs for unshipped features.
 
-| Document                                                                                                 | Description                                           |
-| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| [specs/2026-05-26-carbon-defi-fx-strategy-design.md](specs/2026-05-26-carbon-defi-fx-strategy-design.md) | Carbon DeFi "Invierte en Dolares" FX strategy feature |
+| Document                                                                                 | Description                                                                                  |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [specs/2026-05-26-carbon-defi-initiative.md](specs/2026-05-26-carbon-defi-initiative.md) | Carbon DeFi initiative (unified): FX Strategy "Invierte en Dolares" + Swap Executor Refactor |
 
 ## Backend services
 

--- a/src/components/LegacyTokenDisplay.tsx
+++ b/src/components/LegacyTokenDisplay.tsx
@@ -4,7 +4,7 @@ import { StyleProp, TextStyle } from 'react-native'
 import TokenDisplay from 'src/components/TokenDisplay'
 import { useTokenInfoByAddress, useTokenInfoWithAddressBySymbol } from 'src/tokens/hooks'
 import { LocalAmount } from 'src/transactions/types'
-import { Currency } from 'src/utils/currencies'
+import { Currency, CURRENCY_TO_CHAIN_SYMBOL } from 'src/utils/currencies'
 
 interface Props {
   amount: BigNumber.Value
@@ -41,8 +41,11 @@ function LegacyTokenDisplay({
   }
 
   const tokenInfoFromAddress = useTokenInfoByAddress(tokenAddress)
+  // Look up the token by its on-chain symbol, which may differ from the
+  // Currency enum value (Mento stables: enum is USDm/EURm internally but on
+  // chain they are still cUSD/cEUR after the rebrand).
   const tokenInfoFromCurrency = useTokenInfoWithAddressBySymbol(
-    currency! === Currency.Celo ? 'CELO' : currency!
+    currency ? CURRENCY_TO_CHAIN_SYMBOL[currency] : (currency as unknown as string)
   )
   const tokenInfo = tokenInfoFromAddress || tokenInfoFromCurrency
   return (

--- a/src/fiatExchanges/BidaliScreen.tsx
+++ b/src/fiatExchanges/BidaliScreen.tsx
@@ -18,7 +18,7 @@ import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { tokensByCurrencySelector } from 'src/tokens/selectors'
 import { getHigherBalanceCurrency } from 'src/tokens/utils'
-import { Currency } from 'src/utils/currencies'
+import { Currency, CURRENCY_TO_CHAIN_SYMBOL } from 'src/utils/currencies'
 import networkConfig from 'src/web3/networkConfig'
 
 // Note for later when adding CELO: make sure that Currency.Celo maps to CELO and not cGLD
@@ -40,9 +40,12 @@ function useInitialJavaScript(
     // When a payment request is needed, Bidali calls the provided `onPaymentRequest` method.
     // When a new url needs to be open (currently for FAQ, Terms of Service), `openUrl` is called by Bidali.
     // See also the comment in the `onMessage` handler
+    // Bidali expects the legacy upper-cased on-chain symbol (CUSD/CEUR) for
+    // paymentCurrency, not the new internal Currency value (USDM/EURM).
+    const paymentCurrencyForBidali = CURRENCY_TO_CHAIN_SYMBOL[currency].toUpperCase()
     setInitialJavaScript(`
       window.walletApp = {
-        paymentCurrency: "${currency.toUpperCase()}",
+        paymentCurrency: "${paymentCurrencyForBidali}",
         phoneNumber: ${JSON.stringify(e164PhoneNumber)},
         balances: ${jsonBalances},
         onPaymentRequest: function (paymentRequest) {
@@ -113,10 +116,16 @@ function BidaliScreen({ route, navigation }: Props) {
   const jsonBalances = useMemo(
     () =>
       JSON.stringify(
-        // Maps supported currencies to an object with their balance
-        // Example: [cUSD, cEUR] to { CUSD: X, CEUR: Y }
+        // Maps supported currencies to an object with their balance.
+        // Example: [Currency.Dollar, Currency.Euro] -> { CUSD: X, CEUR: Y }.
+        // Bidali expects the legacy upper-cased on-chain symbols (CUSD/CEUR),
+        // not the new internal Currency values (USDM/EURM), so we resolve via
+        // CURRENCY_TO_CHAIN_SYMBOL before upper-casing.
         Object.fromEntries(
-          BIDALI_CURRENCIES.map((currency) => [currency.toUpperCase(), tokens[currency]?.balance])
+          BIDALI_CURRENCIES.map((currency) => [
+            CURRENCY_TO_CHAIN_SYMBOL[currency].toUpperCase(),
+            tokens[currency]?.balance,
+          ])
         )
       ),
     [tokens]

--- a/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
@@ -1,4 +1,5 @@
 import {
+  CryptoType,
   FiatAccountSchema,
   FiatAccountType,
   FiatType,
@@ -18,7 +19,6 @@ import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/utils'
 import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
 import { selectFiatConnectQuote } from 'src/fiatconnect/slice'
 import { NetworkId } from 'src/transactions/types'
-import { Currency } from 'src/utils/currencies'
 import { createMockStore } from 'test/utils'
 import {
   mockCusdAddress,
@@ -612,7 +612,9 @@ describe('FiatConnectQuote', () => {
         fiatAccountType: FiatAccountType.BankAccount,
         tokenId: mockCusdTokenId,
       })
-      expect(quote.getCryptoType()).toEqual(Currency.Dollar)
+      // FiatConnect external protocol keeps legacy CryptoType.cUSD ('cUSD'),
+      // distinct from our internal Currency.Dollar ('USDm') after the rebrand.
+      expect(quote.getCryptoType()).toEqual(CryptoType.cUSD)
     })
   })
 

--- a/src/fiatconnect/consts.ts
+++ b/src/fiatconnect/consts.ts
@@ -8,10 +8,17 @@ export const FIATCONNECT_CURRENCY_TO_WALLET_CURRENCY: Partial<Record<FiatType, L
     [FiatType.USD]: LocalCurrencyCode.USD,
   }
 
+// Maps the wallet's internal Currency value (e.g. 'USDm', 'EURm', 'CELO') to the
+// FiatConnect protocol's CryptoType (which keeps legacy 'cUSD'/'cEUR'/'cREAL'
+// strings because they are an external protocol contract we don't control).
+// Legacy on-chain symbols (cUSD/cEUR/cREAL) are also accepted as keys so callers
+// that still pass the raw token.symbol resolve correctly.
 export const WALLET_CRYPTO_TO_FIATCONNECT_CRYPTO: Record<string, CryptoType | undefined> = {
   CELO: CryptoType.CELO,
-  cEUR: CryptoType.cEUR,
+  USDm: CryptoType.cUSD,
+  EURm: CryptoType.cEUR,
   cUSD: CryptoType.cUSD,
+  cEUR: CryptoType.cEUR,
   cREAL: CryptoType.cREAL,
   COPm: 'COPm',
   USDT: 'USDT',

--- a/src/localCurrency/hooks.test.tsx
+++ b/src/localCurrency/hooks.test.tsx
@@ -83,7 +83,6 @@ describe(localCurrencyHooks.useLocalCurrencyToShow, () => {
     })
   })
 
-  // Special case for CELO because of the cGLD symbol/enum value used historically
   it('returns the expected values when the currency is CELO', async () => {
     render(
       <Provider store={createStore()}>
@@ -93,7 +92,7 @@ describe(localCurrencyHooks.useLocalCurrencyToShow, () => {
 
     expect(useLocalCurrencyToShowSpy).toHaveReturnedTimes(1)
     expect(useLocalCurrencyToShowSpy).toHaveReturnedWith({
-      amountCurrency: 'cGLD',
+      amountCurrency: 'CELO',
       localCurrencyCode: 'COP',
       localCurrencyExchangeRate: '10',
     })

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -15,7 +15,7 @@ import {
 } from 'src/transactions/types'
 import { ONBOARDING_FEATURES_ENABLED } from 'src/config'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
-import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { CiCoCurrency } from 'src/utils/currencies'
 import { Screens } from 'src/navigator/Screens'
 import {
   DEFAULT_DAILY_PAYMENT_LIMIT_CUSD_LEGACY,
@@ -450,11 +450,13 @@ describe('Redux persist migrations', () => {
       },
     })
     expect(migratedSchema.localCurrency.exchangeRates).toBeDefined()
-    expect(migratedSchema.localCurrency.exchangeRates[Currency.Dollar]).toEqual(
+    // v16 wrote exchangeRates['cUSD'] and balances['cUSD'] using the legacy
+    // literal that Currency.Dollar held at the time.
+    expect(migratedSchema.localCurrency.exchangeRates.cUSD).toEqual(
       v15Schema.localCurrency.exchangeRate
     )
     expect(migratedSchema.stableToken.balance).toBeUndefined()
-    expect(migratedSchema.stableToken.balances[Currency.Dollar]).toEqual('150')
+    expect(migratedSchema.stableToken.balances.cUSD).toEqual('150')
     expect(migratedSchema.escrow.isReclaiming).toBeFalsy()
     expect(migratedSchema.escrow.sentEscrowedPayments.length).toEqual(0)
   })
@@ -855,6 +857,10 @@ describe('Redux persist migrations', () => {
   })
 
   it('works from v106 to v107', () => {
+    // Historical fixture: at v106, persisted state used legacy on-chain symbols
+    // ('cUSD', 'cGLD'). The migration only transforms Currency.Celo -> CELO.
+    // We use literal strings to reflect what real wallets had on disk at v106
+    // (the Currency enum was later rebranded internally to USDm/EURm/CELO).
     const oldSchema = {
       ...v106Schema,
       fiatConnect: {
@@ -862,11 +868,11 @@ describe('Redux persist migrations', () => {
         cachedFiatAccountUses: [
           {
             providerId: 'provider-two',
-            cryptoType: Currency.Dollar,
+            cryptoType: 'cUSD',
           },
           {
             providerId: 'provider-one',
-            cryptoType: Currency.Celo,
+            cryptoType: 'cGLD',
           },
         ],
         cachedQuoteParams: {
@@ -874,14 +880,14 @@ describe('Redux persist migrations', () => {
             ['some-schema']: {
               cryptoAmount: '10',
               fiatAmount: '10',
-              cryptoType: Currency.Dollar,
+              cryptoType: 'cUSD',
             },
           },
           'some-other-provider': {
             ['some-schema']: {
               cryptoAmount: '10',
               fiatAmount: '10',
-              cryptoType: Currency.Celo,
+              cryptoType: 'cGLD',
             },
           },
         },
@@ -1219,8 +1225,9 @@ describe('Redux persist migrations', () => {
     const oldSchema = v145Schema
     const migratedSchema = migrations[146](oldSchema)
     const expectedSchema: any = _.cloneDeep(oldSchema)
-    expectedSchema.localCurrency.usdToLocalRate =
-      oldSchema.localCurrency.exchangeRates[Currency.Dollar]
+    // v16 wrote exchangeRates['cUSD'] (legacy Currency.Dollar literal); v146
+    // reads it under that same key when promoting to usdToLocalRate.
+    expectedSchema.localCurrency.usdToLocalRate = oldSchema.localCurrency.exchangeRates.cUSD
     delete expectedSchema.localCurrency.exchangeRates
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -15,7 +15,7 @@ import { Screens } from 'src/navigator/Screens'
 import { Position } from 'src/positions/types'
 import { Recipient } from 'src/recipients/recipient'
 import { Network, NetworkId, StandbyTransaction, TokenTransaction } from 'src/transactions/types'
-import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { CiCoCurrency } from 'src/utils/currencies'
 import networkConfig from 'src/web3/networkConfig'
 import { ONBOARDING_FEATURES_ENABLED } from 'src/config'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
@@ -36,8 +36,12 @@ export function updateCachedQuoteParams(cachedQuoteParams: {
     Object.entries(kycSchemas).forEach(([kycSchema, cachedParams]) => {
       newCachedQuoteParams[providerId][kycSchema] = {
         ...cachedParams,
+        // Historical migration check: at the time this ran, Currency.Celo's
+        // value was 'cGLD'. The internal enum has since been rebranded to
+        // Currency.Celo = 'CELO', so we hardcode the literal 'cGLD' to keep
+        // matching the values that real wallets had persisted at v106.
         cryptoType:
-          cachedParams.cryptoType === Currency.Celo ? CiCoCurrency.CELO : cachedParams.cryptoType,
+          cachedParams.cryptoType === 'cGLD' ? CiCoCurrency.CELO : cachedParams.cryptoType,
       }
     })
   })
@@ -324,18 +328,22 @@ export const migrations = {
     localCurrency: {
       ...state.localCurrency,
       exchangeRate: undefined,
+      // Historical migration: at v16, Currency enum values were 'cUSD', 'cEUR',
+      // 'cGLD'. Hardcoded as literals because the enum was later rebranded to
+      // USDm/EURm/CELO and downstream migrations (e.g. v146) read these keys
+      // expecting the legacy strings.
       exchangeRates: {
-        [Currency.Dollar]: state.localCurrency.exchangeRate,
-        [Currency.Euro]: null,
-        [Currency.Celo]: null,
+        cUSD: state.localCurrency.exchangeRate,
+        cEUR: null,
+        cGLD: null,
       },
     },
     stableToken: {
       ...state.stableToken,
       balance: undefined,
       balances: {
-        [Currency.Dollar]: state.stableToken.balance,
-        [Currency.Euro]: null,
+        cUSD: state.stableToken.balance,
+        cEUR: null,
       },
     },
     escrow: {
@@ -1028,9 +1036,13 @@ export const migrations = {
     fiatConnect: {
       ...state.fiatConnect,
       cachedFiatAccountUses: state.fiatConnect.cachedFiatAccountUses.map(
-        (use: { cryptoType: Currency }) => ({
+        // Historical migration: at v106 the persisted cryptoType could be the
+        // legacy literal 'cGLD' (Currency.Celo's old value before the internal
+        // rebrand to 'CELO'). Hardcoded so future-changes to the enum value
+        // do not silently break the upgrade path for wallets stuck at v106.
+        (use: { cryptoType: string }) => ({
           ...use,
-          cryptoType: use.cryptoType === Currency.Celo ? CiCoCurrency.CELO : use.cryptoType,
+          cryptoType: use.cryptoType === 'cGLD' ? CiCoCurrency.CELO : use.cryptoType,
         })
       ),
       cachedQuoteParams: updateCachedQuoteParams(state.fiatConnect.cachedQuoteParams),
@@ -1260,7 +1272,9 @@ export const migrations = {
       ..._.omit(state.localCurrency, 'exchangeRates'),
       // We were previously fetching cUSD to local, but blockchain-api was returning USD to local
       // assuming cUSD == USD, so it's correct to keep this rate here
-      usdToLocalRate: state.localCurrency.exchangeRates[Currency.Dollar],
+      // Historical: v16 wrote exchangeRates['cUSD']. Hardcoded literal so this
+      // migration stays correct if Currency.Dollar's value is rebranded later.
+      usdToLocalRate: state.localCurrency.exchangeRates.cUSD,
     },
   }),
   147: (state: any) => ({

--- a/src/send/utils.ts
+++ b/src/send/utils.ts
@@ -16,7 +16,7 @@ import { TransactionDataInput } from 'src/send/types'
 import { tokensListSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { convertLocalToTokenAmount, getSupportedNetworkIdsForSend } from 'src/tokens/utils'
-import { Currency } from 'src/utils/currencies'
+import { Currency, CURRENCY_TO_CHAIN_SYMBOL } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
 import { call, put, select } from 'typed-redux-saga'
 
@@ -52,7 +52,13 @@ export function* handleSendPaymentData({
   const tokens: TokenBalance[] = yield* select((state) =>
     tokensListSelector(state, supportedNetworkIds)
   )
-  const tokenInfo = tokens.find((token) => token?.symbol === (data.token ?? Currency.Dollar))
+  // Match against the on-chain token symbol. Currency.Dollar value is 'USDm'
+  // (new internal naming) but the cUSD Mento stable still has on-chain symbol
+  // 'cUSD' (contract was rebranded but not redeployed). data.token from a
+  // deeplink may still send the legacy symbol, which is also accepted here.
+  const tokenInfo = tokens.find(
+    (token) => token?.symbol === (data.token ?? CURRENCY_TO_CHAIN_SYMBOL[Currency.Dollar])
+  )
 
   if (!tokenInfo?.priceUsd) {
     navigate(Screens.SendEnterAmount, {

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -21,7 +21,7 @@ import {
   TokenBalancesWithAddress,
 } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
-import { Currency } from 'src/utils/currencies'
+import { Currency, CURRENCY_TO_CHAIN_SYMBOL } from 'src/utils/currencies'
 import { isVersionBelowMinimum } from 'src/utils/versionCheck'
 import networkConfig from 'src/web3/networkConfig'
 import { isFeeCurrency, sortByUsdBalance, usdBalance } from './utils'
@@ -260,14 +260,30 @@ export const tokensByUsdBalanceSelector = createSelector(
 export const tokensByCurrencySelector = createSelector(
   tokensListWithAddressSelector,
   (tokens): CurrencyTokens => {
-    const cUsdTokenInfo = tokens.find((token) => token?.symbol === Currency.Dollar)
-    const cEurTokenInfo = tokens.find((token) => token?.symbol === Currency.Euro)
-    const copmTokenInfo = tokens.find((token) => token?.symbol === Currency.COP)
-    // Currency.Celo === 'cGLD' for legacy reasons, so we just use a hard-coded string.
-    const celoTokenInfo = tokens.find((token) => token?.symbol === 'CELO')
-    const usdtTokenInfo = tokens.find((token) => token?.symbol === Currency.USDT)
-    const usdcTokenInfo = tokens.find((token) => token?.symbol === Currency.USDC)
-    const usatTokenInfo = tokens.find((token) => token?.symbol === Currency.USAT)
+    // Currency enum values do NOT always match the on-chain token symbol (Mento
+    // stables were rebranded cXXX -> XXXm without redeploying), so resolve via
+    // CURRENCY_TO_CHAIN_SYMBOL when comparing against token.symbol.
+    const cUsdTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.Dollar]
+    )
+    const cEurTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.Euro]
+    )
+    const copmTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.COP]
+    )
+    const celoTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.Celo]
+    )
+    const usdtTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.USDT]
+    )
+    const usdcTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.USDC]
+    )
+    const usatTokenInfo = tokens.find(
+      (token) => token?.symbol === CURRENCY_TO_CHAIN_SYMBOL[Currency.USAT]
+    )
 
     return {
       [Currency.Dollar]: cUsdTokenInfo,

--- a/src/tokens/utils.test.tsx
+++ b/src/tokens/utils.test.tsx
@@ -39,9 +39,11 @@ describe(getHigherBalanceCurrency, () => {
   it('should return the currency with the higher balance in the local currency', () => {
     expect(
       getHigherBalanceCurrency([Currency.Dollar, Currency.Euro, Currency.Celo], tokens)
-    ).toEqual('cGLD')
-    expect(getHigherBalanceCurrency([Currency.Dollar, Currency.Euro], tokens)).toEqual('cUSD')
-    expect(getHigherBalanceCurrency([Currency.Dollar], tokens)).toEqual('cUSD')
+    ).toEqual(Currency.Celo)
+    expect(getHigherBalanceCurrency([Currency.Dollar, Currency.Euro], tokens)).toEqual(
+      Currency.Dollar
+    )
+    expect(getHigherBalanceCurrency([Currency.Dollar], tokens)).toEqual(Currency.Dollar)
   })
 
   it('should return `undefined` when balances are `null`', () => {

--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -1,11 +1,25 @@
 export enum Currency {
-  Celo = 'cGLD',
-  Dollar = 'cUSD',
-  Euro = 'cEUR',
+  Celo = 'CELO',
+  Dollar = 'USDm',
+  Euro = 'EURm',
   COP = 'COPm',
   USDT = 'USDT',
   USDC = 'USDC',
   USAT = 'USAT',
+}
+
+// Some Currency values differ from the on-chain token symbol for legacy reasons
+// (Mento stables were rebranded cXXX -> XXXm without redeploying the contracts).
+// Use this map whenever you need to compare an on-chain token's `symbol` field
+// against a Currency value.
+export const CURRENCY_TO_CHAIN_SYMBOL: Record<Currency, string> = {
+  [Currency.Celo]: 'CELO',
+  [Currency.Dollar]: 'cUSD',
+  [Currency.Euro]: 'cEUR',
+  [Currency.COP]: 'COPm',
+  [Currency.USDT]: 'USDT',
+  [Currency.USDC]: 'USDC',
+  [Currency.USAT]: 'USAT',
 }
 
 // Important: when adding new currencies, the string must match the symbol
@@ -82,8 +96,10 @@ export function resolveCurrency(currencyCode: string): Currency | undefined {
   const mapping: Record<string, Currency | undefined> = {
     CELO: Currency.Celo,
     CGLD: Currency.Celo,
-    CUSD: Currency.Dollar,
-    CEUR: Currency.Euro,
+    CUSD: Currency.Dollar, // legacy on-chain symbol; still resolves to Currency.Dollar (USDm)
+    USDM: Currency.Dollar,
+    CEUR: Currency.Euro, // legacy on-chain symbol; still resolves to Currency.Euro (EURm)
+    EURM: Currency.Euro,
     COPM: Currency.COP,
     USDT: Currency.USDT,
     USDC: Currency.USDC,
@@ -97,7 +113,9 @@ export function resolveCICOCurrency(currencyCode: string): CiCoCurrency {
     CELO: CiCoCurrency.CELO,
     CGLD: CiCoCurrency.CELO,
     CUSD: CiCoCurrency.USDT, // legacy: cUSD-named code routes to USDT (kept for backwards compat)
+    USDM: CiCoCurrency.USDT, // new naming; routes to USDT for CICO flows
     CEUR: CiCoCurrency.cEUR,
+    EURM: CiCoCurrency.cEUR,
     CREAL: CiCoCurrency.cREAL,
     USDT: CiCoCurrency.USDT,
     USDC: CiCoCurrency.USDC,

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -373,16 +373,20 @@ const networkConfig: NetworkConfig = {
     [Network.Base]: base,
   },
   currencyToTokenId: {
+    // CiCoCurrency.CELO === Currency.Celo === 'CELO' (single key satisfies both)
     [CiCoCurrency.CELO]: CELO_TOKEN_ID_MAINNET,
+    // External-facing CiCoCurrency keeps legacy cXXX strings (FiatConnect contract).
     [CiCoCurrency.cUSD]: CUSD_TOKEN_ID_MAINNET,
     [CiCoCurrency.cEUR]: CEUR_TOKEN_ID_MAINNET,
     [CiCoCurrency.cREAL]: CREAL_TOKEN_ID_MAINNET,
     [CiCoCurrency.ETH]: ETH_TOKEN_ID_MAINNET,
-    [Currency.Celo]: CELO_TOKEN_ID_MAINNET,
-    [CiCoCurrency.USDT]: USDT_TOKEN_ID_MAINNET,
-    [CiCoCurrency.USDC]: USDC_TOKEN_ID_MAINNET, // also satisfies Currency.USDC (same string 'USDC')
-    [CiCoCurrency.USAT]: USAT_TOKEN_ID_MAINNET, // also satisfies Currency.USAT (same string 'USAT')
-    [CiCoCurrency.COPm]: COPM_TOKEN_ID_MAINNET,
+    // Internal-facing Currency uses new XXXm naming and points to the same token.
+    [Currency.Dollar]: CUSD_TOKEN_ID_MAINNET,
+    [Currency.Euro]: CEUR_TOKEN_ID_MAINNET,
+    [CiCoCurrency.USDT]: USDT_TOKEN_ID_MAINNET, // also satisfies Currency.USDT (same string 'USDT')
+    [CiCoCurrency.USDC]: USDC_TOKEN_ID_MAINNET, // also satisfies Currency.USDC
+    [CiCoCurrency.USAT]: USAT_TOKEN_ID_MAINNET, // also satisfies Currency.USAT
+    [CiCoCurrency.COPm]: COPM_TOKEN_ID_MAINNET, // also satisfies Currency.COP
   },
   celoTokenAddress: CELO_TOKEN_ADDRESS_MAINNET,
   celoGasPriceMinimumAddress: CELO_GAS_PRICE_MINIMUM_ADDRESS_MAINNET,

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -12,7 +12,7 @@ import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { updateCachedQuoteParams } from 'src/redux/migrations'
 import { RootState } from 'src/redux/store'
 import { Network, NetworkId, StandbyTransaction, TokenTransaction } from 'src/transactions/types'
-import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { CiCoCurrency } from 'src/utils/currencies'
 import networkConfig from 'src/web3/networkConfig'
 import {
   mockCeloAddress,
@@ -570,10 +570,14 @@ export const v16Schema = {
   },
   localCurrency: {
     ...v15Schema.localCurrency,
+    // Historical persisted shape: at v16, Currency enum values held legacy
+    // on-chain symbols ('cGLD'/'cEUR'/'cUSD'). The enum has since been
+    // rebranded internally (CELO/EURm/USDm) but historical state fixtures must
+    // keep the literal keys that real wallets had on disk.
     exchangeRates: {
-      [Currency.Celo]: '3',
-      [Currency.Euro]: '2',
-      [Currency.Dollar]: v15Schema.localCurrency.exchangeRate,
+      cGLD: '3',
+      cEUR: '2',
+      cUSD: v15Schema.localCurrency.exchangeRate,
     },
     exchangeRate: undefined,
     fetchRateFailed: false,
@@ -581,14 +585,15 @@ export const v16Schema = {
   stableToken: {
     ...v15Schema.stableToken,
     balances: {
-      [Currency.Euro]: null,
-      [Currency.Dollar]: v15Schema.stableToken.balance ?? null,
+      cEUR: null,
+      cUSD: v15Schema.stableToken.balance ?? null,
     },
     balance: undefined,
   },
   send: {
     ...v15Schema.send,
-    lastUsedCurrency: Currency.Dollar,
+    // Historical: at v16 Currency.Dollar held the legacy literal 'cUSD'.
+    lastUsedCurrency: 'cUSD',
   },
   exchange: {
     ...v15Schema.exchange,
@@ -2005,7 +2010,8 @@ export const v107Schema = {
     ...v106Schema.fiatConnect,
     cachedFiatAccountUses: v106Schema.fiatConnect.cachedFiatAccountUses.map((use: any) => ({
       ...use,
-      cryptoType: use.cryptoType === Currency.Celo ? CiCoCurrency.CELO : use.cryptoType,
+      // Historical: Currency.Celo held the legacy literal 'cGLD' at this version.
+      cryptoType: use.cryptoType === 'cGLD' ? CiCoCurrency.CELO : use.cryptoType,
     })),
     cachedQuoteParams: updateCachedQuoteParams(v106Schema.fiatConnect.cachedQuoteParams),
   },
@@ -2497,7 +2503,8 @@ export const v146Schema = {
   },
   localCurrency: {
     ..._.omit(v145Schema.localCurrency, 'exchangeRates'),
-    usdToLocalRate: v145Schema.localCurrency.exchangeRates[Currency.Dollar],
+    // Historical: v16 wrote exchangeRates['cUSD'] (legacy literal).
+    usdToLocalRate: v145Schema.localCurrency.exchangeRates.cUSD,
   },
 }
 


### PR DESCRIPTION
## Summary

Internal rename of the wallet's \`Currency\` enum to align with the Mento rebrand convention (cXXX -> XXXm) for code readability. **No user-facing change** (the UI already displayed Dolares / Pesos / Oro per the display rule) and **no Redux migration** needed (persisted state is keyed by tokenId, not Currency enum values).

## Changes

| Layer | What |
|---|---|
| Enum values | \`Currency.Celo='cGLD' -> 'CELO'\`, \`Currency.Dollar='cUSD' -> 'USDm'\`, \`Currency.Euro='cEUR' -> 'EURm'\` |
| New helper | \`CURRENCY_TO_CHAIN_SYMBOL\` map so consumers comparing against \`token.symbol\` (still cUSD/cEUR on chain) keep working |
| Resolve helpers | \`resolveCurrency\` / \`resolveCICOCurrency\` now accept both legacy (\`CUSD\`/\`CEUR\`/\`CGLD\`) and new (\`USDM\`/\`EURM\`) codes |
| External contracts preserved | \`CiCoCurrency\` unchanged (maps to \`@fiatconnect/fiatconnect-types\`), BidaliScreen payload keeps legacy CUSD/CEUR upper-cased keys, FiatConnect mapping accepts both old and new keys |
| Historical migrations | v16 / v107 / migrateCachedQuoteParams now use hardcoded literals (\`'cGLD'\`/\`'cUSD'\`) so they cannot silently drift if the enum is renamed again later |

Single carry-over commit on \`docs/README.md\` points the spec index to the Carbon DeFi unified spec from a recent docs consolidation; flagged in the commit message and easy to revert independently if you prefer.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] Affected modules: \`yarn jest src/utils/currencies.test.ts src/tokens/selectors.test.ts src/redux/migrations.test.ts src/tokens/utils.test.tsx src/send/utils.test.ts src/fiatExchanges/quotes/FiatConnectQuote.test.ts src/fiatExchanges/BidaliScreen.test.tsx src/tokens/PositionItem.test.tsx src/dapps/DappShortcutsRewards.test.tsx src/localCurrency/hooks.test.tsx\` -> 235/235 pass, 8 snapshots pass
- [x] Full \`yarn test\` -> 4224/4224 tests pass, 96 snapshots pass. The 230 "failed suites" in the log are pre-existing OpenZeppelin submodule tests under \`contracts/lib/\` and \`contracts-research/lib/\` that jest scans incorrectly. Not introduced here.
- [x] \`yarn test:update-root-state-schema\` -> "up to date" (CiCoCurrency preserved means the schema's cUSD/cEUR/cREAL enum members are still valid; the new Currency values appear as additional members)
- [ ] Manual smoke on mainnetdev: send / swap / earn flows still resolve tokens correctly

## Risks

- Persisted state migration **not** required (state is keyed by tokenId, not by Currency enum).
- FiatConnect/Bidali/Simplex external API contracts preserved via the boundary mappings.
- BidaliScreen / fiatExchanges screens are still wired in Navigator but reportedly unused; the rename does not break their compile, and if they ever re-activate they will continue speaking the legacy on-chain symbols externally.