### PR TITLE
fix(pre-push): skip validation on branch deletion

### DIFF
--- a/scripts/hooks/pre-push.js
+++ b/scripts/hooks/pre-push.js
@@ -10,6 +10,10 @@ const exec = (args) => execSync(args).toString().trim()
 // Set this to the FIRST day where commits are valid!
 const THRESHOLD_DATE = new Date('2019-07-17')
 
+// Git sends this SHA when there is no commit on one side of the push
+// (e.g. localSHA on a branch delete, remoteSHA on a new-branch push).
+const ZERO_SHA = '0000000000000000000000000000000000000000'
+
 ////////////////////////////////////////////////////////////////
 /// UTILITY FUNCTIONS
 ////////////////////////////////////////////////////////////////
@@ -19,7 +23,7 @@ function mergeBaseFor(refA, refB) {
 }
 
 function getCommitRange(change, remoteName) {
-  if (change.remoteSHA === '0000000000000000000000000000000000000000') {
+  if (change.remoteSHA === ZERO_SHA) {
     // pushing a new branch
     // => commit range = changes from main
     const fromSHA = mergeBaseFor(`${remoteName}/main`, change.localSHA)
@@ -83,6 +87,12 @@ const changes = stdinData
   })
 
 for (const change of changes) {
+  // Branch deletion: localSHA is all zeros and there are no incoming commits
+  // to validate. Skip; getCommitRange would otherwise call `git merge-base`
+  // with an invalid SHA and abort the entire push.
+  if (change.localSHA === ZERO_SHA) {
+    continue
+  }
   // console.log('Checking commits to push to ', change.remoteRef)
   const [from, to] = getCommitRange(change, remoteName)
 


### PR DESCRIPTION
## Summary

Pre-push hook was rejecting branch-deletion pushes (\`git push origin --delete <branch>\`) because it tried to call \`git merge-base\` with the all-zero SHA git uses to signal "no incoming commits."

## Repro

\`\`\`
git push origin --delete some-merged-branch
# husky - pre-push script failed (code 1)
# fatal: Not a valid commit name 0000000000000000000000000000000000000000
\`\`\`

Hit this today while cleaning up the stale \`spike/wri-s2-ethers-v5-deps\` branch; had to go through the GitHub API as a workaround.

## Fix

[scripts/hooks/pre-push.js](scripts/hooks/pre-push.js): early-continue at the top of the validation loop when \`change.localSHA === ZERO_SHA\`. Also extracts the magic SHA to a named constant shared with \`getCommitRange\`.

## Test plan

- [x] Simulated deletion refspec piped into hook via stdin -> exit 0 (previously exit 1)
- [x] The push of this PR itself exercises the hook on a fresh-branch push -> hook accepted
- [ ] Next \`git push origin --delete\` against this repo by anyone with the hook installed should succeed without husky failure