### PR TITLE
feat(wri): TX feed migration to TuCop indexer + watch registration (gated)

### DIFF
--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -44,6 +44,17 @@ export enum StatsigFeatureGates {
   SHOW_NEERU_VAULTS = 'show_neeru_vaults',
   WRI_PREFLIGHT_SWAP_SIMULATION = 'wri_preflight_swap_simulation',
   WRI_DOLLARS_SPEND_7702_V1 = 'wri_dollars_spend_7702_v1',
+  // Flip the transaction feed source from Valora's getWalletTransactions to
+  // TuCop's own indexer (which classifies EIP-7702 atomic batches that Valora
+  // ignores). Coordinated with backend's INDEXER_ENABLED=true; do not roll
+  // out the wallet flag until the backend indexer is live AND has caught up
+  // to the latest block. See tasks/plans/wri-tx-feed-tucop.md.
+  WRI_TX_FEED_TUCOP_V1 = 'wri_tx_feed_tucop_v1',
+  // Pre-approve the CIP-64 fee adapters for USDC/USDT (one-time MAX_UINT256
+  // grants) so users without CELO or Mento stables can still pay gas with
+  // their dollar balances. Decoupled from the feed flag — bootstrap is a
+  // wallet-only action with no feed dependency.
+  WRI_COPM_FEE_BOOTSTRAP_V1 = 'wri_copm_fee_bootstrap_v1',
 }
 
 export enum StatsigExperiments {

--- a/src/transactions/api.test.ts
+++ b/src/transactions/api.test.ts
@@ -1,0 +1,111 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { setupListeners } from '@reduxjs/toolkit/query'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+import { transactionFeedV2Api } from 'src/transactions/api'
+import { LocalCurrencyCode } from 'src/localCurrency/consts'
+import networkConfig from 'src/web3/networkConfig'
+
+jest.mock('src/statsig', () => ({
+  ...jest.requireActual('src/statsig'),
+  getFeatureGate: jest.fn(),
+  getMultichainFeatures: jest.fn().mockReturnValue({ showTransfers: ['celo-mainnet'] }),
+}))
+
+function buildStore() {
+  const store = configureStore({
+    reducer: { [transactionFeedV2Api.reducerPath]: transactionFeedV2Api.reducer },
+    middleware: (getDefault) => getDefault().concat(transactionFeedV2Api.middleware),
+  })
+  setupListeners(store.dispatch)
+  return store
+}
+
+describe('transactionFeedV2Api', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('routes to the legacy Valora endpoint when WRI_TX_FEED_TUCOP_V1 is off', async () => {
+    jest.mocked(getFeatureGate).mockImplementation((g) => {
+      if (g === StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1) return false
+      return false
+    })
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ transactions: [], pageInfo: {} }), { status: 200 })
+      )
+
+    const store = buildStore()
+    await store.dispatch(
+      transactionFeedV2Api.endpoints.transactionFeedV2.initiate({
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        localCurrencyCode: LocalCurrencyCode.USD,
+        endCursor: undefined,
+      })
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const firstArg = fetchSpy.mock.calls[0][0]
+    const url = typeof firstArg === 'string' ? firstArg : (firstArg as Request).url
+    expect(url.startsWith(networkConfig.getWalletTransactionsUrl)).toBe(true)
+    expect(url.startsWith(networkConfig.wriTxFeedUrl)).toBe(false)
+    fetchSpy.mockRestore()
+  })
+
+  it('routes to the TuCop indexer endpoint when WRI_TX_FEED_TUCOP_V1 is on', async () => {
+    jest.mocked(getFeatureGate).mockImplementation((g) => {
+      if (g === StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1) return true
+      return false
+    })
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ transactions: [], pageInfo: {} }), { status: 200 })
+      )
+
+    const store = buildStore()
+    await store.dispatch(
+      transactionFeedV2Api.endpoints.transactionFeedV2.initiate({
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        localCurrencyCode: LocalCurrencyCode.USD,
+        endCursor: undefined,
+      })
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const firstArg = fetchSpy.mock.calls[0][0]
+    const url = typeof firstArg === 'string' ? firstArg : (firstArg as Request).url
+    expect(url.startsWith(networkConfig.wriTxFeedUrl)).toBe(true)
+    expect(url.startsWith(networkConfig.getWalletTransactionsUrl)).toBe(false)
+    fetchSpy.mockRestore()
+  })
+
+  it('preserves the existing query params (address, networkIds, includeTypes, localCurrencyCode) under both gates', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ transactions: [], pageInfo: {} }), { status: 200 })
+      )
+
+    const store = buildStore()
+    await store.dispatch(
+      transactionFeedV2Api.endpoints.transactionFeedV2.initiate({
+        address: '0xabc',
+        localCurrencyCode: LocalCurrencyCode.COP,
+        endCursor: undefined,
+      })
+    )
+
+    const firstArg = fetchSpy.mock.calls[0][0]
+    const url = typeof firstArg === 'string' ? firstArg : (firstArg as Request).url
+    // RTK Query URL-encodes the params; assert by substring rather than parsing.
+    expect(url).toContain('address=0xabc')
+    expect(url).toContain('localCurrencyCode=COP')
+    expect(url).toContain('networkIds=celo-mainnet')
+    expect(url).toContain('includeTypes=')
+    fetchSpy.mockRestore()
+  })
+})

--- a/src/transactions/api.ts
+++ b/src/transactions/api.ts
@@ -1,6 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { type LocalCurrencyCode } from 'src/localCurrency/consts'
-import { getMultichainFeatures } from 'src/statsig'
+import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { FEED_V2_INCLUDE_TYPES, type PageInfo, type TokenTransaction } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -9,8 +10,12 @@ type TransactionFeedV2Response = {
   pageInfo: PageInfo
 }
 
+// baseUrl is intentionally empty: each query resolves the absolute URL at call
+// time so the gate flip (WRI_TX_FEED_TUCOP_V1) takes effect without a wallet
+// restart. fetchBaseQuery treats an absolute URL on the request as overriding
+// baseUrl, so an empty baseUrl is safe.
 const baseQuery = fetchBaseQuery({
-  baseUrl: networkConfig.getWalletTransactionsUrl,
+  baseUrl: '',
   headers: { Accept: 'application/json' },
 })
 
@@ -27,8 +32,17 @@ export const transactionFeedV2Api = createApi({
       }
     >({
       query: ({ address, localCurrencyCode, endCursor: afterCursor }) => {
+        // WRI Track C feed migration: when the gate is on, route through
+        // TuCop's own indexer which classifies EIP-7702 atomic batches that
+        // Valora ignores (tx.from == tx.to == userEOA calling execute()).
+        // Both endpoints accept the same query params and return the same
+        // shape, so this is a drop-in flip — no caller changes required.
+        const useTucopFeed = getFeatureGate(StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1)
+        const url = useTucopFeed
+          ? networkConfig.wriTxFeedUrl
+          : networkConfig.getWalletTransactionsUrl
         return {
-          url: '',
+          url,
           params: {
             address,
             networkIds: getMultichainFeatures().showTransfers.join(','),

--- a/src/transactions/registerWatchSaga.test.ts
+++ b/src/transactions/registerWatchSaga.test.ts
@@ -1,0 +1,63 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { throwError } from 'redux-saga-test-plan/providers'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+import { registerWalletForFeedWatch } from 'src/transactions/registerWatchSaga'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+import networkConfig from 'src/web3/networkConfig'
+
+jest.mock('src/statsig', () => ({
+  getFeatureGate: jest.fn(),
+}))
+jest.mock('src/utils/fetchWithTimeout', () => ({
+  fetchWithTimeout: jest.fn(),
+}))
+
+const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
+
+describe('registerWalletForFeedWatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('skips the POST when WRI_TX_FEED_TUCOP_V1 is off', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    const fetchMock = jest.mocked(fetchWithTimeout)
+    await expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the address to wriTxWatchUrl when the gate is on', async () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((g) => g === StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1)
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    await expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    const [url, opts] = jest.mocked(fetchWithTimeout).mock.calls[0]
+    expect(url).toBe(networkConfig.wriTxWatchUrl)
+    expect(opts?.method).toBe('POST')
+    expect(opts?.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(opts?.body).toBe(JSON.stringify({ address: MOCK_WALLET }))
+  })
+
+  it('does not throw when the backend returns 5xx; logs and exits', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response('Internal Server Error', { status: 503 }))
+    // The saga must not bubble — it's a fire-and-forget side effect that
+    // retries on the next boot.
+    await expect(expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()).resolves.not.toThrow()
+  })
+
+  it('does not throw when fetchWithTimeout itself throws (network down / abort)', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.mocked(fetchWithTimeout).mockRejectedValue(new Error('network unreachable'))
+    await expect(expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()).resolves.not.toThrow()
+  })
+})

--- a/src/transactions/registerWatchSaga.test.ts
+++ b/src/transactions/registerWatchSaga.test.ts
@@ -1,6 +1,4 @@
 import { expectSaga } from 'redux-saga-test-plan'
-import * as matchers from 'redux-saga-test-plan/matchers'
-import { throwError } from 'redux-saga-test-plan/providers'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { registerWalletForFeedWatch } from 'src/transactions/registerWatchSaga'

--- a/src/transactions/registerWatchSaga.ts
+++ b/src/transactions/registerWatchSaga.ts
@@ -1,0 +1,103 @@
+import { call, delay, select, spawn, take, takeEvery } from 'typed-redux-saga'
+import { Actions as Web3Actions } from 'src/web3/actions'
+import { walletAddressSelector } from 'src/web3/selectors'
+import networkConfig from 'src/web3/networkConfig'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+import Logger from 'src/utils/Logger'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+import { REHYDRATE, type RehydrateAction } from 'src/redux/persist-helper'
+
+const TAG = 'transactions/registerWatchSaga'
+
+// WRI Track C: Tell the TuCop backend indexer to start tracking this wallet's
+// future transactions. The indexer keeps a Postgres row per watched address
+// and persists every Celo tx that touches it; without this call the wallet
+// would never receive its own atomic-7702 batches in the feed.
+//
+// Trigger: both REHYDRATE (existing users on every boot) AND SET_ACCOUNT (new
+// users just past onboarding). Backend is idempotent, so calling repeatedly
+// is fine — we get bulletproof coverage at the cost of one cheap POST per
+// boot for users that are already watched.
+//
+// Gated: only fires when WRI_TX_FEED_TUCOP_V1 is on. There's no point asking
+// the backend to track a wallet whose feed we won't be consuming. If the
+// gate flips on later (during the rollout) the next boot picks it up.
+//
+// Failure mode: silent. The endpoint may 5xx during a backend incident; the
+// next boot retries. We never alert the user — the feed itself falls back to
+// Valora when the gate is off, and to the indexer's last known state when
+// the gate is on, regardless of whether the watch call succeeded.
+
+// 15 second timeout. Backend acks the watch synchronously after enqueuing the
+// indexer backfill job, so this should be sub-second under normal load.
+const WATCH_TIMEOUT_MS = 15_000
+
+export function* registerWalletForFeedWatch(walletAddress: string) {
+  // Re-check the gate at call time; another saga (e.g. statsig refresh) might
+  // have flipped it in between the trigger fire and now.
+  const gateOn: boolean = yield* call(getFeatureGate, StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1)
+  if (!gateOn) {
+    Logger.debug(TAG, `WRI_TX_FEED_TUCOP_V1 off; skipping watch for ${walletAddress}`)
+    return
+  }
+
+  try {
+    const response: Response = yield* call(
+      fetchWithTimeout,
+      networkConfig.wriTxWatchUrl,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: walletAddress }),
+      },
+      WATCH_TIMEOUT_MS
+    )
+
+    if (response.ok) {
+      // Backend may return { ok: true, backfillStartedAt?, backfillCompleted? }.
+      // We don't gate the feed on backfillCompleted because the user can keep
+      // using the wallet while the indexer catches up — Valora-shape pagination
+      // covers the gap.
+      Logger.info(TAG, `watch ok for ${walletAddress} (status ${response.status})`)
+    } else {
+      Logger.warn(
+        TAG,
+        `watch returned ${response.status} for ${walletAddress}; will retry on next boot`
+      )
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    Logger.warn(TAG, `watch threw for ${walletAddress}: ${message}; will retry on next boot`)
+  }
+}
+
+function* handleSetAccount() {
+  // SET_ACCOUNT fires on onboarding (new wallet) AND on import flow. After
+  // dispatch the address is in the selector — give the reducer a tick to
+  // settle so the next select() resolves to the freshly-set value.
+  yield* delay(0)
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) return
+  yield* call(registerWalletForFeedWatch, walletAddress)
+}
+
+function* handleRehydrate(action: RehydrateAction) {
+  // The web3 slice's rehydration payload carries the persisted account; once
+  // it's restored we ask the backend to keep watching. Existing users that
+  // boot the app after a flag flip get covered here.
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) return
+  // Spawn so failures (network, backend down) never wedge other rehydrate
+  // listeners.
+  yield* spawn(registerWalletForFeedWatch, walletAddress)
+}
+
+export function* watchRegisterWalletForFeed() {
+  yield* takeEvery(Web3Actions.SET_ACCOUNT, handleSetAccount)
+  // We can't use takeEvery for REHYDRATE because redux-persist dispatches it
+  // once per persisted key; instead, wait for the first REHYDRATE then act,
+  // then return. After that SET_ACCOUNT covers every state change.
+  const rehydrateAction = (yield* take(REHYDRATE)) as RehydrateAction
+  yield* call(handleRehydrate, rehydrateAction)
+}

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -18,6 +18,7 @@ import { publicClient } from 'src/viem'
 import networkConfig, { networkIdToNetwork } from 'src/web3/networkConfig'
 import { call, delay, fork, put, select, spawn } from 'typed-redux-saga'
 import { Hash, TransactionReceipt } from 'viem'
+import { watchRegisterWalletForFeed } from 'src/transactions/registerWatchSaga'
 
 const TAG = 'transactions/saga'
 
@@ -136,6 +137,7 @@ export function* watchPendingTransactions() {
 
 export function* transactionSaga() {
   yield* spawn(watchPendingTransactions)
+  yield* spawn(watchRegisterWalletForFeed)
 }
 
 function* handleTransactionReceiptReceived({

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -96,6 +96,13 @@ interface NetworkConfig {
   getXautPriceUrl: string
   blockscoutProxyBase: string
   wriDelegateRelayUrl: string
+  wriTxFeedUrl: string
+  wriTxWatchUrl: string
+  wriFeeAdapterBootstrapUrl: string
+  wriFeeAdapterAddresses: {
+    USDC: Address
+    USDT: Address
+  }
   tucopBackendApiUrl: string
 }
 
@@ -301,6 +308,25 @@ const CROSS_CHAIN_EXPLORER_URL = 'https://axelarscan.io/gmp/'
 const TUCOP_BACKEND_BASE = 'https://tucop-backend-production.up.railway.app'
 const GET_XAUT_PRICE_URL = `${TUCOP_BACKEND_BASE}/api/prices/xaut?vs=usd`
 const WRI_DELEGATE_RELAY_URL = `${TUCOP_BACKEND_BASE}/api/wri/delegate-relay`
+// WRI Track C feed migration (gated by StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1):
+// indexer-backed feed that classifies EIP-7702 atomic batches Valora ignores.
+// Same response shape as getWalletTransactions, so the swap is just a baseUrl
+// flip inside transactions/api.ts. /watch registers wallets so the indexer
+// tracks them going forward.
+const WRI_TX_FEED_URL = `${TUCOP_BACKEND_BASE}/api/transactions/feed`
+const WRI_TX_WATCH_URL = `${TUCOP_BACKEND_BASE}/api/transactions/watch`
+// Pre-authorization endpoint for the CIP-64 fee adapters (gated by
+// WRI_COPM_FEE_BOOTSTRAP_V1). Mints one-time MAX_UINT256 approvals on the
+// underlying USDC/USDT so users without CELO or Mento stables can still pay
+// gas. Adapter addresses are sourced from celopedia (canonical Mento list).
+const WRI_FEE_ADAPTER_BOOTSTRAP_URL = `${TUCOP_BACKEND_BASE}/api/wri/fee-adapter-bootstrap`
+// Canonical CIP-64 fee adapter addresses on Celo mainnet, verified via the
+// celopedia-skill builder guide (Allowed Fee Currencies table). Used by the
+// fee-bootstrap flow to grant infinite approval on the underlying token. The
+// adapter ABI is non-standard (no token()/owner() getters) so we don't read
+// the underlying on-chain — celopedia is the source of truth.
+const WRI_FEE_ADAPTER_USDC = '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B'
+const WRI_FEE_ADAPTER_USDT = '0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72'
 const BLOCKSCOUT_PROXY_BASE = `${TUCOP_BACKEND_BASE}/api/v2`
 
 const networkConfig: NetworkConfig = {
@@ -422,6 +448,13 @@ const networkConfig: NetworkConfig = {
   getXautPriceUrl: GET_XAUT_PRICE_URL,
   blockscoutProxyBase: BLOCKSCOUT_PROXY_BASE,
   wriDelegateRelayUrl: WRI_DELEGATE_RELAY_URL,
+  wriTxFeedUrl: WRI_TX_FEED_URL,
+  wriTxWatchUrl: WRI_TX_WATCH_URL,
+  wriFeeAdapterBootstrapUrl: WRI_FEE_ADAPTER_BOOTSTRAP_URL,
+  wriFeeAdapterAddresses: {
+    USDC: WRI_FEE_ADAPTER_USDC,
+    USDT: WRI_FEE_ADAPTER_USDT,
+  },
   tucopBackendApiUrl: TUCOP_BACKEND_BASE,
 }
 


### PR DESCRIPTION
## Summary

Wallet-side wiring for the WRI Track C transaction feed migration. Lets the team flip the wallet feed source from Valora's \`getWalletTransactions\` to TuCop's own indexer (the one that classifies the EIP-7702 atomic batches Valora ignores) by setting a single Statsig gate to true. Backend side is owned by the backend team (\`tasks/plans/wri-transaction-feed-indexer.md\` over there).

**This PR ships infrastructure only — the gate \`WRI_TX_FEED_TUCOP_V1\` is OFF in Statsig.** No user-visible behavior change at merge time.

### What's in
- New Statsig flags: \`WRI_TX_FEED_TUCOP_V1\` (feed source) and \`WRI_COPM_FEE_BOOTSTRAP_V1\` (the second piece, gated for a follow-up PR).
- New \`networkConfig\` fields: \`wriTxFeedUrl\`, \`wriTxWatchUrl\`, \`wriFeeAdapterBootstrapUrl\`, and a typed map of the canonical CIP-64 fee adapter addresses for USDC/USDT (verified via celopedia builder guide).
- \`transactions/api.ts\` refactor: \`baseUrl\` now resolves **per-query** instead of at module load, so the flag flip takes effect without a wallet restart. Empty \`baseUrl\` with absolute URLs in the query.
- New \`registerWatchSaga\`: POSTs \`/api/transactions/watch\` once per boot when the gate is on, hooked to both \`SET_ACCOUNT\` (new users at onboarding) and the first \`REHYDRATE\` (existing users on boot). Idempotent on backend, fire-and-forget — retries on next boot if backend down.

### Rollout plan (after merge)
1. Backend confirms \`INDEXER_ENABLED=true\` and the indexer has caught up to the latest Celo block.
2. Smoke test: diff \`${TUCOP_BACKEND}/api/transactions/feed\` vs \`${VALORA}/getWalletTransactions\` for a real address. If any field differs, RTK Query parses silently wrong and the feed goes empty — fix shape mismatch first.
3. Smoke wallet \`0x81dCf9160237D0EF0d4db27CFb2EA9743547f882\`: confirm the 2 atomic-7702 txs (\`0xbefe73...\`, \`0x5d42ce...\`) appear classified as SWAP_TRANSACTION.
4. Flip \`WRI_TX_FEED_TUCOP_V1\` to 5% → 25% → 100% over a week with a \`feed-empty-rate\` metric on the cohort.

### Out of scope
- \`WRI_COPM_FEE_BOOTSTRAP_V1\` follow-up PR: detection of "user only has USDC/USDT", activation sheet UI ("Activar Dólares para pagar tarifas"), call to \`/api/wri/fee-adapter-bootstrap\`, persisted \`feeAdapterBootstrapped\` flag per token.

## Test plan
- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/transactions src/web3 src/statsig src/swap src/send src/dollarsSpend\` — 504/504 pass
- [x] New \`transactions/api.test.ts\` (3 cases): off→Valora, on→TuCop, params preserved under both
- [x] New \`registerWatchSaga.test.ts\` (4 cases): gate off→no POST, gate on→POST with correct body, silent on 5xx, silent on network error
- [ ] Manual after backend confirms indexer is live: flip the gate to a dogfood user, swap a few stablecoins, confirm the feed renders the txs the same as before (Valora) + an atomic 7702 tx renders too (new behavior)