### PR TITLE
fix(earn/neeru): harden close-error detection + always-visible principal-only fallback

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2961,7 +2961,9 @@
       "penaltyLabel": "Early withdrawal fee ({{percentage}}%)",
       "totalLabel": "Total",
       "earlyWarning": "You are withdrawing before {{date}}. The fee applies only to the interest, never to your principal.",
-      "confirmCta": "Confirm withdrawal"
+      "confirmCta": "Confirm withdrawal",
+      "principalOnlyCta": "Exit with principal only",
+      "principalOnlyHelp": "If the normal withdrawal fails, you can recover your principal without interest."
     },
     "emergencyCloseSheet": {
       "title": "Emergency withdrawal",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2968,7 +2968,9 @@
       "penaltyLabel": "Comision por retiro temprano ({{percentage}}%)",
       "totalLabel": "Total",
       "earlyWarning": "Estas retirando antes del {{date}}. La comision se aplica solo al interes, nunca al capital.",
-      "confirmCta": "Confirmar retiro"
+      "confirmCta": "Confirmar retiro",
+      "principalOnlyCta": "Salir solo con mi capital",
+      "principalOnlyHelp": "Si el retiro normal falla, puedes recuperar tu capital sin intereses."
     },
     "emergencyCloseSheet": {
       "title": "Retiro de emergencia",

--- a/src/earn/neeru/NeeruCloseSheet.tsx
+++ b/src/earn/neeru/NeeruCloseSheet.tsx
@@ -16,9 +16,10 @@ import { Spacing } from 'src/styles/styles'
 interface Props {
   position: NeeruIndividualPosition
   onClose: () => void
+  onPrincipalOnlyRequested?: (position: NeeruIndividualPosition) => void
 }
 
-export default function NeeruCloseSheet({ position, onClose }: Props) {
+export default function NeeruCloseSheet({ position, onClose, onPrincipalOnlyRequested }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const closeStatus = useSelector(neeruCloseStatusSelector)
@@ -67,6 +68,22 @@ export default function NeeruCloseSheet({ position, onClose }: Props) {
           onPress={() => dispatch(closePositionStart({ positionId: position.positionId }))}
           style={styles.cta}
         />
+        {onPrincipalOnlyRequested && (
+          <>
+            <Button
+              testID="NeeruCloseSheet.PrincipalOnly"
+              size={BtnSizes.FULL}
+              type={BtnTypes.SECONDARY}
+              text={t('neeruVaults.closeSheet.principalOnlyCta')}
+              disabled={closeStatus === 'loading'}
+              onPress={() => onPrincipalOnlyRequested(position)}
+              style={styles.secondaryCta}
+            />
+            <Text style={styles.principalOnlyHelp}>
+              {t('neeruVaults.closeSheet.principalOnlyHelp')}
+            </Text>
+          </>
+        )}
       </View>
     </BottomSheet>
   )
@@ -111,4 +128,11 @@ const styles = StyleSheet.create({
     marginTop: Spacing.Smallest8,
   },
   cta: { marginTop: Spacing.Regular16 },
+  secondaryCta: { marginTop: Spacing.Smallest8 },
+  principalOnlyHelp: {
+    ...typeScale.bodySmall,
+    color: Colors.gray3,
+    marginTop: Spacing.Smallest8,
+    textAlign: 'center',
+  },
 })

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -124,7 +124,14 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
         />
       </ScrollView>
       {selectedPosition && (
-        <NeeruCloseSheet position={selectedPosition} onClose={() => setSelectedPosition(null)} />
+        <NeeruCloseSheet
+          position={selectedPosition}
+          onClose={() => setSelectedPosition(null)}
+          onPrincipalOnlyRequested={(pos) => {
+            setSelectedPosition(null)
+            setEmergencyTarget(pos)
+          }}
+        />
       )}
       {emergencyTarget && (
         <NeeruEmergencyCloseSheet

--- a/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
@@ -54,4 +54,30 @@ describe('NeeruCloseSheet', () => {
     fireEvent.press(getByTestId('NeeruCloseSheet.Confirm'))
     expect(spy).toHaveBeenCalledWith(closePositionStart({ positionId: '1234' }))
   })
+
+  it('hides the principal-only option when no callback is provided', () => {
+    const store = createMockStore({ neeru: initialNeeruState } as any)
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <NeeruCloseSheet position={pos} onClose={jest.fn()} />
+      </Provider>
+    )
+    expect(queryByTestId('NeeruCloseSheet.PrincipalOnly')).toBeNull()
+  })
+
+  it('exposes principal-only option that invokes the callback with the position', () => {
+    const store = createMockStore({ neeru: initialNeeruState } as any)
+    const onPrincipalOnlyRequested = jest.fn()
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <NeeruCloseSheet
+          position={pos}
+          onClose={jest.fn()}
+          onPrincipalOnlyRequested={onPrincipalOnlyRequested}
+        />
+      </Provider>
+    )
+    fireEvent.press(getByTestId('NeeruCloseSheet.PrincipalOnly'))
+    expect(onPrincipalOnlyRequested).toHaveBeenCalledWith(pos)
+  })
 })

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -122,6 +122,26 @@ describe('NeeruVaultDetailScreen', () => {
     expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
   })
 
+  it('opens NeeruEmergencyCloseSheet proactively when principal-only option is tapped', () => {
+    const store = createMockStore({
+      neeru: {
+        ...initialNeeruState,
+        positions: [positionFor('321')],
+        fetchStatus: 'success',
+      },
+    } as any)
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
+      </Provider>
+    )
+    fireEvent.press(getByTestId('NeeruPositionRow.Manage.321'))
+    expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
+    fireEvent.press(getByTestId('NeeruCloseSheet.PrincipalOnly'))
+    expect(queryByTestId('NeeruCloseSheet')).toBeNull()
+    expect(getByTestId('NeeruEmergencyCloseSheet')).toBeTruthy()
+  })
+
   it('opens NeeruEmergencyCloseSheet when close fails with InterestPoolLow', () => {
     // Start with idle state so user can tap Manage to seed lastSelectedRef
     const store = createMockStore({

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -11,6 +11,7 @@ import {
   emergencyCloseNeeruPositionSaga,
   fetchNeeruPositionsSaga,
   handleNeeruDepositOptimistic,
+  isInterestPoolLow,
   pollUntilBackendCatchesUp,
 } from 'src/earn/neeru/saga'
 import {
@@ -383,5 +384,50 @@ describe('handleNeeruDepositOptimistic', () => {
     expect(observed.baseUrl).toBe(networkConfig.tucopBackendApiUrl)
     expect(observed.walletAddress).toBe(WALLET)
     expect(observed.txHash).toBe(TX.toLowerCase())
+  })
+})
+
+describe('isInterestPoolLow', () => {
+  it('detects dev-style error.message', () => {
+    expect(isInterestPoolLow(new Error('Reverted: InterestPoolLow'))).toBe(true)
+  })
+  it('detects viem prod-style selector in error.cause.data', () => {
+    const err = Object.assign(new Error('Execution reverted'), {
+      cause: { data: '0x2648b779' },
+    })
+    expect(isInterestPoolLow(err)).toBe(true)
+  })
+  it('detects selector inside a longer hex blob (cause.details)', () => {
+    const err = Object.assign(new Error('estimateGas failed'), {
+      cause: { details: 'execution reverted: 0x2648b779000000000000' },
+    })
+    expect(isInterestPoolLow(err)).toBe(true)
+  })
+  it('returns false for unrelated errors', () => {
+    expect(isInterestPoolLow(new Error('insufficient funds'))).toBe(false)
+    expect(isInterestPoolLow('not an error')).toBe(false)
+    expect(isInterestPoolLow(null)).toBe(false)
+  })
+})
+
+describe('closeNeeruPositionSaga prod-shape InterestPoolLow', () => {
+  const WALLET = '0x' + 'a'.repeat(40)
+  const POSITION_ID = '4242'
+
+  it('detects InterestPoolLow when viem revert surfaces as selector in cause.data', async () => {
+    const prodShapeError = Object.assign(new Error('Execution reverted'), {
+      cause: { data: '0x2648b779' },
+    })
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [matchers.call.fn(triggerShortcutRequest), { transactions: [] }],
+        [matchers.call.fn(prepareTransactions), Promise.reject(prodShapeError)],
+      ])
+      .put({ type: NEERU_INTEREST_POOL_LOW_ACTION, payload: { positionId: POSITION_ID } })
+      .put(closePositionFailure({ positionId: POSITION_ID, error: 'InterestPoolLow' }))
+      .run()
   })
 })

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -50,8 +50,28 @@ const TRANCHE_DURATION_SECONDS: Record<NeeruTrancheId, number> = {
   3: 90 * 86_400,
 }
 
-function isInterestPoolLow(error: Error): boolean {
-  return error.message.includes('InterestPoolLow')
+// 4-byte selector for the custom error InterestPoolLow(). Matched here because
+// the fondo ABI is intentionally not loaded into the wallet (zero-exposure),
+// so viem surfaces reverts with the raw selector instead of the decoded name.
+const INTEREST_POOL_LOW_SELECTOR = '0x2648b779'
+
+export function isInterestPoolLow(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+
+  const msg = error.message ?? ''
+  if (msg.toLowerCase().includes('interestpoollow')) return true
+
+  const cause = (error as { cause?: { data?: unknown; details?: unknown } }).cause
+  const candidates: unknown[] = [cause?.data, cause?.details, msg]
+  for (const c of candidates) {
+    if (
+      typeof c === 'string' &&
+      c.toLowerCase().includes(INTEREST_POOL_LOW_SELECTOR.toLowerCase())
+    ) {
+      return true
+    }
+  }
+  return false
 }
 
 export function* fetchNeeruPositionsSaga(_action: ReturnType<typeof fetchPositionsStart>) {


### PR DESCRIPTION
## Summary

Cubre el gap de detección de `InterestPoolLow` reportado por el equipo backend, y agrega una salida secundaria siempre visible en el sheet de cierre normal para que el usuario no dependa exclusivamente del detector.

## Cambio A — detector por selector de 4 bytes

Antes, `isInterestPoolLow(error)` matcheaba sólo `error.message.includes('InterestPoolLow')`. En producción viem surface el revert como `EstimateGasExecutionError` con el selector raw en `error.cause.data` o `error.cause.details`, sin el nombre legible (porque el wallet no carga la ABI del fondo, por política de cero-exposición). Resultado: el detector se evaluaba false → el usuario veía toast genérico y nunca se abría el emergency sheet.

Implementación:
- Selector hardcoded `0x2648b779` (verificado por `toFunctionSelector('InterestPoolLow()')` y `keccak256(utf8('InterestPoolLow()'))[:10]`).
- `isInterestPoolLow` ahora exportado, acepta `unknown`, narrowing seguro, matchea por nombre (dev/test) o por selector (prod).
- Tests unitarios cubren los 4 casos: nombre en message, selector en `cause.data`, selector dentro de hex blob en `cause.details`, errores irrelevantes.
- Test de saga adicional: cuando `prepareTransactions` rechaza con error shape de producción, el saga sigue disparando `NEERU_INTEREST_POOL_LOW_ACTION` + `closePositionFailure({ error: 'InterestPoolLow' })`.

## Cambio C — opción secundaria siempre visible en el close sheet

Antes, el flujo de salida con sólo capital era reactivo: el usuario tenía que tapar "Confirmar retiro", recibir el revert, y entonces se abría el emergency sheet. Si el detector fallaba por cualquier motivo (nuevos formatos de error de viem en futuros upgrades, edge cases), el escape se perdía.

Ahora `NeeruCloseSheet` expone un CTA secundario "Salir solo con mi capital" debajo del CTA principal, con un texto de ayuda. Tapearlo cierra el close sheet y abre `NeeruEmergencyCloseSheet`, que mantiene el patrón de doble-tap para confirmar (no hay riesgo de tap accidental que pierda intereses).

Implementación:
- `NeeruCloseSheet`: prop opcional `onPrincipalOnlyRequested?: (position) => void`. Si está, renderiza el secondary CTA + help text.
- `NeeruVaultDetailScreen`: pasa el callback que cierra el close sheet y setea `emergencyTarget`.
- i18n: 2 claves nuevas en `closeSheet` (`principalOnlyCta`, `principalOnlyHelp`) en `base` (en) y `es-419`.
- Tests: hidden cuando no hay callback, invoca callback con la posición correcta, y el flujo proactivo end-to-end en `NeeruVaultDetailScreen.test.tsx`.

## Restricciones cumplidas

- NO se importó `fondoCOPmMVPAbi` ni ninguna ABI completa al wallet. La detección por selector es offline.
- NO se pidió ningún cambio al backend (`getEarnPositions` sigue intacto).
- El path reactivo previo (revert → detección → emergency sheet) sigue funcionando como antes; el proactivo es complementario.

## Test plan

- [x] `yarn build:ts`
- [x] `yarn lint`
- [x] `yarn jest src/earn/neeru` — 12 suites / 75 tests pass
- [x] `yarn jest src/earn` — 29 suites / 242 tests pass (sin regresiones)
- [ ] Smoke en simulador con backend apuntando al proxy nuevo
- [ ] Smoke manual de revert forzado para validar el path por selector

## Relación con PR #225

PR #225 (`chore/neeru-fondo-address-bump`) es independiente y mergeable hoy. Esta PR se ramificó desde `Development` limpio; cuando #225 mergee, esta se rebasea sin conflictos.