### PR TITLE
chore(earn/neeru): update fondo COPm contract address

### DIFF
--- a/src/earn/EarnHome.test.tsx
+++ b/src/earn/EarnHome.test.tsx
@@ -127,8 +127,8 @@ describe('EarnHome', () => {
   describe('Neeru Vaults gate', () => {
     const neeruPool = {
       ...mockEarnPositions[0],
-      positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
-      address: '0xd05cdf2dc56d97333c547519df58d56145766294',
+      positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-1',
+      address: '0x988af5977201a0e988f2c75ea952532f6beb5082',
       networkId: NetworkId['celo-mainnet'],
       appId: 'neeru-vaults',
       appName: 'Neeru Vaults',

--- a/src/earn/PoolCard.test.tsx
+++ b/src/earn/PoolCard.test.tsx
@@ -54,7 +54,7 @@ describe('PoolCard', () => {
       const neeruPool = {
         ...mockEarnPositions[0],
         appId: 'neeru-vaults',
-        positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
+        positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-1',
       }
       const { getByText, queryByText } = render(
         <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -15,8 +15,8 @@ jest.mock('src/navigator/NavigationService', () => ({ navigate: jest.fn() }))
 const pool = {
   ...mockEarnPositions[0],
   appId: 'neeru-vaults',
-  positionId: 'celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-1',
-  address: '0xd05cdf2dc56d97333c547519df58d56145766294',
+  positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-1',
+  address: '0x988af5977201a0e988f2c75ea952532f6beb5082',
   networkId: NetworkId['celo-mainnet'],
 }
 
@@ -101,7 +101,7 @@ describe('NeeruVaultDetailScreen', () => {
       </Provider>
     )
     expect(queryByText('neeruVaults.detail.transparency.title')).toBeNull()
-    expect(queryByText(/0xD05CDF2DC56D97333c547519dF58D56145766294/)).toBeNull()
+    expect(queryByText(/0x988af5977201a0e988f2c75ea952532f6beb5082/i)).toBeNull()
   })
 
   it('opens NeeruCloseSheet when a position row Manage is pressed', () => {

--- a/src/earn/neeru/__tests__/constants.test.ts
+++ b/src/earn/neeru/__tests__/constants.test.ts
@@ -3,7 +3,7 @@ import { trancheIdFromPositionId } from 'src/earn/neeru/constants'
 describe('trancheIdFromPositionId', () => {
   it('extracts tranche id from a valid Neeru positionId', () => {
     expect(
-      trancheIdFromPositionId('celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-2')
+      trancheIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-2')
     ).toBe(2)
   })
   it('returns null for non-Neeru positionId', () => {
@@ -11,7 +11,7 @@ describe('trancheIdFromPositionId', () => {
   })
   it('returns null for out-of-range tranche', () => {
     expect(
-      trancheIdFromPositionId('celo-mainnet:0xd05cdf2dc56d97333c547519df58d56145766294:tranche-9')
+      trancheIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-9')
     ).toBeNull()
   })
 })

--- a/src/earn/neeru/constants.ts
+++ b/src/earn/neeru/constants.ts
@@ -2,10 +2,9 @@ import { NetworkId } from 'src/transactions/types'
 
 export const NEERU_APP_ID = 'neeru-vaults'
 
-export const FONDO_COPM_MVP_ADDRESS = '0xd05cdf2dc56d97333c547519df58d56145766294' as const
+export const FONDO_COPM_MVP_ADDRESS = '0x988af5977201a0e988f2c75ea952532f6beb5082' as const
 export const COPM_TOKEN_ADDRESS = '0x8a567e2ae79ca692bd748ab832081c45de4041ea' as const
 export const COPM_TOKEN_ID = `${NetworkId['celo-mainnet']}:${COPM_TOKEN_ADDRESS}` as const
-export const FONDO_DEPLOY_BLOCK = BigInt(70594026)
 
 export type NeeruTrancheId = 0 | 1 | 2 | 3
 


### PR DESCRIPTION
## Summary

Bump the Neeru fondo COPm contract address to the new deployment on Celo mainnet. Wallet ABI and integration surface are unchanged; only the address constant moves. Test fixtures aligned to the new address.

## Changes

- `src/earn/neeru/constants.ts`: update `FONDO_COPM_MVP_ADDRESS`; remove unused `FONDO_DEPLOY_BLOCK` (no consumers in wallet)
- 4 test fixtures updated to the new address (`PoolCard`, `EarnHome`, `NeeruVaultDetailScreen`, `constants`)

## Out of scope

Backend (`TuCOPWallet-Backend`) hooks-api shortcuts and indexer changes are handled separately in that repo.

## Test plan

- [x] `yarn build:ts`
- [x] `yarn lint`
- [x] `yarn jest src/earn/neeru src/earn/PoolCard.test.tsx src/earn/EarnHome.test.tsx` — 14 suites, 80 tests pass
- [ ] Smoke on simulator once backend points at the new address