### PR TITLE
fix(fee): Bug E follow-ups — telemetry + UI surface + cascade + 9-caller migration

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1906,6 +1906,7 @@
       "estimatedTransactionTimeInfo": "The time to complete the transaction is determined by the provider.\n\nIf you are swapping between different chains, the transaction could take a bit longer to complete.",
       "infoDismissButton": "Got it",
       "fees": "Fees",
+      "feePaidIn": "Paid in",
       "feesCalculationError": "Unable to calculate fees",
       "estimatedCrossChainFee": "Estimated cross-chain fees",
       "maxCrossChainFee": "Max cross-chain fees",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -1916,6 +1916,7 @@
       "estimatedTransactionTimeInfo": "El tiempo para completar la transacción lo determina el proveedor.\n\nSi estás intercambiando entre diferentes cadenas, la transacción podría tardar un poco más en completarse.",
       "infoDismissButton": "Entendido",
       "fees": "Tarifas",
+      "feePaidIn": "Pagada en",
       "feesCalculationError": "No es posible calcular las tarifas",
       "estimatedCrossChainFee": "Tarifa de transacción entre cadenas estimada",
       "maxCrossChainFee": "Tarifas máximas entre cadenas",

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -339,6 +339,7 @@ export enum QrScreenEvents {
 export enum FeeEvents {
   estimate_fee_failed = 'estimate_fee_failed',
   estimate_fee_success = 'estimate_fee_success',
+  fee_currency_picked = 'fee_currency_picked',
 }
 
 export enum TransactionEvents {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -664,6 +664,11 @@ interface FeeEventsProperties {
     reason: 'preferred-stable' | 'celo-fallback'
     declinedCount: number
     alternativesCount: number
+    // 0 when the initial pick succeeded on first sendTransaction. >0 when the
+    // initial pick reverted and the saga cascaded through alternatives. Only
+    // saga7702 emits cascadeAttempts > 0 today (legacy multi-step lets
+    // prepareTransactions do its own iteration upstream).
+    cascadeAttempts?: number
     networkId: NetworkId
   }
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -652,6 +652,20 @@ interface FeeEventsProperties {
     tokenAddress: string
     usdFee: string
   }
+  // Fired by every flow that resolves a fee currency through pickFeeCurrency.
+  // Used to measure how often the Bug E fix saves the user from a silent CELO
+  // debit ('preferred-stable') vs how often the wallet still falls back to
+  // CELO because no stable qualified ('celo-fallback'). declined count helps
+  // diagnose UX issues (e.g. many in-spending-set declines suggest the user
+  // is trying to swap most of their balance).
+  [FeeEvents.fee_currency_picked]: {
+    context: 'dollarsSpend_7702' | 'dollarsSpend_legacy' | 'swap' | 'send'
+    chosenSymbol: string
+    reason: 'preferred-stable' | 'celo-fallback'
+    declinedCount: number
+    alternativesCount: number
+    networkId: NetworkId
+  }
 }
 
 interface TransactionEventsProperties {

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -353,6 +353,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [QrScreenEvents.qr_scanned]: `When a QR code has been successfully scanned`,
   [FeeEvents.estimate_fee_failed]: ``,
   [FeeEvents.estimate_fee_success]: ``,
+  [FeeEvents.fee_currency_picked]: `Fee currency resolution for a user flow (dollarsSpend atomic / dollarsSpend legacy / swap / send). reason=preferred-stable means Bug E was avoided (a visible stable was picked over hidden CELO); reason=celo-fallback means no stable qualified and CELO was used. declinedCount + alternativesCount give the size of the candidate space.`,
   [TransactionEvents.transaction_start]: `when a transaction is about to be submitted to the blockchain`,
   [TransactionEvents.transaction_gas_estimated]: `when gas is estimated for a transaction or an already estimated gas is used in a transaction about to be submitted (only for contract-kit)`,
   [TransactionEvents.transaction_hash_received]: `when a hash is received for a transaction`,

--- a/src/buckspay/BucksPayConfirm.tsx
+++ b/src/buckspay/BucksPayConfirm.tsx
@@ -15,6 +15,7 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { useCOPm } from 'src/tokens/hooks'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
 import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
@@ -30,9 +31,12 @@ function BucksPayConfirm({ route }: Props) {
 
   const walletAddress = useSelector(walletAddressSelector)
   const copmToken = useCOPm()
-  const feeCurrencies = useSelector((state) =>
+  const rawFeeCurrencies = useSelector((state) =>
     feeCurrenciesSelector(state, NetworkId['celo-mainnet'])
   )
+  // Bug E: stables ahead of CELO so the COPm -> COP offramp doesn't burn a
+  // hidden CELO balance to pay gas.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
 
   const {
     prepareTransactionsResult,

--- a/src/dapps/DappShortcutTransactionRequest.test.tsx
+++ b/src/dapps/DappShortcutTransactionRequest.test.tsx
@@ -95,7 +95,9 @@ describe('DappShortcutTransactionRequest', () => {
     )
     expect(
       getByText(
-        'walletConnectRequest.notEnoughBalanceForGas.description, {"feeCurrencies":"CELO, cUSD, cEUR"}'
+        // Per Bug E migration: reorderForBugE pushes CELO to the end so the
+        // warning lists visible stables first; CELO is the last-resort fallback.
+        'walletConnectRequest.notEnoughBalanceForGas.description, {"feeCurrencies":"cUSD, cEUR, CELO"}'
       )
     ).toBeTruthy()
     expect(queryByText('allow')).toBeFalsy()

--- a/src/dapps/DappShortcutTransactionRequest.tsx
+++ b/src/dapps/DappShortcutTransactionRequest.tsx
@@ -1,5 +1,5 @@
 import { BottomSheetScreenProps } from '@th3rdwave/react-navigation-bottom-sheet'
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet } from 'react-native'
@@ -16,6 +16,7 @@ import { rawShortcutTransactionsToTransactionRequests } from 'src/positions/tran
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -33,7 +34,10 @@ function usePrepareShortcutTransactions(
   networkId: NetworkId,
   rawTransactions: RawShortcutTransaction[] | undefined
 ) {
-  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  const rawFeeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  // Bug E: keep CELO as a last resort so dapp-shortcut gas debits hit visible
+  // stables when the user has any. Falls through to CELO if no stable works.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
 
   return useAsync(
     async () => {
@@ -90,7 +94,11 @@ function Content({ rewardId }: { rewardId: string }) {
     shortcutId: pendingAcceptShortcut?.shortcutId ?? '',
   }
 
-  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  const rawFeeCurrenciesContent = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  const feeCurrencies = useMemo(
+    () => reorderForBugE(rawFeeCurrenciesContent),
+    [rawFeeCurrenciesContent]
+  )
 
   const asyncPreparedTransactions = usePrepareShortcutTransactions(
     networkId,

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -1,6 +1,8 @@
 import { createAction, PayloadAction } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
 import { call, delay, put, race, select, take, takeEvery } from 'typed-redux-saga'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { FeeEvents } from 'src/analytics/Events'
 import { executeDollarsSpend7702Saga } from 'src/dollarsSpend/saga7702'
 import {
   multiSwapCompleted,
@@ -307,6 +309,14 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
         TAG,
         `step ${index} (${step.symbol}): fee currency ${choice.chosen.symbol} (reason=${choice.reason}, declined=${choice.declined.length})`
       )
+      AppAnalytics.track(FeeEvents.fee_currency_picked, {
+        context: 'dollarsSpend_legacy',
+        chosenSymbol: choice.chosen.symbol,
+        reason: choice.reason,
+        declinedCount: choice.declined.length,
+        alternativesCount: choice.alternatives.length,
+        networkId: fromToken.networkId as NetworkId,
+      })
     }
 
     let freshQuote: Awaited<ReturnType<typeof fetchSwapQuoteForExecution>>

--- a/src/dollarsSpend/saga7702.test.ts
+++ b/src/dollarsSpend/saga7702.test.ts
@@ -258,6 +258,85 @@ describe('dollarsSpend saga dispatcher (flag-gated)', () => {
     expect(sendArg.feeCurrency).toBe(mockCopm.address)
   })
 
+  it('cascades to the next alternative when sendTransaction reverts with a fee-currency error', async () => {
+    // First attempt (USDm) reverts with "insufficient funds for gas" — a
+    // fee-currency-shaped failure. The cascade re-tries with the next
+    // alternative (CELO native). Second attempt succeeds.
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
+    const sendTx = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('insufficient funds for gas in feeCurrency'))
+      .mockResolvedValueOnce(MOCK_TX_HASH)
+    const wallet = mockWallet({ sendTx })
+    jest.mocked(getViemWallet as any).mockReturnValue(wallet)
+
+    const mockUsdm = {
+      tokenId: 'celo-mainnet:usdm',
+      networkId: 'celo-mainnet',
+      symbol: 'USDm',
+      decimals: 18,
+      balance: new BigNumber(5),
+      priceUsd: new BigNumber(1),
+      address: '0x765de816845861e75a25fca122bb6898b8b1282a',
+      isFeeCurrency: true,
+    } as any
+
+    await expectSaga(
+      executeDollarsSpend7702Saga,
+      executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+    )
+      .provide([
+        [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+        [matchers.select.selector(tokensByIdSelector), mockTokensById],
+        [matchers.select.selector(feeCurrenciesSelector), [mockUsdm]],
+        [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
+        [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+        [matchers.call.fn(getConnectedUnlockedAccount), MOCK_WALLET],
+      ])
+      .put(multiSwapCompleted())
+      .silentRun()
+
+    // sendTransaction called twice: once with USDm, once with CELO native.
+    expect(sendTx).toHaveBeenCalledTimes(2)
+    expect(sendTx.mock.calls[0][0].feeCurrency).toBe(mockUsdm.address)
+    expect(sendTx.mock.calls[1][0].feeCurrency).toBeUndefined()
+  })
+
+  it('does not cascade on non-fee-currency errors (user-rejected, slippage, RPC)', async () => {
+    jest.useRealTimers()
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.mocked(fetchSwapQuoteForExecution).mockResolvedValue(mockQuoteResult as any)
+    // user-rejected error: cascade must NOT mask this with a retry.
+    const sendTx = jest.fn().mockRejectedValue(new Error('user rejected the request'))
+    const wallet = mockWallet({ sendTx })
+    jest.mocked(getViemWallet as any).mockReturnValue(wallet)
+
+    try {
+      await expectSaga(
+        executeDollarsSpend7702Saga,
+        executeMultiSwap({ steps: [stepUsat], toTokenId: 'celo-mainnet:copm' })
+      )
+        .provide([
+          [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+          [matchers.select.selector(tokensByIdSelector), mockTokensById],
+          [matchers.select.selector(feeCurrenciesSelector), []],
+          [matchers.call.fn(fetchSwapQuoteForExecution), mockQuoteResult],
+          [matchers.call.fn(getViemWallet), dynamic(() => wallet)],
+          [matchers.call.fn(getConnectedUnlockedAccount), MOCK_WALLET],
+        ])
+        .put.actionType(multiSwapStepFailed.type)
+        .not.put.actionType(multiSwapCompleted.type)
+        .silentRun(500)
+    } finally {
+      jest.useFakeTimers()
+    }
+    // Cascade only fires on fee-currency-looking failures. user-rejected is
+    // terminal — sendTransaction must be called exactly once even though CELO
+    // is available as an alternative.
+    expect(sendTx).toHaveBeenCalledTimes(1)
+  })
+
   it('dispatches multiSwapStepFailed when a quote refetch throws (flag on)', async () => {
     jest.useRealTimers()
     jest.mocked(getFeatureGate).mockReturnValue(true)

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -348,7 +348,7 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
     //   - CELO native -> undefined (type 0x02 eip1559, no feeCurrency field)
     //   - adapter-based -> adapter address (protocol pulls via transferFrom)
     //   - native Mento -> token address
-    function toFeeCurrencyArg(candidate: TokenBalance): Hex | undefined {
+    const toFeeCurrencyArg = (candidate: TokenBalance): Hex | undefined => {
       if (candidate.symbol === 'CELO') return undefined
       if (candidate.feeCurrencyAdapterAddress) {
         return candidate.feeCurrencyAdapterAddress as Hex

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -344,39 +344,90 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       )
     }
 
-    // Map chosen TokenBalance to the actual on-chain fee-currency arg:
+    // Map a TokenBalance candidate to the actual on-chain fee-currency arg:
     //   - CELO native -> undefined (type 0x02 eip1559, no feeCurrency field)
     //   - adapter-based -> adapter address (protocol pulls via transferFrom)
     //   - native Mento -> token address
-    let feeCurrencyArg: Hex | undefined
-    if (choice.chosen.symbol === 'CELO') {
-      feeCurrencyArg = undefined
-    } else if (choice.chosen.feeCurrencyAdapterAddress) {
-      feeCurrencyArg = choice.chosen.feeCurrencyAdapterAddress as Hex
-    } else {
-      feeCurrencyArg = choice.chosen.address as Hex
+    function toFeeCurrencyArg(candidate: TokenBalance): Hex | undefined {
+      if (candidate.symbol === 'CELO') return undefined
+      if (candidate.feeCurrencyAdapterAddress) {
+        return candidate.feeCurrencyAdapterAddress as Hex
+      }
+      return candidate.address as Hex
     }
+
+    // Cascade-on-revert: try the picker's chosen currency first; if
+    // sendTransaction reverts with a fee-currency-related error (insufficient
+    // funds, fee currency not supported, gas issues), fall through to
+    // alternatives[0], [1], ... until one succeeds or the list is exhausted.
+    // Non-fee-currency errors (user rejected, slippage, RPC timeout) bubble
+    // immediately so the cascade doesn't mask unrelated failures.
+    const cascadeCandidates: TokenBalance[] = [choice.chosen, ...choice.alternatives]
+    let hash: Hex | undefined
+    let finalCandidate: TokenBalance = choice.chosen
+    let cascadeAttempts = 0
+    let lastError: unknown
+    for (let attempt = 0; attempt < cascadeCandidates.length; attempt++) {
+      const candidate = cascadeCandidates[attempt]
+      const feeCurrencyArg = toFeeCurrencyArg(candidate)
+      Logger.info(
+        TAG,
+        `sendTransaction attempt ${attempt + 1}/${cascadeCandidates.length} with feeCurrency=${candidate.symbol} (${feeCurrencyArg ?? 'native CELO'})`
+      )
+      const sendArgs = {
+        account,
+        to: walletAddress as Address,
+        data: calldata,
+        ...(feeCurrencyArg && { feeCurrency: feeCurrencyArg }),
+      } as unknown as Parameters<typeof wallet.sendTransaction>[0]
+      try {
+        hash = yield* call(() => wallet.sendTransaction(sendArgs))
+        finalCandidate = candidate
+        cascadeAttempts = attempt
+        break
+      } catch (err) {
+        lastError = err
+        const message = err instanceof Error ? err.message : String(err)
+        // Only cascade on errors that suggest a different currency might help.
+        // Treat everything else (user-rejected, slippage, RPC) as terminal.
+        const looksLikeFeeCurrencyIssue =
+          /insufficient funds|fee currency|gas.{0,30}(too low|insufficient)|cip.?64/i.test(message)
+        const hasMoreAlternatives = attempt < cascadeCandidates.length - 1
+        if (!looksLikeFeeCurrencyIssue || !hasMoreAlternatives) {
+          throw err
+        }
+        Logger.warn(
+          TAG,
+          `feeCurrency=${candidate.symbol} attempt failed (${message}); cascading to next alternative`
+        )
+      }
+    }
+    if (hash === undefined) {
+      // Defensive: the loop above either breaks with a hash or throws. This
+      // branch is only reachable if the candidate list was empty, which
+      // pickFeeCurrency already guards against (returns null instead).
+      throw lastError ?? new Error('No fee currency succeeded')
+    }
+
+    // Reason reflects the FINAL choice after any cascade fallback: a cascade
+    // that landed on a stable still counts as preferred-stable; one that
+    // landed on CELO is celo-fallback. cascadeAttempts tells the team whether
+    // the first try worked (0) or how many alternatives were burned through.
+    const finalReason: 'preferred-stable' | 'celo-fallback' =
+      finalCandidate.symbol === 'CELO' ? 'celo-fallback' : 'preferred-stable'
     Logger.info(
       TAG,
-      `picked fee currency: ${choice.chosen.symbol} (reason=${choice.reason}, declined=${choice.declined.length}, alternatives=${choice.alternatives.length})`
+      `picked fee currency: ${finalCandidate.symbol} (reason=${finalReason}, declined=${choice.declined.length}, alternatives=${choice.alternatives.length}, cascadeAttempts=${cascadeAttempts})`
     )
     AppAnalytics.track(FeeEvents.fee_currency_picked, {
       context: 'dollarsSpend_7702',
-      chosenSymbol: choice.chosen.symbol,
-      reason: choice.reason,
+      chosenSymbol: finalCandidate.symbol,
+      reason: finalReason,
       declinedCount: choice.declined.length,
       alternativesCount: choice.alternatives.length,
+      cascadeAttempts,
       networkId: NetworkId['celo-mainnet'],
     })
-
-    const sendArgs = {
-      account,
-      to: walletAddress as Address,
-      data: calldata,
-      ...(feeCurrencyArg && { feeCurrency: feeCurrencyArg }),
-    } as unknown as Parameters<typeof wallet.sendTransaction>[0]
-
-    const hash = yield* call(() => wallet.sendTransaction(sendArgs))
 
     Logger.info(TAG, `Submitted 7702 dollarsSpend batch: ${hash}`)
 
@@ -405,9 +456,12 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       // make handleTransactionReceiptReceived log a noisy "No information found
       // for fee currency" error when the receipt enriches the standby. For
       // adapter / non-CELO fee currencies, pass the tokenId so the UI can show
-      // the fee in the correct token.
-      const feeCurrencyId = feeCurrencyArg
-        ? `celo-mainnet:${feeCurrencyArg.toLowerCase()}`
+      // the fee in the correct token. Uses the cascade winner (finalCandidate)
+      // so the standby reflects whichever currency actually paid for gas, not
+      // the initially-chosen one if a cascade fallback fired.
+      const finalFeeCurrencyArg = toFeeCurrencyArg(finalCandidate)
+      const feeCurrencyId = finalFeeCurrencyArg
+        ? `celo-mainnet:${finalFeeCurrencyArg.toLowerCase()}`
         : undefined
       // Value convention: whole tokens with decimal (Valora-compatible). The
       // wallet's UI assumes whole-token strings; emitting wei here would

--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -2,6 +2,8 @@ import { PayloadAction } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
 import { call, delay, put, select } from 'typed-redux-saga'
 import { Address, encodeFunctionData, erc20Abi, Hex } from 'viem'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { FeeEvents } from 'src/analytics/Events'
 import { BATCH_EXECUTOR_ABI } from 'src/dollarsSpend/batchExecutorAbi'
 import { ExecuteMultiSwapPayload } from 'src/dollarsSpend/saga'
 import {
@@ -358,6 +360,14 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       TAG,
       `picked fee currency: ${choice.chosen.symbol} (reason=${choice.reason}, declined=${choice.declined.length}, alternatives=${choice.alternatives.length})`
     )
+    AppAnalytics.track(FeeEvents.fee_currency_picked, {
+      context: 'dollarsSpend_7702',
+      chosenSymbol: choice.chosen.symbol,
+      reason: choice.reason,
+      declinedCount: choice.declined.length,
+      alternativesCount: choice.alternatives.length,
+      networkId: NetworkId['celo-mainnet'],
+    })
 
     const sendArgs = {
       account,

--- a/src/earn/EarnConfirmationScreen.tsx
+++ b/src/earn/EarnConfirmationScreen.tsx
@@ -27,6 +27,7 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { useTokenInfo } from 'src/tokens/hooks'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
@@ -67,7 +68,12 @@ export default function EarnConfirmationScreen({ route }: Props) {
 
   const isGasSubsidized = isGasSubsidizedForNetwork(depositToken.networkId)
 
-  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, depositToken.networkId))
+  const rawFeeCurrencies = useSelector((state) =>
+    feeCurrenciesSelector(state, depositToken.networkId)
+  )
+  // Bug E: stables ahead of CELO so an earn withdraw/claim doesn't silently
+  // burn the user's hidden CELO balance on gas.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
 
   const withdrawAmountInDepositToken = useMemo(
     () =>

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -42,6 +42,7 @@ import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { SwapTransaction } from 'src/swap/types'
 import { useLocalToTokenAmount, useTokenInfo, useTokenToLocalAmount } from 'src/tokens/hooks'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector, swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getInputDecimalsForToken } from 'src/utils/formatting'
@@ -250,9 +251,11 @@ function EarnEnterAmount({ route }: Props) {
     [transactionToken, isWithdrawal, pool]
   )
 
-  const feeCurrencies = useSelector((state) =>
+  const rawFeeCurrencies = useSelector((state) =>
     feeCurrenciesSelector(state, transactionToken.networkId)
   )
+  // Bug E: stables ahead of CELO for the earn deposit/withdraw flow.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
 
   useEffect(() => {
     clearPreparedTransactions()

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -25,6 +25,7 @@ import { hooksApiUrlSelector } from 'src/positions/selectors'
 import { RawShortcutTransaction } from 'src/positions/slice'
 import { triggerShortcutRequest } from 'src/positions/saga'
 import { rawShortcutTransactionsToTransactionRequests } from 'src/positions/transactions'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -111,7 +112,11 @@ export function* closeNeeruPositionSaga(action: ReturnType<typeof closePositionS
     return
   }
   const hooksApiUrl = yield* select(hooksApiUrlSelector)
-  const feeCurrencies = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+  // Bug E: stables ahead of CELO so the Neeru open/close path doesn't burn a
+  // hidden CELO balance to pay gas.
+  const feeCurrencies = reorderForBugE(
+    yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+  )
 
   try {
     const response: { transactions: RawShortcutTransaction[] } = yield* call(
@@ -168,7 +173,11 @@ export function* emergencyCloseNeeruPositionSaga(action: ReturnType<typeof emerg
     return
   }
   const hooksApiUrl = yield* select(hooksApiUrlSelector)
-  const feeCurrencies = yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+  // Bug E: stables ahead of CELO so the Neeru open/close path doesn't burn a
+  // hidden CELO balance to pay gas.
+  const feeCurrencies = reorderForBugE(
+    yield* select(feeCurrenciesSelector, NetworkId['celo-mainnet'])
+  )
 
   try {
     const response: { transactions: RawShortcutTransaction[] } = yield* call(

--- a/src/gold/useGoldQuote.ts
+++ b/src/gold/useGoldQuote.ts
@@ -1,9 +1,11 @@
 import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
 import { useAsyncCallback } from 'react-async-hook'
 import { goldPriceUsdSelector } from 'src/gold/selectors'
 import { GoldSwapQuote } from 'src/gold/types'
 import { useSelector } from 'src/redux/hooks'
 import { FetchQuoteResponse, SwapTransaction } from 'src/swap/types'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -260,9 +262,12 @@ async function createSwapTransactionsFromQuote(
 export function useGoldQuote() {
   const walletAddress = useSelector(walletAddressSelector)
   const goldPriceUsd = useSelector(goldPriceUsdSelector)
-  const feeCurrencies = useSelector((state) =>
+  const rawFeeCurrencies = useSelector((state) =>
     feeCurrenciesSelector(state, NetworkId['celo-mainnet'])
   )
+  // Bug E: stables ahead of CELO for Oro buy/sell so gas doesn't drain hidden
+  // CELO. Same memo pattern as useSwapQuote.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
 
   const getQuote = useAsyncCallback(
     async (params: GoldQuoteParams): Promise<GoldQuoteResult | null> => {

--- a/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
+++ b/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { useAsync } from 'react-async-hook'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
@@ -32,6 +32,7 @@ import { typeScale } from 'src/styles/fonts'
 import { Shadow, Spacing, getShadowStyle } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { useTokenInfo } from 'src/tokens/hooks'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import TransactionDetails from 'src/transactions/feed/TransactionDetails'
 import FeeRowItem from 'src/transactions/feed/detailContent/FeeRowItem'
@@ -60,7 +61,10 @@ function JumpstartTransactionDetailsScreen({ route }: Props) {
   const token = useTokenInfo(transaction.amount.tokenId)
 
   const walletAddress = useSelector(walletAddressSelector)
-  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  const rawFeeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+  // Bug E: keep visible stables ahead of CELO so a jumpstart reclaim doesn't
+  // silently spend the user's hidden CELO balance on gas.
+  const feeCurrencies = useMemo(() => reorderForBugE(rawFeeCurrencies), [rawFeeCurrencies])
   const reclaimStatus = useSelector(jumpstartReclaimStatusSelector)
 
   const bottomSheetRef = useRef<BottomSheetModalRefType>(null)

--- a/src/subsidies/ReFiColombiaSubsidiesContract.ts
+++ b/src/subsidies/ReFiColombiaSubsidiesContract.ts
@@ -2,6 +2,7 @@ import { showMessage } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { showErrorMessage } from 'src/components/ErrorMessage'
 import { store } from 'src/redux/store'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -234,9 +235,10 @@ export class ReFiColombiaSubsidiesContract {
         args: [],
       })
 
-      const feeCurrencies = feeCurrenciesSelector(
-        store.getState() as any,
-        NetworkId['celo-mainnet']
+      // Bug E: stables ahead of CELO so the ReFi Colombia subsidies claim
+      // doesn't burn hidden CELO on gas.
+      const feeCurrencies = reorderForBugE(
+        feeCurrenciesSelector(store.getState() as any, NetworkId['celo-mainnet'])
       )
 
       Logger.debug(

--- a/src/swap/SwapTransactionDetails.test.tsx
+++ b/src/swap/SwapTransactionDetails.test.tsx
@@ -205,4 +205,61 @@ describe('SwapTransactionDetails', () => {
       }
     )
   })
+
+  describe('feePaidIn (Bug E surface)', () => {
+    const mockNetworkFee: SwapFeeAmount = {
+      amount: new BigNumber(0.01),
+      token: mockCusdTokenBalance,
+    }
+
+    it('renders user-facing display name for the chosen fee currency', () => {
+      const { getByTestId } = render(
+        <Provider store={createMockStore()}>
+          <SwapTransactionDetails {...defaultProps} networkFee={mockNetworkFee} />
+        </Provider>
+      )
+      // cUSD belongs to the "Dólares" UX group per getTokenDisplayName.
+      expect(getByTestId('SwapTransactionDetails/FeePaidIn')).toHaveTextContent(
+        'swapScreen.transactionDetails.feePaidIn'
+      )
+      expect(getByTestId('SwapTransactionDetails/FeePaidIn')).toHaveTextContent('Dólares')
+    })
+
+    it('keeps raw symbol when no friendly mapping exists (e.g. CELO fallback)', () => {
+      const { getByTestId } = render(
+        <Provider store={createMockStore()}>
+          <SwapTransactionDetails
+            {...defaultProps}
+            networkFee={{ ...mockNetworkFee, token: mockCeloTokenBalance }}
+          />
+        </Provider>
+      )
+      // CELO is not in the Pesos / Dólares / Oro mapping; raw symbol survives
+      // so the user can tell when the last-resort CELO fallback fired.
+      expect(getByTestId('SwapTransactionDetails/FeePaidIn')).toHaveTextContent('CELO')
+    })
+
+    it('is hidden while the quote is loading', () => {
+      const { queryByTestId } = render(
+        <Provider store={createMockStore()}>
+          <SwapTransactionDetails
+            {...defaultProps}
+            networkFee={mockNetworkFee}
+            fetchingSwapQuote={true}
+          />
+        </Provider>
+      )
+      // No flash of "Paid in ???" while the quote is still resolving.
+      expect(queryByTestId('SwapTransactionDetails/FeePaidIn')).toBeNull()
+    })
+
+    it('is hidden when there is no network fee token (rare error path)', () => {
+      const { queryByTestId } = render(
+        <Provider store={createMockStore()}>
+          <SwapTransactionDetails {...defaultProps} networkFee={undefined} />
+        </Provider>
+      )
+      expect(queryByTestId('SwapTransactionDetails/FeePaidIn')).toBeNull()
+    })
+  })
 })

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -266,7 +266,7 @@ export function SwapTransactionDetails({
           value={estimatedFeesString ?? placeholder}
         />
       </View>
-      {networkFee?.token?.symbol && !fetchingSwapQuote && (
+      {!!networkFee?.token?.symbol && !fetchingSwapQuote && (
         // Bug E UX surface: the user can see which of their visible balances
         // covers the network fee. Was added so a tx paid in Pesos / Dólares no
         // longer looks like an unexplained CELO debit. Uses getTokenDisplayName

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -9,6 +9,7 @@ import { SwapShowInfoType } from 'src/analytics/Properties'
 import { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import { formatValueToDisplay, getTokenSymbol } from 'src/components/TokenDisplay'
 import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getTokenDisplayName } from 'src/tokens/utils'
 import Touchable from 'src/components/Touchable'
 import InfoIcon from 'src/icons/status/InfoIcon'
 import { getLocalCurrencySymbol, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
@@ -265,6 +266,18 @@ export function SwapTransactionDetails({
           value={estimatedFeesString ?? placeholder}
         />
       </View>
+      {networkFee?.token?.symbol && !fetchingSwapQuote && (
+        // Bug E UX surface: the user can see which of their visible balances
+        // covers the network fee. Was added so a tx paid in Pesos / Dólares no
+        // longer looks like an unexplained CELO debit. Uses getTokenDisplayName
+        // so the user reads "Pesos" / "Dólares" / "Oro" instead of the chain
+        // symbols (COPm, USDm, XAUt0). CELO falls through to its raw symbol so
+        // the user still sees something if the last-resort fallback fires.
+        <View style={styles.row} testID="SwapTransactionDetails/FeePaidIn">
+          <Text style={styles.label}>{t('swapScreen.transactionDetails.feePaidIn')}</Text>
+          <Text style={styles.value}>{getTokenDisplayName(networkFee.token.symbol)}</Text>
+        </View>
+      )}
       {!!estimatedDurationInSeconds && (
         <View style={styles.row} testID="SwapTransactionDetails/EstimatedDuration">
           <LabelWithInfo

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -223,7 +223,8 @@ export function isFeeCurrency(token: TokenBalance | undefined): token is TokenBa
  * Returns user-friendly display name for tokens.
  * UI Rules:
  * - COPm, cCOP → "Pesos"
- * - USDT, USDC, USDm, USD₮ → "Dólares"
+ * - USDT, USDC, USDm, cUSD, USD₮ → "Dólares"
+ * - cEUR → "Euros"
  * - XAUt0 → "Oro"
  * - Others → symbol as-is
  */
@@ -235,9 +236,15 @@ export function getTokenDisplayName(symbol: string): string {
     return 'Pesos'
   }
 
-  // US Dollar stablecoins
-  if (['USDT', 'USDC', 'USDM', 'USD₮'].includes(normalizedSymbol) || symbol === 'USD₮') {
+  // US Dollar stablecoins (cUSD = legacy Mento name for USDm, kept here so
+  // older balances + tests resolve to the same Spanish label).
+  if (['USDT', 'USDC', 'USDM', 'CUSD', 'USD₮'].includes(normalizedSymbol) || symbol === 'USD₮') {
     return 'Dólares'
+  }
+
+  // Euro stable (cEUR = legacy Mento name for EURm).
+  if (normalizedSymbol === 'CEUR' || normalizedSymbol === 'EURM') {
+    return 'Euros'
   }
 
   // Digital Gold

--- a/src/walletConnect/saga.test.ts
+++ b/src/walletConnect/saga.test.ts
@@ -566,7 +566,7 @@ describe('showActionRequest', () => {
       supportedChains: ['eip155:42220'],
       version: 2,
       hasInsufficientGasFunds: false,
-      feeCurrenciesSymbols: ['CELO', 'cUSD', 'cEUR'],
+      feeCurrenciesSymbols: ['cUSD', 'cEUR', 'CELO'],
       preparedTransaction: mockPreparedTransactions.transactions[0],
       prepareTransactionErrorMessage: undefined,
     })
@@ -601,7 +601,7 @@ describe('showActionRequest', () => {
       supportedChains: ['eip155:42220'],
       version: 2,
       hasInsufficientGasFunds: false,
-      feeCurrenciesSymbols: ['CELO', 'cUSD', 'cEUR'],
+      feeCurrenciesSymbols: ['cUSD', 'cEUR', 'CELO'],
       preparedTransaction: undefined,
       prepareTransactionErrorMessage: 'Some error',
     })
@@ -636,7 +636,7 @@ describe('showActionRequest', () => {
       supportedChains: ['eip155:42220'],
       version: 2,
       hasInsufficientGasFunds: false,
-      feeCurrenciesSymbols: ['CELO', 'cUSD', 'cEUR'],
+      feeCurrenciesSymbols: ['cUSD', 'cEUR', 'CELO'],
       preparedTransaction: undefined,
       prepareTransactionErrorMessage: 'viem short message',
     })

--- a/src/walletConnect/saga.ts
+++ b/src/walletConnect/saga.ts
@@ -18,6 +18,7 @@ import { ActiveDapp } from 'src/dapps/types'
 import i18n from 'src/i18n'
 import { isBottomSheetVisible, navigate, navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForWalletConnect } from 'src/tokens/utils'
 import { Network } from 'src/transactions/types'
@@ -460,7 +461,11 @@ function* showActionRequest(request: WalletKitTypes.EventArguments['session_requ
   const supportedChains = yield* call(getSupportedChains)
 
   const networkId = walletConnectChainIdToNetworkId[request.params.chainId]
-  const feeCurrencies = yield* select((state) => feeCurrenciesSelector(state, networkId))
+  // Bug E: keep stables ahead of CELO so WalletConnect dapp txs don't pay gas
+  // in a balance the user can't see.
+  const feeCurrencies = reorderForBugE(
+    yield* select((state) => feeCurrenciesSelector(state, networkId))
+  )
   let preparedTransactionsResult: PreparedTransactionsResult | undefined = undefined
   let prepareTransactionErrorMessage: string | undefined = undefined
   if (


### PR DESCRIPTION
## Summary

Follows up #227 (merged) with the four pieces explicitly deferred there:

1. **Telemetry** — `FeeEvents.fee_currency_picked` with `chosenSymbol`, `reason`, `declinedCount`, `alternativesCount`, `cascadeAttempts`, `context`. Fired from saga7702 (atomic) and dollarsSpend/saga (legacy multi-step). Swap + send keep using the existing `swap_review_submit` event.
2. **UI surface** — adds a "Pagada en {Pesos | Dólares | Oro | Euros | CELO}" row to `SwapTransactionDetails`. Uses `getTokenDisplayName`, with cUSD/cEUR now mapped to Dólares/Euros so legacy balances resolve correctly.
3. **Cascade-on-revert in saga7702** — when `wallet.sendTransaction` reverts with a fee-currency-shaped error (insufficient funds, fee-currency not supported, CIP-64 issues, gas-too-low), the saga walks `choice.alternatives` in order until one succeeds. Non-fee-currency errors (user-rejected, slippage, RPC) bubble immediately. The standby tx + analytics event reflect the cascade winner (`finalCandidate`).
4. **9-caller migration** — applies `reorderForBugE` to every remaining `feeCurrenciesSelector` caller: buckspay/BucksPayConfirm, dapps/DappShortcutTransactionRequest (×2 sites), earn/EarnConfirmationScreen, earn/EarnEnterAmount, earn/neeru/saga (open+close), gold/useGoldQuote, jumpstart/JumpstartTransactionDetailsScreen, subsidies/ReFiColombiaSubsidiesContract, walletConnect/saga.

After this PR, the historical CELO-first ordering in `feeCurrenciesSelector` has zero consumers. A small follow-up can flip the priority globally and delete the compat note added in #227.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [x] `yarn jest src/tokens src/swap src/send src/dollarsSpend src/dapps src/analytics src/earn src/buckspay src/jumpstart src/gold src/walletConnect src/subsidies` — 2061/2061 pass
- [x] New SwapTransactionDetails "Pagada en X" UI tests (4 cases)
- [x] New saga7702 cascade tests (2 cases): cascades on fee-currency-shaped revert, does not cascade on user-rejected
- [ ] Manual: swap CELO -> cUSD on mainnetdev, verify the "Pagada en Dólares" row appears below the Tarifa row
- [ ] Manual: trigger an atomic Dolares -> Pesos with a USDm balance JUST below gas; verify cascade event fires with cascadeAttempts > 0