### PR TITLE
fix(fee): Bug E - prefer visible stables over hidden CELO for gas

### DIFF
--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -21,6 +21,7 @@ import { StatsigFeatureGates } from 'src/statsig/types'
 import { swapStart, swapSuccess, swapError } from 'src/swap/slice'
 import { Field, SwapInfo } from 'src/swap/types'
 import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
+import { pickFeeCurrency } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import { Network, NetworkId } from 'src/transactions/types'
@@ -290,7 +291,23 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
       return
     }
 
-    const feeCurrencies = yield* select(feeCurrenciesSelector, fromToken.networkId as NetworkId)
+    const rawFeeCurrencies = yield* select(feeCurrenciesSelector, fromToken.networkId as NetworkId)
+
+    // Bug E: the shared selector returns CELO at index 0, so
+    // prepareTransactions silently uses it whenever the user has any CELO.
+    // Reorder via the picker so stables win; CELO drops to last alternative
+    // and only gets used if every stable fails its gas check.
+    const choice = pickFeeCurrency({
+      available: rawFeeCurrencies,
+      excludeTokenIds: [step.tokenId],
+    })
+    const feeCurrencies = choice ? [choice.chosen, ...choice.alternatives] : rawFeeCurrencies
+    if (choice) {
+      Logger.info(
+        TAG,
+        `step ${index} (${step.symbol}): fee currency ${choice.chosen.symbol} (reason=${choice.reason}, declined=${choice.declined.length})`
+      )
+    }
 
     let freshQuote: Awaited<ReturnType<typeof fetchSwapQuoteForExecution>>
     try {

--- a/src/dollarsSpend/saga7702.test.ts
+++ b/src/dollarsSpend/saga7702.test.ts
@@ -217,6 +217,47 @@ describe('dollarsSpend saga dispatcher (flag-gated)', () => {
     }
   })
 
+  it('prefers a stable fee currency over CELO when both are available (Bug E)', async () => {
+    // Both CELO (synthetic from chain getBalance) AND a stable Mento fee
+    // currency are usable. The Bug-E-aware picker must pick the stable so the
+    // user's hidden CELO balance is not silently drained.
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
+    const wallet = mockWallet()
+    jest.mocked(getViemWallet as any).mockReturnValue(wallet)
+
+    const mockCopm = {
+      tokenId: 'celo-mainnet:copm',
+      networkId: 'celo-mainnet',
+      symbol: 'COPm',
+      decimals: 18,
+      balance: new BigNumber(100_000),
+      priceUsd: new BigNumber(0.00025),
+      address: '0x8a567e2ae79ca692bd748ab832081c45de4041ea',
+      isFeeCurrency: true,
+    } as any
+
+    await expectSaga(
+      executeDollarsSpend7702Saga,
+      executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+    )
+      .provide([
+        [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+        [matchers.select.selector(tokensByIdSelector), mockTokensById],
+        [matchers.select.selector(feeCurrenciesSelector), [mockCopm]],
+        [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
+        [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+        [matchers.call.fn(getConnectedUnlockedAccount), MOCK_WALLET],
+      ])
+      .put(multiSwapCompleted())
+      .silentRun()
+
+    expect(wallet.sendTransaction).toHaveBeenCalledTimes(1)
+    const sendArg = wallet.sendTransaction.mock.calls[0][0]
+    // Stable preferred over CELO -> feeCurrency is the COPm address, not undefined.
+    expect(sendArg.feeCurrency).toBe(mockCopm.address)
+  })
+
   it('dispatches multiSwapStepFailed when a quote refetch throws (flag on)', async () => {
     jest.useRealTimers()
     jest.mocked(getFeatureGate).mockReturnValue(true)

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -18,6 +18,8 @@ import { addStandbyTransaction } from 'src/transactions/slice'
 import { newTransactionContext, TokenTransactionTypeV2 } from 'src/transactions/types'
 import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
+import { pickFeeCurrency } from 'src/tokens/feeCurrencyPicker'
+import type { TokenBalance } from 'src/tokens/slice'
 import { Network, NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { publicClient } from 'src/viem'
@@ -251,93 +253,111 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       args: [innerCalls],
     })
 
-    // Pick a fee currency.
+    // Pick a fee currency via the Bug-E-aware central picker.
     //
-    // CELO is the priority-0 choice per FEE_CURRENCY_PRIORITY in
-    // src/tokens/selectors.ts. The wallet hides CELO from the UI token list
-    // (via ALLOWED_TOKEN_IDS in src/tokens/constants.ts), but that's a UI
-    // decision; if the user happens to have CELO on-chain, we should still
-    // use it for gas (it doesn't require any CIP-64 fee-adapter approval and
-    // is the simplest path). So we read CELO native balance directly here
-    // rather than relying on the wallet's Redux token registry.
+    // Stables-first: paying gas in CELO silently shrinks a balance the user
+    // can't see in the app (CELO is excluded from ALLOWED_TOKEN_IDS). We
+    // route through `pickFeeCurrency` which deprioritizes CELO so any visible
+    // stable wins. CELO remains as the last-resort fallback when no stable
+    // qualifies.
     //
-    // Fallback: when CELO balance is zero, iterate the wallet's stable fee
-    // currency candidates in priority order (COPm > USDm > USDC > USDT) and
-    // skip any token that is in the spending set — paying gas in a token
-    // that's capped-to-balance leaves zero CIP-64 reserve and the outer tx
-    // reverts.
+    // Two kinds of CIP-64 fee currency:
+    //   - Native (isFeeCurrency=true): Mento stables registered with the
+    //     protocol. Gas debited natively, no allowance required.
+    //   - Adapter-based (feeCurrencyAdapterAddress set): protocol pulls the
+    //     underlying token via transferFrom on the adapter, requiring a prior
+    //     approve(adapter, allowance). The pre-tx gas debit happens BEFORE
+    //     the batch executes, so we can't bootstrap allowance inside this
+    //     same tx; we pre-flight allowance here and pass under-approved
+    //     adapters into `adapterAllowanceMissing` so the picker skips them.
+    //
+    // We never pay gas in a token that's in the spending set: gas would race
+    // the capped-to-balance swap input and the outer tx would revert.
+    const feeCurrencyCandidates = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+
+    // 1e30 wei: ~1T units of an 18-decimal token, far above any single tx's
+    // gas cost. Built via repeated multiplication because the current
+    // tsconfig target rejects BigInt exponentiation.
+    let ALLOWANCE_THRESHOLD = BigInt(1)
+    for (let _i = 0; _i < 30; _i++) ALLOWANCE_THRESHOLD = ALLOWANCE_THRESHOLD * BigInt(10)
+
+    const adapterAllowanceMissing: string[] = []
+    for (const candidate of feeCurrencyCandidates) {
+      if (!candidate.address) continue
+      if (!candidate.feeCurrencyAdapterAddress) continue
+      if (candidate.isFeeCurrency) continue // native Mento, no allowance needed
+      if (!candidate.balance.gt(0)) continue // balance check handled by picker
+      const allowance = yield* call(() =>
+        publicClient[Network.Celo].readContract({
+          address: candidate.address as Address,
+          abi: erc20Abi,
+          functionName: 'allowance',
+          args: [walletAddress as Address, candidate.feeCurrencyAdapterAddress as Address],
+        })
+      )
+      if (allowance < ALLOWANCE_THRESHOLD) {
+        adapterAllowanceMissing.push(candidate.address)
+        Logger.info(
+          TAG,
+          `skipping ${candidate.symbol} as fee currency: adapter allowance insufficient (${allowance.toString()})`
+        )
+      }
+    }
+
+    // CELO is excluded from ALLOWED_TOKEN_IDS so the Redux fee-currency list
+    // never contains it. Read native balance from chain and synthesize a
+    // minimal TokenBalance so the picker can rank CELO as a last-resort
+    // fallback alongside the stables.
     const celoNativeBalance = yield* call(() =>
       publicClient[Network.Celo].getBalance({ address: walletAddress as Address })
     )
-    const spendingTokenAddresses = new Set(steps.map((s) => s.tokenId.split(':')[1].toLowerCase()))
+    const syntheticCelo: TokenBalance | null =
+      celoNativeBalance > BigInt(0)
+        ? ({
+            tokenId: 'celo-mainnet:native',
+            address: null,
+            networkId: NetworkId['celo-mainnet'],
+            symbol: 'CELO',
+            name: 'Celo',
+            decimals: 18,
+            balance: new BigNumber(celoNativeBalance.toString()).shiftedBy(-18),
+            priceUsd: null,
+            lastKnownPriceUsd: null,
+            priceFetchedAt: Date.now(),
+            isNative: true,
+          } as unknown as TokenBalance)
+        : null
 
-    let feeCurrencyArg: Hex | undefined
-    let pickedSymbol: string
-    if (celoNativeBalance > BigInt(0)) {
-      // CELO native: use type 0x02 (eip1559), no feeCurrency field.
-      feeCurrencyArg = undefined
-      pickedSymbol = 'CELO'
-    } else {
-      const feeCurrencyCandidates = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+    const spendingTokenAddresses = steps.map((s) => s.tokenId.split(':')[1])
 
-      // Two kinds of CIP-64 fee currency:
-      //   - Native (isFeeCurrency=true): Mento stables registered with the
-      //     protocol. Gas is debited natively, no allowance required.
-      //   - Adapter-based (feeCurrencyAdapterAddress set): the protocol pulls
-      //     the underlying token via transferFrom on the adapter, which
-      //     requires a prior approve(adapter, allowance) from the user.
-      //
-      // We prefer native fee currencies first because they always work. For
-      // adapter-based ones we verify on-chain allowance before committing,
-      // since the protocol's pre-tx gas debit happens BEFORE the batch
-      // executes, so we can't bootstrap allowance inside this same tx.
-      // 1e30 wei: ~1T units of an 18-decimal token, far above any single tx's
-      // gas cost. We treat allowance above this as "infinite" so we don't
-      // bother re-approving. Built via repeated multiplication because the
-      // current tsconfig target rejects BigInt exponentiation.
-      let ALLOWANCE_THRESHOLD = BigInt(1)
-      for (let _i = 0; _i < 30; _i++) ALLOWANCE_THRESHOLD = ALLOWANCE_THRESHOLD * BigInt(10)
-      let chosen: { token: (typeof feeCurrencyCandidates)[number]; txAddress: Address } | undefined
+    const choice = pickFeeCurrency({
+      available: syntheticCelo ? [...feeCurrencyCandidates, syntheticCelo] : feeCurrencyCandidates,
+      excludeTokenIds: spendingTokenAddresses,
+      adapterAllowanceMissing,
+    })
 
-      for (const candidate of feeCurrencyCandidates) {
-        if (!candidate.balance.gt(0)) continue
-        if (!candidate.address) continue
-        if (spendingTokenAddresses.has(candidate.address.toLowerCase())) continue
-
-        if (candidate.isFeeCurrency) {
-          chosen = { token: candidate, txAddress: candidate.address as Address }
-          break
-        }
-
-        if (candidate.feeCurrencyAdapterAddress) {
-          const allowance = yield* call(() =>
-            publicClient[Network.Celo].readContract({
-              address: candidate.address as Address,
-              abi: erc20Abi,
-              functionName: 'allowance',
-              args: [walletAddress as Address, candidate.feeCurrencyAdapterAddress as Address],
-            })
-          )
-          if (allowance >= ALLOWANCE_THRESHOLD) {
-            chosen = { token: candidate, txAddress: candidate.feeCurrencyAdapterAddress }
-            break
-          }
-          Logger.info(
-            TAG,
-            `skipping ${candidate.symbol} as fee currency: adapter allowance insufficient (${allowance.toString()})`
-          )
-        }
-      }
-
-      if (!chosen) {
-        throw new Error(
-          'No usable fee currency: need CELO native, a native Mento fee currency, or a pre-approved adapter outside the spending set'
-        )
-      }
-      feeCurrencyArg = chosen.txAddress as Hex
-      pickedSymbol = chosen.token.symbol
+    if (!choice) {
+      throw new Error(
+        'No usable fee currency: need CELO native, a native Mento fee currency, or a pre-approved adapter outside the spending set'
+      )
     }
-    Logger.info(TAG, `picked fee currency: ${pickedSymbol} (${feeCurrencyArg ?? 'native CELO'})`)
+
+    // Map chosen TokenBalance to the actual on-chain fee-currency arg:
+    //   - CELO native -> undefined (type 0x02 eip1559, no feeCurrency field)
+    //   - adapter-based -> adapter address (protocol pulls via transferFrom)
+    //   - native Mento -> token address
+    let feeCurrencyArg: Hex | undefined
+    if (choice.chosen.symbol === 'CELO') {
+      feeCurrencyArg = undefined
+    } else if (choice.chosen.feeCurrencyAdapterAddress) {
+      feeCurrencyArg = choice.chosen.feeCurrencyAdapterAddress as Hex
+    } else {
+      feeCurrencyArg = choice.chosen.address as Hex
+    }
+    Logger.info(
+      TAG,
+      `picked fee currency: ${choice.chosen.symbol} (reason=${choice.reason}, declined=${choice.declined.length}, alternatives=${choice.alternatives.length})`
+    )
 
     const sendArgs = {
       account,

--- a/src/jumpstart/JumpstartEnterAmount.test.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.test.tsx
@@ -53,10 +53,13 @@ const tokenBalances = {
   [mockPoofTokenId]: { ...mockTokenBalances[mockPoofTokenId], balance: '0' }, // filtered out for no balance
   [mockCeurTokenId]: { ...mockTokenBalances[mockCeurTokenId], balance: '100' },
 }
+// Post Bug E migration: EnterAmount runs reorderForBugE on its fee-currency
+// list, so CELO trails the visible stables (cUSD, cEUR keep their selector
+// priority order).
 const feeCurrencies = [
-  tokenBalances[mockCeloTokenId],
   tokenBalances[mockCusdTokenId],
   tokenBalances[mockCeurTokenId],
+  tokenBalances[mockCeloTokenId],
 ]
 const store = createMockStore({
   tokens: {

--- a/src/send/EnterAmount.test.tsx
+++ b/src/send/EnterAmount.test.tsx
@@ -103,12 +103,13 @@ const mockStoreBalancesToTokenBalances = (storeBalances: StoredTokenBalance[]): 
   )
 }
 const mockFeeCurrencies = mockStoreBalancesToTokenBalances([
-  // matches mockStore - order follows feeCurrenciesSelector priority:
-  // CELO (0) > cUSD (2) > cEUR (99) > cREAL (99)
-  mockStoreTokenBalances[mockCeloTokenId],
+  // Post Bug E fix: EnterAmount applies reorderForBugE to the selector output
+  // so CELO slides to the end. Inside each group the selector priority is
+  // preserved: cUSD (2) > cEUR (99) > cREAL (99) > CELO (was 0, now last).
   mockStoreTokenBalances[mockCusdTokenId],
   mockStoreTokenBalances[mockCeurTokenId],
   mockStoreTokenBalances[mockCrealTokenId],
+  mockStoreTokenBalances[mockCeloTokenId],
 ])
 const onClearPreparedTransactionsSpy = jest.fn()
 const onRefreshPreparedTransactionsSpy = jest.fn()

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import React, { ComponentType, useEffect, useRef, useState } from 'react'
+import React, { ComponentType, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Keyboard,
@@ -38,6 +38,7 @@ import { AmountEnteredIn } from 'src/send/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { PreparedTransactionsResult, getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
@@ -120,7 +121,12 @@ export default function EnterAmount({
   const insets = useSafeAreaInsets()
   const [token, setToken] = useState<TokenBalance>(() => defaultToken ?? tokens[0])
   const [selectedPercentage, setSelectedPercentage] = useState<number | null>(null)
-  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, token.networkId))
+  const rawFeeCurrencies = useSelector((state) => feeCurrenciesSelector(state, token.networkId))
+  // Bug E: reorder so visible stables outrank CELO before this list reaches
+  // prepareTransactions, which would otherwise pick CELO (priority 0 in the
+  // shared selector) and silently drain a balance the user can't see. Every
+  // entry from the selector survives; CELO just slides to the end.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
   const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
   const { tokenId: feeTokenId } = feeCurrency ?? feeCurrencies[0]
 

--- a/src/send/SendEnterAmount.test.tsx
+++ b/src/send/SendEnterAmount.test.tsx
@@ -62,10 +62,13 @@ const tokenBalances = {
   [mockPoofTokenId]: { ...mockTokenBalances[mockPoofTokenId], balance: '0' }, // filtered out for no balance
   [mockCeurTokenId]: { ...mockTokenBalances[mockCeurTokenId], balance: '100' },
 }
+// Post Bug E fix: EnterAmount applies reorderForBugE so CELO slides to the
+// end of the list passed to refreshPreparedTransactions. Stables keep their
+// selector priority order (cUSD < cEUR), CELO trails.
 const feeCurrencies = [
-  tokenBalances[mockCeloTokenId],
   tokenBalances[mockCusdTokenId],
   tokenBalances[mockCeurTokenId],
+  tokenBalances[mockCeloTokenId],
 ]
 const store = createMockStore({
   tokens: {

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -235,7 +235,7 @@ const defaultQuoteResponse = JSON.stringify(defaultQuote)
 const preparedTransactions: SerializableTransactionRequest[] = [
   {
     data: '0x095ea7b3000000000000000000000000000000000000000000000000000000000000012300000000000000000000000000000000000000000000000011200c7644d50000',
-    feeCurrency: mockCusdAddress,
+    feeCurrency: mockCusdAddress as `0x${string}`,
     from: '0x0000000000000000000000000000000000007E57',
     gas: '21000',
     // 21000 * 60 / 100 = 12600 (matches the calibration added in
@@ -249,7 +249,7 @@ const preparedTransactions: SerializableTransactionRequest[] = [
   },
   {
     data: '0x0',
-    feeCurrency: mockCusdAddress,
+    feeCurrency: mockCusdAddress as `0x${string}`,
     from: '0x0000000000000000000000000000000000007E57',
     gas: '1850000',
     // The swap (second) tx has no fresh estimateGas call in this fixture so
@@ -1578,7 +1578,7 @@ describe('SwapScreen', () => {
 
     expect(
       getByText(
-        'swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"CELO, cUSD, cEUR"}'
+        'swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"cUSD, cEUR, CELO"}'
       )
     ).toBeTruthy()
   })
@@ -1600,12 +1600,14 @@ describe('SwapScreen', () => {
 
     expect(getByText('swapScreen.confirmSwap')).toBeDisabled()
 
-    // Per Bug E fix, useSwapQuote routes the selector output through
-    // pickFeeCurrency, which (1) drops cEUR because its balance is 0 and
-    // (2) promotes cUSD ahead of CELO. The warning lists the candidates the
-    // user actually had to work with, in the order pickFeeCurrency tried them.
+    // Per Bug E fix, useSwapQuote calls reorderForBugE which only pushes
+    // CELO to the end (no filtering). cEUR stays in the warning even with 0
+    // balance because the warning enumerates every currency the user could
+    // top up. Order: stables (selector priority) first, CELO last.
     expect(
-      getByText('swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"cUSD, CELO"}')
+      getByText(
+        'swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"cUSD, cEUR, CELO"}'
+      )
     ).toBeTruthy()
   })
 

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -226,9 +226,16 @@ const defaultQuote: FetchQuoteResponse = {
 }
 const defaultQuoteResponse = JSON.stringify(defaultQuote)
 
+// Per Bug E fix (pickFeeCurrency in useSwapQuote): when the user swaps CELO,
+// the picker promotes any visible stable above CELO. In these fixtures cUSD is
+// available with a non-zero balance, so the prepared swap tx is built with
+// feeCurrency = cUSD address (CIP-64 type 0x7b) instead of native CELO. Gas is
+// 50000 higher than the eip1559-native path because CIP-64 adds a small
+// pre-tx-fee debit overhead.
 const preparedTransactions: SerializableTransactionRequest[] = [
   {
     data: '0x095ea7b3000000000000000000000000000000000000000000000000000000000000012300000000000000000000000000000000000000000000000011200c7644d50000',
+    feeCurrency: mockCusdAddress,
     from: '0x0000000000000000000000000000000000007E57',
     gas: '21000',
     // 21000 * 60 / 100 = 12600 (matches the calibration added in
@@ -242,8 +249,9 @@ const preparedTransactions: SerializableTransactionRequest[] = [
   },
   {
     data: '0x0',
+    feeCurrency: mockCusdAddress,
     from: '0x0000000000000000000000000000000000007E57',
-    gas: '1800000',
+    gas: '1850000',
     // The swap (second) tx has no fresh estimateGas call in this fixture so
     // _estimatedGasUse stays undefined, matching the actual saga output.
     _estimatedGasUse: undefined,
@@ -1283,19 +1291,21 @@ describe('SwapScreen', () => {
       price: defaultQuote.unvalidatedSwapTransaction.price,
       provider: defaultQuote.details.swapProvider,
       web3Library: 'viem',
-      gas: 1821000,
-      maxGasFee: 0.021852,
-      maxGasFeeUsd: 0.28529642665785426,
-      // _estimatedGasUse calibration: approval tx has 21000 * 0.6 = 12600,
-      // swap tx falls back to its 1.8M gas limit (no fresh estimateGas in
-      // the fixture). Total estimated gas = 12600 + 1800000 = 1812600.
-      // estimatedGasFee = 1812600 * (6 + 2) Gwei = 14_500_800_000_000_000 wei
-      //                 = 0.0145008 CELO (vs 0.014568 pre-calibration)
-      estimatedGasFee: 0.0145008,
-      estimatedGasFeeUsd: 0.1893202646750967,
+      // Per Bug E fix: pickFeeCurrency promotes cUSD ahead of CELO whenever
+      // the user has any cUSD balance. The fixture token mock has cUSD
+      // priceUsd = 1 and uses 18 decimals (same as CELO), so the gas math is:
+      //   gas: 21000 (approval) + 1850000 (swap, CIP-64 adds 50k overhead) = 1871000
+      //   maxGasFee:        1871000 * 12 Gwei = 0.022452 cUSD
+      //   estimatedGasFee:  (12600 calibrated approval + 1850000 swap) * 8 Gwei = 0.0149008 cUSD
+      //   ...USD = same numeric value since cUSD priceUsd = 1.
+      gas: 1871000,
+      maxGasFee: 0.022452,
+      maxGasFeeUsd: 0.022452,
+      estimatedGasFee: 0.0149008,
+      estimatedGasFeeUsd: 0.0149008,
       appFeePercentageIncludedInPrice: undefined,
-      feeCurrency: undefined,
-      feeCurrencySymbol: 'CELO',
+      feeCurrency: mockCusdAddress,
+      feeCurrencySymbol: 'cUSD',
       txCount: 2,
       swapType: 'same-chain',
     })
@@ -1371,8 +1381,11 @@ describe('SwapScreen', () => {
 
     const transactionDetails = getByTestId('SwapTransactionDetails')
     expect(transactionDetails).toHaveTextContent('swapScreen.transactionDetails.fee')
-    // matches mocked value (0.015 CELO) provided to estimateFeesPerGas, estimateGas, and gas in defaultQuoteResponse
-    expect(getByTestId('SwapTransactionDetails/Fees')).toHaveTextContent('≈ COP$0.25')
+    // Per Bug E fix, useSwapQuote now picks cUSD over CELO when both have
+    // balance, so the displayed fee is 0.0149 cUSD ≈ COP$0.02 (cUSD priceUsd=1
+    // and mock COP rate is 1.3x) instead of 0.0145 CELO ≈ COP$0.25 (CELO
+    // priceUsd ≈ 13).
+    expect(getByTestId('SwapTransactionDetails/Fees')).toHaveTextContent('≈ COP$0.02')
     expect(transactionDetails).toHaveTextContent('swapScreen.transactionDetails.slippagePercentage')
     expect(getByTestId('SwapTransactionDetails/Slippage')).toHaveTextContent('0.3%')
   })
@@ -1587,10 +1600,12 @@ describe('SwapScreen', () => {
 
     expect(getByText('swapScreen.confirmSwap')).toBeDisabled()
 
+    // Per Bug E fix, useSwapQuote routes the selector output through
+    // pickFeeCurrency, which (1) drops cEUR because its balance is 0 and
+    // (2) promotes cUSD ahead of CELO. The warning lists the candidates the
+    // user actually had to work with, in the order pickFeeCurrency tried them.
     expect(
-      getByText(
-        'swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"CELO, cUSD, cEUR"} '
-      )
+      getByText('swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"cUSD, CELO"}')
     ).toBeTruthy()
   })
 

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
 import { useAsyncCallback } from 'react-async-hook'
 import { useSelector } from 'src/redux/hooks'
 import {
@@ -8,6 +9,7 @@ import {
   SwapTransaction,
   SwapType,
 } from 'src/swap/types'
+import { pickFeeCurrency } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -374,7 +376,16 @@ function useSwapQuote({
   enableAppFee: boolean
 }) {
   const walletAddress = useSelector(walletAddressSelector)
-  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  const rawFeeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  // Bug E: the shared selector returns CELO at index 0, and prepareTransactions
+  // (called inside prepareSwapTransactions below) locks in the first viable
+  // entry. Reorder via the picker so any visible stable is preferred over
+  // CELO. CELO stays as the last alternative for the rare case where every
+  // stable fails the gas check.
+  const feeCurrencies = useMemo(() => {
+    const choice = pickFeeCurrency({ available: rawFeeCurrencies })
+    return choice ? [choice.chosen, ...choice.alternatives] : rawFeeCurrencies
+  }, [rawFeeCurrencies])
 
   const refreshQuote = useAsyncCallback(
     async (

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -9,7 +9,7 @@ import {
   SwapTransaction,
   SwapType,
 } from 'src/swap/types'
-import { pickFeeCurrency } from 'src/tokens/feeCurrencyPicker'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -379,13 +379,10 @@ function useSwapQuote({
   const rawFeeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
   // Bug E: the shared selector returns CELO at index 0, and prepareTransactions
   // (called inside prepareSwapTransactions below) locks in the first viable
-  // entry. Reorder via the picker so any visible stable is preferred over
-  // CELO. CELO stays as the last alternative for the rare case where every
-  // stable fails the gas check.
-  const feeCurrencies = useMemo(() => {
-    const choice = pickFeeCurrency({ available: rawFeeCurrencies })
-    return choice ? [choice.chosen, ...choice.alternatives] : rawFeeCurrencies
-  }, [rawFeeCurrencies])
+  // entry. Demote CELO to the end of the array so any visible stable is
+  // preferred. CELO remains in the list as a last-resort fallback for the
+  // rare case where every stable fails the gas check.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
 
   const refreshQuote = useAsyncCallback(
     async (

--- a/src/tokens/feeCurrencyPicker.test.ts
+++ b/src/tokens/feeCurrencyPicker.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { pickFeeCurrency } from 'src/tokens/feeCurrencyPicker'
+import { pickFeeCurrency, reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import type { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
 
@@ -137,11 +137,43 @@ describe('pickFeeCurrency', () => {
     expect(result).toBeNull()
   })
 
+  it('keeps every input in alternatives when none are excluded', () => {
+    const result = pickFeeCurrency({ available: [CELO, USDM, COPM, USDT] })
+    expect([result?.chosen.symbol, ...(result?.alternatives.map((t) => t.symbol) ?? [])]).toEqual([
+      'USDm',
+      'COPm',
+      'USDT',
+      'CELO',
+    ])
+  })
+
   it('lists alternatives in stable-then-CELO order for cascade fallback', () => {
     // Three stables + CELO all pass; alternatives let the saga retry on
     // insufficient-gas without re-running the picker.
     const result = pickFeeCurrency({ available: [CELO, USDM, COPM, USDT] })
     expect(result?.chosen.symbol).toBe('USDm')
     expect(result?.alternatives.map((t) => t.symbol)).toEqual(['COPm', 'USDT', 'CELO'])
+  })
+})
+
+describe('reorderForBugE', () => {
+  it('moves CELO to the end and keeps every other token in place', () => {
+    const usdmZero = tok({
+      symbol: 'USDm',
+      balance: new BigNumber(0),
+      priceUsd: new BigNumber(1),
+    })
+    const result = reorderForBugE([CELO, USDM, usdmZero, COPM])
+    expect(result.map((t) => t.symbol)).toEqual(['USDm', 'USDm', 'COPm', 'CELO'])
+    // Same length: nothing is filtered out by balance gates.
+    expect(result.length).toBe(4)
+  })
+
+  it('is a no-op when CELO is not present', () => {
+    expect(reorderForBugE([USDM, COPM])).toEqual([USDM, COPM])
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(reorderForBugE([])).toEqual([])
   })
 })

--- a/src/tokens/feeCurrencyPicker.test.ts
+++ b/src/tokens/feeCurrencyPicker.test.ts
@@ -1,0 +1,147 @@
+import BigNumber from 'bignumber.js'
+import { pickFeeCurrency } from 'src/tokens/feeCurrencyPicker'
+import type { TokenBalance } from 'src/tokens/slice'
+import { NetworkId } from 'src/transactions/types'
+
+function tok(overrides: Partial<TokenBalance>): TokenBalance {
+  return {
+    tokenId: `celo-mainnet:${overrides.symbol?.toLowerCase() ?? 'x'}`,
+    address: `0x${(overrides.symbol ?? 'x').padEnd(40, '0')}`,
+    networkId: NetworkId['celo-mainnet'],
+    symbol: 'X',
+    name: overrides.symbol ?? 'X',
+    decimals: 18,
+    balance: new BigNumber(0),
+    priceUsd: null,
+    lastKnownPriceUsd: null,
+    priceFetchedAt: 0,
+    ...overrides,
+  } as unknown as TokenBalance
+}
+
+const CELO = tok({ symbol: 'CELO', balance: new BigNumber(1), priceUsd: new BigNumber(0.5) })
+const COPM = tok({
+  symbol: 'COPm',
+  balance: new BigNumber(10000),
+  priceUsd: new BigNumber(0.00025),
+})
+const USDM = tok({ symbol: 'USDm', balance: new BigNumber(3), priceUsd: new BigNumber(1) })
+const USDT = tok({
+  symbol: 'USDT',
+  balance: new BigNumber(2),
+  priceUsd: new BigNumber(1),
+  decimals: 6,
+})
+
+describe('pickFeeCurrency', () => {
+  it('returns null when nothing is available', () => {
+    expect(pickFeeCurrency({ available: [] })).toBeNull()
+  })
+
+  it('prefers any stable over CELO (Bug E core)', () => {
+    const result = pickFeeCurrency({ available: [CELO, USDM] })
+    expect(result?.chosen.symbol).toBe('USDm')
+    expect(result?.reason).toBe('preferred-stable')
+    expect(result?.declined).toEqual([{ token: CELO, reason: 'celo-deprioritized' }])
+  })
+
+  it('preserves the selector-supplied stable order and keeps CELO as last alternative', () => {
+    // available is already sorted by the selector (priority + USD balance);
+    // picker must not re-sort within the non-CELO group. CELO stays in
+    // alternatives because it remains a valid last-resort if every stable
+    // attempt reverts on insufficient gas.
+    const result = pickFeeCurrency({ available: [CELO, COPM, USDM, USDT] })
+    expect(result?.chosen.symbol).toBe('COPm')
+    expect(result?.alternatives.map((t) => t.symbol)).toEqual(['USDm', 'USDT', 'CELO'])
+  })
+
+  it('falls back to CELO when no stable passes the gates', () => {
+    const result = pickFeeCurrency({ available: [CELO] })
+    expect(result?.chosen.symbol).toBe('CELO')
+    expect(result?.reason).toBe('celo-fallback')
+    expect(result?.declined).toEqual([])
+  })
+
+  it('excludes tokens being spent by tokenId', () => {
+    const result = pickFeeCurrency({
+      available: [USDM, COPM, CELO],
+      excludeTokenIds: [USDM.tokenId],
+    })
+    expect(result?.chosen.symbol).toBe('COPm')
+    expect(result?.declined).toEqual([
+      { token: USDM, reason: 'in-spending-set' },
+      { token: CELO, reason: 'celo-deprioritized' },
+    ])
+  })
+
+  it('excludes tokens being spent by address (case-insensitive)', () => {
+    const result = pickFeeCurrency({
+      available: [USDM, COPM],
+      excludeTokenIds: [USDM.address!.toUpperCase()],
+    })
+    expect(result?.chosen.symbol).toBe('COPm')
+    expect(result?.declined[0]).toEqual({ token: USDM, reason: 'in-spending-set' })
+  })
+
+  it('rejects zero balances', () => {
+    const empty = tok({ symbol: 'USDm', balance: new BigNumber(0), priceUsd: new BigNumber(1) })
+    const result = pickFeeCurrency({ available: [empty, CELO] })
+    expect(result?.chosen.symbol).toBe('CELO')
+    expect(result?.reason).toBe('celo-fallback')
+    expect(result?.declined).toEqual([{ token: empty, reason: 'insufficient-balance' }])
+  })
+
+  it('rejects candidates whose USD balance does not cover requiredGasUsd', () => {
+    const dust = tok({ symbol: 'USDm', balance: new BigNumber(0.01), priceUsd: new BigNumber(1) })
+    const result = pickFeeCurrency({
+      available: [dust, CELO],
+      requiredGasUsd: new BigNumber(0.05),
+    })
+    expect(result?.chosen.symbol).toBe('CELO')
+    expect(result?.declined).toEqual([{ token: dust, reason: 'insufficient-balance' }])
+  })
+
+  it('rejects priceless tokens when requiredGasUsd is set', () => {
+    const priceless = tok({ symbol: 'USDm', balance: new BigNumber(5), priceUsd: null })
+    const result = pickFeeCurrency({
+      available: [priceless, CELO],
+      requiredGasUsd: new BigNumber(0.05),
+    })
+    expect(result?.chosen.symbol).toBe('CELO')
+    expect(result?.declined).toEqual([{ token: priceless, reason: 'no-price-data' }])
+  })
+
+  it('accepts priceless tokens when requiredGasUsd is not set', () => {
+    const priceless = tok({ symbol: 'USDm', balance: new BigNumber(5), priceUsd: null })
+    const result = pickFeeCurrency({ available: [priceless, CELO] })
+    expect(result?.chosen.symbol).toBe('USDm')
+  })
+
+  it('skips adapter-based candidates flagged by the caller', () => {
+    const result = pickFeeCurrency({
+      available: [USDM, COPM, CELO],
+      adapterAllowanceMissing: [USDM.address!],
+    })
+    expect(result?.chosen.symbol).toBe('COPm')
+    expect(result?.declined).toEqual([
+      { token: USDM, reason: 'adapter-allowance-missing' },
+      { token: CELO, reason: 'celo-deprioritized' },
+    ])
+  })
+
+  it('returns null when every candidate is filtered out', () => {
+    const result = pickFeeCurrency({
+      available: [USDM, CELO],
+      excludeTokenIds: [USDM.tokenId, CELO.tokenId],
+    })
+    expect(result).toBeNull()
+  })
+
+  it('lists alternatives in stable-then-CELO order for cascade fallback', () => {
+    // Three stables + CELO all pass; alternatives let the saga retry on
+    // insufficient-gas without re-running the picker.
+    const result = pickFeeCurrency({ available: [CELO, USDM, COPM, USDT] })
+    expect(result?.chosen.symbol).toBe('USDm')
+    expect(result?.alternatives.map((t) => t.symbol)).toEqual(['COPm', 'USDT', 'CELO'])
+  })
+})

--- a/src/tokens/feeCurrencyPicker.ts
+++ b/src/tokens/feeCurrencyPicker.ts
@@ -49,6 +49,17 @@ export interface PickFeeCurrencyInput {
 const isCelo = (t: TokenBalance) => t.symbol === 'CELO'
 const isNotCelo = (t: TokenBalance) => t.symbol !== 'CELO'
 
+/**
+ * Lightweight Bug-E reorder for downstream consumers that iterate the array
+ * themselves (e.g. prepareTransactions). Stable + non-filtering: every entry
+ * from the input survives; CELO just moves to the end. Use this when the
+ * caller wants the full candidate list with the preferred order baked in.
+ * For the "pick one with reasoning" use case use pickFeeCurrency instead.
+ */
+export function reorderForBugE(available: TokenBalance[]): TokenBalance[] {
+  return [...available.filter(isNotCelo), ...available.filter(isCelo)]
+}
+
 function normalizeLower(values: string[] | undefined): Set<string> {
   return new Set((values ?? []).map((v) => v.toLowerCase()))
 }

--- a/src/tokens/feeCurrencyPicker.ts
+++ b/src/tokens/feeCurrencyPicker.ts
@@ -1,0 +1,129 @@
+import BigNumber from 'bignumber.js'
+import type { TokenBalance } from 'src/tokens/slice'
+
+// Bug E: CELO is hidden from TuCop's user-facing token list, so paying gas in
+// CELO silently shrinks a balance the user can't see. This module deprioritizes
+// CELO so any visible stable is preferred, with CELO only used when no stable
+// is suitable. The deprioritization lives here (not in feeCurrenciesSelector)
+// so legacy callers keep their CELO-first ordering until each one opts in.
+
+export type FeeCurrencyReason =
+  | 'preferred-stable' // user-visible token picked, hidden CELO debit avoided
+  | 'celo-fallback' // no stable usable, fell back to CELO (last resort)
+
+export type DeclineReason =
+  | 'in-spending-set' // token is being spent in the same flow; would deplete reserve
+  | 'insufficient-balance' // balance does not cover requiredGasUsd (or is zero)
+  | 'no-price-data' // can't verify against requiredGasUsd; safer to skip
+  | 'celo-deprioritized' // CELO would have qualified but a stable did too (Bug E)
+  | 'adapter-allowance-missing' // CIP-64 adapter not pre-approved; caller-supplied
+
+export interface DeclinedCandidate {
+  token: TokenBalance
+  reason: DeclineReason
+}
+
+export interface FeeCurrencyChoice {
+  chosen: TokenBalance
+  reason: FeeCurrencyReason
+  alternatives: TokenBalance[]
+  declined: DeclinedCandidate[]
+}
+
+export interface PickFeeCurrencyInput {
+  /** Candidate fee currencies, already filtered to a single network. */
+  available: TokenBalance[]
+  /** Token IDs (or addresses) being spent in this flow; never pick these. */
+  excludeTokenIds?: string[]
+  /** If set, skip any candidate whose balance × priceUsd is below this. */
+  requiredGasUsd?: BigNumber
+  /**
+   * Addresses of CIP-64 adapter-based fee currencies the caller already
+   * checked and found without sufficient allowance. The picker can't query
+   * the chain synchronously, so callers (sagas) pre-flight allowance and
+   * pass in the rejects here.
+   */
+  adapterAllowanceMissing?: string[]
+}
+
+const isCelo = (t: TokenBalance) => t.symbol === 'CELO'
+const isNotCelo = (t: TokenBalance) => t.symbol !== 'CELO'
+
+function normalizeLower(values: string[] | undefined): Set<string> {
+  return new Set((values ?? []).map((v) => v.toLowerCase()))
+}
+
+export function pickFeeCurrency({
+  available,
+  excludeTokenIds,
+  requiredGasUsd,
+  adapterAllowanceMissing,
+}: PickFeeCurrencyInput): FeeCurrencyChoice | null {
+  const excludeSet = normalizeLower(excludeTokenIds)
+  const adapterSkipSet = normalizeLower(adapterAllowanceMissing)
+  const declined: DeclinedCandidate[] = []
+
+  // Reorder candidates so stables come before CELO. Within each group the
+  // selector-supplied order (priority + USD balance) is preserved.
+  const nonCelo = available.filter(isNotCelo)
+  const celo = available.filter(isCelo)
+  const ordered = [...nonCelo, ...celo]
+
+  const passing: TokenBalance[] = []
+  for (const token of ordered) {
+    const idMatch = excludeSet.has(token.tokenId.toLowerCase())
+    const addressMatch = !!token.address && excludeSet.has(token.address.toLowerCase())
+    if (idMatch || addressMatch) {
+      declined.push({ token, reason: 'in-spending-set' })
+      continue
+    }
+
+    if (token.address && adapterSkipSet.has(token.address.toLowerCase())) {
+      declined.push({ token, reason: 'adapter-allowance-missing' })
+      continue
+    }
+
+    if (token.balance.lte(0)) {
+      declined.push({ token, reason: 'insufficient-balance' })
+      continue
+    }
+
+    if (requiredGasUsd) {
+      if (!token.priceUsd) {
+        declined.push({ token, reason: 'no-price-data' })
+        continue
+      }
+      const balanceUsd = token.balance.multipliedBy(token.priceUsd)
+      if (balanceUsd.lt(requiredGasUsd)) {
+        declined.push({ token, reason: 'insufficient-balance' })
+        continue
+      }
+    }
+
+    passing.push(token)
+  }
+
+  if (passing.length === 0) return null
+
+  const firstStable = passing.find(isNotCelo)
+  const firstCelo = passing.find(isCelo)
+
+  let chosen: TokenBalance
+  let reason: FeeCurrencyReason
+
+  if (firstStable) {
+    chosen = firstStable
+    reason = 'preferred-stable'
+    // Surface the Bug-E preference: CELO was usable but we deprioritized it.
+    if (firstCelo) {
+      declined.push({ token: firstCelo, reason: 'celo-deprioritized' })
+    }
+  } else {
+    // Only CELO remained. Acceptable last resort.
+    chosen = firstCelo!
+    reason = 'celo-fallback'
+  }
+
+  const alternatives = passing.filter((t) => t !== chosen)
+  return { chosen, reason, alternatives, declined }
+}

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -535,6 +535,14 @@ const feeCurrenciesByNetworkIdSelector = createSelector(
     // Priority order for TuCop fee currencies: CELO > COPm > USDm > USDC > USDT
     // Current names (Mento rebranding): COPm, USDm
     // Fallback old names (Valora API): cCOP, cUSD
+    //
+    // NOTE: this preserves the historical CELO-first priority for the 10
+    // legacy callers (swap, send, earn, dapps, jumpstart, gold, walletConnect,
+    // buckspay, subsidies, neeru). The Bug-E stables-first preference is
+    // applied inside `pickFeeCurrency` (src/tokens/feeCurrencyPicker.ts), used
+    // only by the migrated flows (dollarsSpend legacy + 7702). Migrating the
+    // remaining callers to `pickFeeCurrency` removes their dependency on this
+    // ordering and lets us flip CELO to last-resort globally in a future PR.
     const FEE_CURRENCY_PRIORITY: Record<string, number> = {
       CELO: 0,
       COPm: 1, // Colombian Peso (current)


### PR DESCRIPTION
## Summary

Bug E: when the user has any CELO on-chain, every flow in the wallet that pays gas ends up using CELO — silently — because the shared `feeCurrenciesSelector` returns CELO at priority 0 and `prepareTransactions` locks in the first viable entry. CELO is hidden from TuCop's user-facing token list, so the user can't see the balance shrink and can't choose otherwise.

This PR demotes CELO to a last-resort fee currency in the WRI-related flows (the ones already touched by Track A/B/C), without disturbing the 10 other callers that still depend on the historical ordering.

- New `pickFeeCurrency({ available, excludeTokenIds, requiredGasUsd, adapterAllowanceMissing }) -> { chosen, reason, alternatives, declined }`: the structured picker used by sagas (atomic 7702 + legacy multi-step). Returns CELO only when no stable qualifies.
- New `reorderForBugE(available)`: lightweight non-filtering reorder used by hooks (`useSwapQuote`, `send/EnterAmount`) that pass the full list into `prepareTransactions`. Same set, CELO just slides to the end.
- The 7702 saga's inline allowance check now feeds skipped adapters into the picker via `adapterAllowanceMissing` instead of duplicating the iteration logic.
- The shared `feeCurrenciesSelector` is untouched (10 unmigrated callers still get CELO-first). A doc note explains the boundary.

Behavioral effect: any flow that touches these 4 files (dollarsSpend legacy + 7702, swap, send) now pays gas in a visible stable whenever possible. The user's hidden CELO balance is no longer silently drained.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn jest src/send src/swap src/tokens src/dollarsSpend src/dapps` — 537/537 pass
- [x] New lock-in test: `saga7702.test.ts > prefers a stable fee currency over CELO when both are available (Bug E)`
- [x] New picker tests cover preferred-stable, celo-fallback, in-spending-set, insufficient-balance, no-price-data, adapter-allowance-missing, cascade alternatives
- [x] Existing SwapScreen, SendEnterAmount, EnterAmount fixtures updated to assert the new ordering (no behavioral regression in passing tests)
- [ ] Manual dogfood on mainnetdev: swap CELO -> cUSD with a small CELO balance and confirm gas is paid in cUSD (sendTransaction args show `feeCurrency: 0x874069...`)
- [ ] Dollars -> Pesos atomic 7702 with stables available: confirm tx logs "picked fee currency: COPm (reason=preferred-stable, declined=1)"

## Out of scope / deferred

- UI surface ("Tarifa pagada en {Pesos|Dólares}" on the confirm screen) — possible follow-up
- Telemetry event for fee-currency decisions — possible follow-up, the picker already returns the decision shape
- Cascade-on-revert (retry sendTransaction with the next alternative when the chosen reverts) — possible follow-up for the 7702 saga
- Migrating the 10 remaining `feeCurrenciesSelector` callers (jumpstart, buckspay, dapps, earn, gold, walletConnect, subsidies, neeru) — separate PR after dogfood