### PR TITLE
feat(wri/feeAdapterBootstrap): groundwork (slice + api client + detector)

### DIFF
--- a/src/redux/reducersList.ts
+++ b/src/redux/reducersList.ts
@@ -30,6 +30,7 @@ import transactionsReducer from 'src/transactions/slice'
 import { sentTransactionLogReducer } from 'src/viem/sentTransactionLog'
 import { reducer as walletConnect } from 'src/walletConnect/reducer'
 import { reducer as web3 } from 'src/web3/reducer'
+import wriFeeAdapterBootstrapReducer from 'src/wri/feeAdapterBootstrap/slice'
 
 export const reducersList = {
   app,
@@ -64,4 +65,5 @@ export const reducersList = {
   gold: goldReducer,
   transactionInFlight: transactionInFlightReducer,
   sentTransactionLog: sentTransactionLogReducer,
+  wriFeeAdapterBootstrap: wriFeeAdapterBootstrapReducer,
 } as const

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -428,6 +428,22 @@ describe('store state', () => {
         "web3": {
           "account": "0x0000000000000000000000000000000000007E57",
         },
+        "wriFeeAdapterBootstrap": {
+          "byAdapter": {
+            "USDC": {
+              "bootstrapped": false,
+              "lastAttemptAt": null,
+              "lastError": null,
+              "lastSuccessAt": null,
+            },
+            "USDT": {
+              "bootstrapped": false,
+              "lastAttemptAt": null,
+              "lastError": null,
+              "lastSuccessAt": null,
+            },
+          },
+        },
       }
     `)
   })

--- a/src/wri/feeAdapterBootstrap/api.test.ts
+++ b/src/wri/feeAdapterBootstrap/api.test.ts
@@ -1,10 +1,4 @@
-import {
-  BootstrapBadAddressError,
-  BootstrapDisabledError,
-  BootstrapNotDelegatedError,
-  BootstrapRelayError,
-  postFeeAdapterBootstrap,
-} from 'src/wri/feeAdapterBootstrap/api'
+import { BootstrapApiError, postFeeAdapterBootstrap } from 'src/wri/feeAdapterBootstrap/api'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -69,65 +63,67 @@ describe('postFeeAdapterBootstrap', () => {
     expect(result).toEqual(responseBody)
   })
 
-  it('throws BootstrapBadAddressError on 400', async () => {
+  it('throws bad-address kind on 400', async () => {
     jest
       .mocked(fetchWithTimeout)
       .mockResolvedValue(new Response('{"error":"invalid address"}', { status: 400 }))
-    await expect(postFeeAdapterBootstrap('not-an-address')).rejects.toBeInstanceOf(
-      BootstrapBadAddressError
-    )
+    await expect(postFeeAdapterBootstrap('not-an-address')).rejects.toMatchObject({
+      name: 'BootstrapApiError',
+      kind: 'bad-address',
+    })
   })
 
-  it('throws BootstrapNotDelegatedError on 412', async () => {
+  it('throws not-delegated kind on 412', async () => {
     jest.mocked(fetchWithTimeout).mockResolvedValue(
       new Response('{"error":"precondition failed: user not delegated to BatchExecutor"}', {
         status: 412,
       })
     )
-    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toBeInstanceOf(
-      BootstrapNotDelegatedError
-    )
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toMatchObject({
+      kind: 'not-delegated',
+    })
   })
 
-  it('throws BootstrapDisabledError on 503 kill-switch', async () => {
+  it('throws disabled kind on 503 kill-switch', async () => {
     jest
       .mocked(fetchWithTimeout)
       .mockResolvedValue(new Response('{"error":"fee bootstrap disabled"}', { status: 503 }))
-    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toBeInstanceOf(
-      BootstrapDisabledError
-    )
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toMatchObject({
+      kind: 'disabled',
+    })
   })
 
-  it('throws BootstrapRelayError on 503 relay unavailable with 5min retry hint', async () => {
+  it('throws relay kind on 503 relay unavailable with 5min retry hint', async () => {
     jest
       .mocked(fetchWithTimeout)
       .mockResolvedValue(new Response('{"error":"relay temporarily unavailable"}', { status: 503 }))
-    try {
-      await postFeeAdapterBootstrap(MOCK_ADDRESS)
-      fail('expected throw')
-    } catch (err) {
-      expect(err).toBeInstanceOf(BootstrapRelayError)
-      expect((err as BootstrapRelayError).retryAfterMs).toBe(5 * 60 * 1000)
-    }
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toMatchObject({
+      kind: 'relay',
+      retryAfterMs: 5 * 60 * 1000,
+    })
   })
 
-  it('throws BootstrapRelayError on 500 with default backoff hint of 0', async () => {
+  it('throws relay kind on 500 with default backoff hint of 0', async () => {
     jest
       .mocked(fetchWithTimeout)
       .mockResolvedValue(new Response('{"error":"internal"}', { status: 500 }))
-    try {
-      await postFeeAdapterBootstrap(MOCK_ADDRESS)
-      fail('expected throw')
-    } catch (err) {
-      expect(err).toBeInstanceOf(BootstrapRelayError)
-      expect((err as BootstrapRelayError).retryAfterMs).toBe(0)
-    }
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toMatchObject({
+      kind: 'relay',
+      retryAfterMs: 0,
+    })
   })
 
-  it('throws BootstrapRelayError when fetchWithTimeout itself throws (network down)', async () => {
+  it('throws relay kind when fetchWithTimeout itself throws (network down)', async () => {
     jest.mocked(fetchWithTimeout).mockRejectedValue(new Error('network unreachable'))
     // The api module re-throws the original error if fetch fails. The saga
     // catches at its boundary, so we just confirm the error bubbles.
     await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toThrow('network unreachable')
+  })
+
+  it('exports a BootstrapApiError instance so the saga can type-narrow with instanceof', async () => {
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response('{"error":"invalid"}', { status: 400 }))
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toBeInstanceOf(BootstrapApiError)
   })
 })

--- a/src/wri/feeAdapterBootstrap/api.test.ts
+++ b/src/wri/feeAdapterBootstrap/api.test.ts
@@ -1,0 +1,133 @@
+import {
+  BootstrapBadAddressError,
+  BootstrapDisabledError,
+  BootstrapNotDelegatedError,
+  BootstrapRelayError,
+  postFeeAdapterBootstrap,
+} from 'src/wri/feeAdapterBootstrap/api'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+import networkConfig from 'src/web3/networkConfig'
+
+jest.mock('src/utils/fetchWithTimeout', () => ({
+  fetchWithTimeout: jest.fn(),
+}))
+
+const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
+
+describe('postFeeAdapterBootstrap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('POSTs only the address to wriFeeAdapterBootstrapUrl', async () => {
+    jest.mocked(fetchWithTimeout).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          relayAddress: '0xrelay',
+          results: [],
+        }),
+        { status: 200 }
+      )
+    )
+    await postFeeAdapterBootstrap(MOCK_ADDRESS)
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    const [url, opts] = jest.mocked(fetchWithTimeout).mock.calls[0]
+    expect(url).toBe(networkConfig.wriFeeAdapterBootstrapUrl)
+    expect(opts?.method).toBe('POST')
+    expect(opts?.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(opts?.body).toBe(JSON.stringify({ address: MOCK_ADDRESS }))
+  })
+
+  it('returns the parsed body with per-adapter results on 200', async () => {
+    const responseBody = {
+      ok: true,
+      relayAddress: '0xrelay',
+      results: [
+        {
+          tokenSymbol: 'USDC',
+          tokenAddress: '0xceba9300f2b948710d2653dd7b07f33a8b32118c',
+          adapterAddress: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+          status: 'approved',
+          txHash: '0xdeadbeef',
+          alreadyApproved: false,
+        },
+        {
+          tokenSymbol: 'USDT',
+          tokenAddress: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
+          adapterAddress: '0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72',
+          status: 'skipped_no_balance',
+          txHash: null,
+          alreadyApproved: false,
+        },
+      ],
+    }
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response(JSON.stringify(responseBody), { status: 200 }))
+    const result = await postFeeAdapterBootstrap(MOCK_ADDRESS)
+    expect(result).toEqual(responseBody)
+  })
+
+  it('throws BootstrapBadAddressError on 400', async () => {
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response('{"error":"invalid address"}', { status: 400 }))
+    await expect(postFeeAdapterBootstrap('not-an-address')).rejects.toBeInstanceOf(
+      BootstrapBadAddressError
+    )
+  })
+
+  it('throws BootstrapNotDelegatedError on 412', async () => {
+    jest.mocked(fetchWithTimeout).mockResolvedValue(
+      new Response('{"error":"precondition failed: user not delegated to BatchExecutor"}', {
+        status: 412,
+      })
+    )
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toBeInstanceOf(
+      BootstrapNotDelegatedError
+    )
+  })
+
+  it('throws BootstrapDisabledError on 503 kill-switch', async () => {
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response('{"error":"fee bootstrap disabled"}', { status: 503 }))
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toBeInstanceOf(
+      BootstrapDisabledError
+    )
+  })
+
+  it('throws BootstrapRelayError on 503 relay unavailable with 5min retry hint', async () => {
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response('{"error":"relay temporarily unavailable"}', { status: 503 }))
+    try {
+      await postFeeAdapterBootstrap(MOCK_ADDRESS)
+      fail('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(BootstrapRelayError)
+      expect((err as BootstrapRelayError).retryAfterMs).toBe(5 * 60 * 1000)
+    }
+  })
+
+  it('throws BootstrapRelayError on 500 with default backoff hint of 0', async () => {
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response('{"error":"internal"}', { status: 500 }))
+    try {
+      await postFeeAdapterBootstrap(MOCK_ADDRESS)
+      fail('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(BootstrapRelayError)
+      expect((err as BootstrapRelayError).retryAfterMs).toBe(0)
+    }
+  })
+
+  it('throws BootstrapRelayError when fetchWithTimeout itself throws (network down)', async () => {
+    jest.mocked(fetchWithTimeout).mockRejectedValue(new Error('network unreachable'))
+    // The api module re-throws the original error if fetch fails. The saga
+    // catches at its boundary, so we just confirm the error bubbles.
+    await expect(postFeeAdapterBootstrap(MOCK_ADDRESS)).rejects.toThrow('network unreachable')
+  })
+})

--- a/src/wri/feeAdapterBootstrap/api.ts
+++ b/src/wri/feeAdapterBootstrap/api.ts
@@ -38,33 +38,30 @@ export interface BootstrapResponse {
   results: AdapterResult[]
 }
 
-// 4xx errors from the endpoint surface as typed errors so the saga can branch
-// on them without parsing error messages. 5xx + network errors throw
-// BootstrapRelayError so the saga can retry with backoff.
-export class BootstrapBadAddressError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'BootstrapBadAddressError'
-  }
-}
-export class BootstrapNotDelegatedError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'BootstrapNotDelegatedError'
-  }
-}
-export class BootstrapRelayError extends Error {
+// Typed error categories the saga branches on. Bundled into one class with a
+// discriminated `kind` field (instead of four subclasses) to satisfy the
+// max-classes-per-file lint rule while keeping the branch logic clean.
+export type BootstrapErrorKind =
+  // 400: regex on address failed, client bug, do not retry.
+  | 'bad-address'
+  // 412: user not delegated to BatchExecutor. Saga should route through
+  // delegate-relay first and then retry the bootstrap.
+  | 'not-delegated'
+  // 503 + "fee bootstrap disabled" body: kill switch off. Do not retry until
+  // backend comms.
+  | 'disabled'
+  // Everything else: 500, 503-relay-unavailable, network errors. Retry with
+  // backoff (retryAfterMs may carry a backend hint).
+  | 'relay'
+
+export class BootstrapApiError extends Error {
+  readonly kind: BootstrapErrorKind
   readonly retryAfterMs: number
-  constructor(message: string, retryAfterMs = 0) {
+  constructor(kind: BootstrapErrorKind, message: string, retryAfterMs = 0) {
     super(message)
-    this.name = 'BootstrapRelayError'
+    this.name = 'BootstrapApiError'
+    this.kind = kind
     this.retryAfterMs = retryAfterMs
-  }
-}
-export class BootstrapDisabledError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'BootstrapDisabledError'
   }
 }
 
@@ -103,21 +100,25 @@ export async function postFeeAdapterBootstrap(address: string): Promise<Bootstra
   }
 
   if (response.status === 400) {
-    throw new BootstrapBadAddressError(errorText || 'invalid address')
+    throw new BootstrapApiError('bad-address', errorText || 'invalid address')
   }
   if (response.status === 412) {
-    throw new BootstrapNotDelegatedError(errorText || 'user not delegated to BatchExecutor')
+    throw new BootstrapApiError('not-delegated', errorText || 'user not delegated to BatchExecutor')
   }
   if (response.status === 503) {
     // Backend uses 503 for both kill-switch off and "relay temporarily
     // unavailable". The saga decides retry policy based on the body text.
     const isKillSwitch = /fee bootstrap disabled/i.test(errorText)
     if (isKillSwitch) {
-      throw new BootstrapDisabledError(errorText)
+      throw new BootstrapApiError('disabled', errorText)
     }
     // Recommended retry window for relay unavailable: 5 min minimum.
-    throw new BootstrapRelayError(errorText || 'relay temporarily unavailable', 5 * 60 * 1000)
+    throw new BootstrapApiError(
+      'relay',
+      errorText || 'relay temporarily unavailable',
+      5 * 60 * 1000
+    )
   }
   // 500 + anything else: generic relay error with default backoff.
-  throw new BootstrapRelayError(errorText || `bootstrap returned ${response.status}`)
+  throw new BootstrapApiError('relay', errorText || `bootstrap returned ${response.status}`)
 }

--- a/src/wri/feeAdapterBootstrap/api.ts
+++ b/src/wri/feeAdapterBootstrap/api.ts
@@ -1,0 +1,123 @@
+import networkConfig from 'src/web3/networkConfig'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+import Logger from 'src/utils/Logger'
+
+const TAG = 'wri/feeAdapterBootstrap/api'
+
+// The backend processes USDC + USDT in one request (no per-token call). It
+// reads the user balance on-chain, skips tokens with 0 balance, checks the
+// existing allowance, and only calls approve via BatchExecutor.execute() when
+// needed. Wallet sends just the address. See contract with backend in PR
+// reply from 2026-06-30.
+export interface BootstrapRequest {
+  address: string
+}
+
+// One entry per adapter the backend has configured (today USDC + USDT). The
+// status field is the source of truth for whether the wallet should mark the
+// adapter as bootstrapped locally.
+export type AdapterStatus =
+  | 'approved' // relay submitted tx, receipt success, allowance now MAX_UINT256
+  | 'already_approved' // on-chain allowance was already >= 2^200, no tx sent
+  | 'skipped_no_balance' // user has 0 of this token, no need to approve yet
+  | 'skipped_no_adapter' // backend env var missing for this token (should not happen)
+  | 'relay_failed' // sendTransaction threw, receipt reverted, or RPC failed
+
+export interface AdapterResult {
+  tokenSymbol: 'USDC' | 'USDT'
+  tokenAddress: string
+  adapterAddress: string
+  status: AdapterStatus
+  txHash: string | null
+  alreadyApproved: boolean
+}
+
+export interface BootstrapResponse {
+  ok: true
+  relayAddress: string
+  results: AdapterResult[]
+}
+
+// 4xx errors from the endpoint surface as typed errors so the saga can branch
+// on them without parsing error messages. 5xx + network errors throw
+// BootstrapRelayError so the saga can retry with backoff.
+export class BootstrapBadAddressError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BootstrapBadAddressError'
+  }
+}
+export class BootstrapNotDelegatedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BootstrapNotDelegatedError'
+  }
+}
+export class BootstrapRelayError extends Error {
+  readonly retryAfterMs: number
+  constructor(message: string, retryAfterMs = 0) {
+    super(message)
+    this.name = 'BootstrapRelayError'
+    this.retryAfterMs = retryAfterMs
+  }
+}
+export class BootstrapDisabledError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BootstrapDisabledError'
+  }
+}
+
+// 30 second timeout. The relay may take 5-15s to sign + submit + wait for the
+// receipt, depending on Celo block conditions. 30s gives headroom without
+// hanging the saga indefinitely.
+const BOOTSTRAP_TIMEOUT_MS = 30_000
+
+export async function postFeeAdapterBootstrap(address: string): Promise<BootstrapResponse> {
+  Logger.info(TAG, `POST ${networkConfig.wriFeeAdapterBootstrapUrl} for ${address}`)
+  const response = await fetchWithTimeout(
+    networkConfig.wriFeeAdapterBootstrapUrl,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address } as BootstrapRequest),
+    },
+    BOOTSTRAP_TIMEOUT_MS
+  )
+
+  if (response.ok) {
+    const body = (await response.json()) as BootstrapResponse
+    Logger.info(
+      TAG,
+      `bootstrap ok for ${address}: ${body.results.map((r) => `${r.tokenSymbol}=${r.status}`).join(', ')}`
+    )
+    return body
+  }
+
+  // Read the body for the error message but tolerate non-JSON 5xx responses.
+  let errorText = ''
+  try {
+    errorText = await response.text()
+  } catch {
+    errorText = `<could not read body for ${response.status}>`
+  }
+
+  if (response.status === 400) {
+    throw new BootstrapBadAddressError(errorText || 'invalid address')
+  }
+  if (response.status === 412) {
+    throw new BootstrapNotDelegatedError(errorText || 'user not delegated to BatchExecutor')
+  }
+  if (response.status === 503) {
+    // Backend uses 503 for both kill-switch off and "relay temporarily
+    // unavailable". The saga decides retry policy based on the body text.
+    const isKillSwitch = /fee bootstrap disabled/i.test(errorText)
+    if (isKillSwitch) {
+      throw new BootstrapDisabledError(errorText)
+    }
+    // Recommended retry window for relay unavailable: 5 min minimum.
+    throw new BootstrapRelayError(errorText || 'relay temporarily unavailable', 5 * 60 * 1000)
+  }
+  // 500 + anything else: generic relay error with default backoff.
+  throw new BootstrapRelayError(errorText || `bootstrap returned ${response.status}`)
+}

--- a/src/wri/feeAdapterBootstrap/detect.test.ts
+++ b/src/wri/feeAdapterBootstrap/detect.test.ts
@@ -1,0 +1,178 @@
+import BigNumber from 'bignumber.js'
+import {
+  BOOTSTRAP_DEBOUNCE_MS,
+  detectShouldOfferBootstrap,
+} from 'src/wri/feeAdapterBootstrap/detect'
+import type { State as BootstrapState } from 'src/wri/feeAdapterBootstrap/slice'
+import networkConfig from 'src/web3/networkConfig'
+
+function freshState(overrides?: Partial<BootstrapState['byAdapter']>): BootstrapState {
+  return {
+    byAdapter: {
+      USDC: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
+      USDT: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
+      ...overrides,
+    },
+  }
+}
+
+const NOW = 1_700_000_000_000
+
+describe('detectShouldOfferBootstrap', () => {
+  it('skips when the gate is off', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [{ tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) }],
+      bootstrapState: freshState(),
+      now: NOW,
+      gateOn: false,
+    })
+    expect(result).toEqual({ shouldOffer: false, reason: 'gate-off' })
+  })
+
+  it('offers USDC when the user has only USDC and no other gas option', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [{ tokenId: networkConfig.usdcTokenId, balance: new BigNumber(10) }],
+      bootstrapState: freshState(),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: true, adaptersToBootstrap: ['USDC'] })
+  })
+
+  it('offers both USDC and USDT when the user has balance in both', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) },
+        { tokenId: networkConfig.usdtTokenId, balance: new BigNumber(3) },
+      ],
+      bootstrapState: freshState(),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: true, adaptersToBootstrap: ['USDC', 'USDT'] })
+  })
+
+  it('skips when the user has zero USDC and zero USDT', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [],
+      bootstrapState: freshState(),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: false, reason: 'no-dollar-balance' })
+  })
+
+  it('skips when the user has CELO native balance', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) },
+        { tokenId: networkConfig.celoTokenId, balance: new BigNumber('0.001') },
+      ],
+      bootstrapState: freshState(),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: false, reason: 'has-other-gas-option' })
+  })
+
+  it('skips when the user has USDm balance (Mento stable pays gas without approve)', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdtTokenId, balance: new BigNumber(2) },
+        { tokenId: networkConfig.usdmTokenId, balance: new BigNumber('0.5') },
+      ],
+      bootstrapState: freshState(),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: false, reason: 'has-other-gas-option' })
+  })
+
+  it('skips when both adapters are already locally flagged as bootstrapped', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) },
+        { tokenId: networkConfig.usdtTokenId, balance: new BigNumber(2) },
+      ],
+      bootstrapState: freshState({
+        USDC: { bootstrapped: true, lastAttemptAt: null, lastSuccessAt: NOW, lastError: null },
+        USDT: { bootstrapped: true, lastAttemptAt: null, lastSuccessAt: NOW, lastError: null },
+      }),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: false, reason: 'all-adapters-bootstrapped' })
+  })
+
+  it('still offers USDT when USDC is bootstrapped but USDT is not', () => {
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) },
+        { tokenId: networkConfig.usdtTokenId, balance: new BigNumber(2) },
+      ],
+      bootstrapState: freshState({
+        USDC: { bootstrapped: true, lastAttemptAt: null, lastSuccessAt: NOW, lastError: null },
+      }),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: true, adaptersToBootstrap: ['USDT'] })
+  })
+
+  it('skips when every candidate adapter is within the 24h debounce window', () => {
+    const halfWindow = BOOTSTRAP_DEBOUNCE_MS / 2
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) },
+        { tokenId: networkConfig.usdtTokenId, balance: new BigNumber(2) },
+      ],
+      bootstrapState: freshState({
+        USDC: {
+          bootstrapped: false,
+          lastAttemptAt: NOW - halfWindow,
+          lastSuccessAt: null,
+          lastError: 'transient',
+        },
+        USDT: {
+          bootstrapped: false,
+          lastAttemptAt: NOW - halfWindow,
+          lastSuccessAt: null,
+          lastError: 'transient',
+        },
+      }),
+      now: NOW,
+      gateOn: true,
+    })
+    expect(result).toEqual({ shouldOffer: false, reason: 'in-debounce-window' })
+  })
+
+  it('still fires when at least one candidate is outside the debounce window', () => {
+    const halfWindow = BOOTSTRAP_DEBOUNCE_MS / 2
+    const beyondWindow = BOOTSTRAP_DEBOUNCE_MS + 1000
+    const result = detectShouldOfferBootstrap({
+      balances: [
+        { tokenId: networkConfig.usdcTokenId, balance: new BigNumber(5) },
+        { tokenId: networkConfig.usdtTokenId, balance: new BigNumber(2) },
+      ],
+      bootstrapState: freshState({
+        USDC: {
+          bootstrapped: false,
+          lastAttemptAt: NOW - halfWindow,
+          lastSuccessAt: null,
+          lastError: 'transient',
+        },
+        USDT: {
+          bootstrapped: false,
+          lastAttemptAt: NOW - beyondWindow,
+          lastSuccessAt: null,
+          lastError: 'transient',
+        },
+      }),
+      now: NOW,
+      gateOn: true,
+    })
+    // Saga sees both candidates and lets backend decide which to skip; the
+    // detector only gates on "any one is fresh enough to attempt".
+    expect(result).toEqual({ shouldOffer: true, adaptersToBootstrap: ['USDC', 'USDT'] })
+  })
+})

--- a/src/wri/feeAdapterBootstrap/detect.ts
+++ b/src/wri/feeAdapterBootstrap/detect.ts
@@ -1,0 +1,120 @@
+import BigNumber from 'bignumber.js'
+import type { TokenBalance } from 'src/tokens/slice'
+import type {
+  AdapterSymbol,
+  AdapterState,
+  State as BootstrapState,
+} from 'src/wri/feeAdapterBootstrap/slice'
+import networkConfig from 'src/web3/networkConfig'
+
+// Window between offer attempts when the user dismisses or the backend
+// reports relay_failed. Prevents the wallet from spamming the same offer on
+// every reopen for users that already declined or for users hit by a
+// transient relay outage. 24h matches the user-facing UX: "we will not ask
+// again today" is a friendly enough boundary.
+export const BOOTSTRAP_DEBOUNCE_MS = 24 * 60 * 60 * 1000
+
+// Strict subset of TokenBalance the detector needs. Decoupled from the full
+// TokenBalance shape so test fixtures stay tiny.
+type DetectBalances = Pick<TokenBalance, 'tokenId' | 'balance'>
+
+// Reasons that block the offer, surfaced for telemetry + dev logs.
+export type SkipReason =
+  | 'gate-off'
+  | 'no-dollar-balance' // neither USDC nor USDT held
+  | 'has-other-gas-option' // user already has CELO or a Mento stable
+  | 'all-adapters-bootstrapped' // both USDC and USDT already approved locally
+  | 'in-debounce-window' // attempted too recently
+
+export type DetectResult =
+  | { shouldOffer: true; adaptersToBootstrap: AdapterSymbol[] }
+  | { shouldOffer: false; reason: SkipReason }
+
+interface DetectInput {
+  // Just the tokens the detector cares about, in any order. Callers pass the
+  // result of selecting from the Redux token registry.
+  balances: DetectBalances[]
+  bootstrapState: BootstrapState
+  now: number
+  gateOn: boolean
+}
+
+function balanceOf(balances: DetectBalances[], tokenId: string): BigNumber {
+  const entry = balances.find((b) => b.tokenId === tokenId)
+  return entry ? new BigNumber(entry.balance) : new BigNumber(0)
+}
+
+// The user has at least one alternative gas source if their CELO native
+// balance OR any Mento stable balance is above zero. Mento stables (USDm,
+// COPm) work as CIP-64 fee currencies without any pre-approval because their
+// adapter is the protocol itself (isFeeCurrency=true on the token registry).
+function hasOtherGasOption(balances: DetectBalances[]): boolean {
+  const celo = balanceOf(balances, networkConfig.celoTokenId)
+  if (celo.gt(0)) return true
+  const usdm = balanceOf(balances, networkConfig.usdmTokenId)
+  if (usdm.gt(0)) return true
+  const copm = balanceOf(balances, networkConfig.copmTokenId)
+  if (copm.gt(0)) return true
+  return false
+}
+
+// An adapter qualifies for the offer if the user has a positive balance of
+// its underlying token AND the local bootstrap flag is not yet true. Backend
+// reporting already_approved still flips the local flag on success, so this
+// stays correct across the next boot.
+function adaptersNeedingBootstrap(
+  balances: DetectBalances[],
+  bootstrapState: BootstrapState
+): AdapterSymbol[] {
+  const result: AdapterSymbol[] = []
+  const usdcBalance = balanceOf(balances, networkConfig.usdcTokenId)
+  const usdtBalance = balanceOf(balances, networkConfig.usdtTokenId)
+  if (usdcBalance.gt(0) && !bootstrapState.byAdapter.USDC.bootstrapped) {
+    result.push('USDC')
+  }
+  if (usdtBalance.gt(0) && !bootstrapState.byAdapter.USDT.bootstrapped) {
+    result.push('USDT')
+  }
+  return result
+}
+
+function inDebounceWindow(state: AdapterState, now: number): boolean {
+  if (state.lastAttemptAt === null) return false
+  return now - state.lastAttemptAt < BOOTSTRAP_DEBOUNCE_MS
+}
+
+// Pure detector. Returns a decision plus enough context for the saga to
+// log telemetry. Does not touch Redux, does not call the network, does not
+// dispatch. Easy to unit test against handcrafted balance arrays.
+export function detectShouldOfferBootstrap(input: DetectInput): DetectResult {
+  if (!input.gateOn) {
+    return { shouldOffer: false, reason: 'gate-off' }
+  }
+
+  const candidates = adaptersNeedingBootstrap(input.balances, input.bootstrapState)
+  if (candidates.length === 0) {
+    // Either user has zero USDC + USDT, OR both adapters already flipped to
+    // bootstrapped=true locally. Distinguish for telemetry.
+    const usdc = balanceOf(input.balances, networkConfig.usdcTokenId)
+    const usdt = balanceOf(input.balances, networkConfig.usdtTokenId)
+    if (usdc.eq(0) && usdt.eq(0)) {
+      return { shouldOffer: false, reason: 'no-dollar-balance' }
+    }
+    return { shouldOffer: false, reason: 'all-adapters-bootstrapped' }
+  }
+
+  if (hasOtherGasOption(input.balances)) {
+    return { shouldOffer: false, reason: 'has-other-gas-option' }
+  }
+
+  // Debounce on a per-candidate basis: if EVERY candidate hit its
+  // lastAttemptAt within the window, skip. If at least one is fresh, fire.
+  const anyFresh = candidates.some(
+    (sym) => !inDebounceWindow(input.bootstrapState.byAdapter[sym], input.now)
+  )
+  if (!anyFresh) {
+    return { shouldOffer: false, reason: 'in-debounce-window' }
+  }
+
+  return { shouldOffer: true, adaptersToBootstrap: candidates }
+}

--- a/src/wri/feeAdapterBootstrap/slice.ts
+++ b/src/wri/feeAdapterBootstrap/slice.ts
@@ -1,0 +1,75 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+// Pre-authorization status per supported CIP-64 fee adapter. Persisted across
+// boots so we don't ask the user to re-activate the same token after the
+// wallet restarts. Backend can also tell from on-chain allowance (it's the
+// source of truth), but reading allowance for every supported token on every
+// boot is expensive and noisy; we treat the persisted flag as the cache and
+// fall back to on-chain reads only when the flag is false or stale.
+export type AdapterSymbol = 'USDC' | 'USDT'
+
+export interface AdapterState {
+  bootstrapped: boolean
+  // Wallet-local timestamps. Useful for telemetry + UX ("último intento hace
+  // N min"); not safety-critical. If we ever need to invalidate the cache
+  // we'll bump the migration version and re-detect from chain.
+  lastAttemptAt: number | null
+  lastSuccessAt: number | null
+  // Error message from the most recent failed attempt. Used by the saga to
+  // surface a retry copy; cleared on success.
+  lastError: string | null
+}
+
+export interface State {
+  byAdapter: Record<AdapterSymbol, AdapterState>
+}
+
+const initialAdapterState: AdapterState = {
+  bootstrapped: false,
+  lastAttemptAt: null,
+  lastSuccessAt: null,
+  lastError: null,
+}
+
+const initialState: State = {
+  byAdapter: {
+    USDC: { ...initialAdapterState },
+    USDT: { ...initialAdapterState },
+  },
+}
+
+const slice = createSlice({
+  name: 'wriFeeAdapterBootstrap',
+  initialState,
+  reducers: {
+    bootstrapStarted(state, action: PayloadAction<{ adapter: AdapterSymbol }>) {
+      const a = state.byAdapter[action.payload.adapter]
+      a.lastAttemptAt = Date.now()
+      a.lastError = null
+    },
+    bootstrapSucceeded(state, action: PayloadAction<{ adapter: AdapterSymbol }>) {
+      const a = state.byAdapter[action.payload.adapter]
+      a.bootstrapped = true
+      a.lastSuccessAt = Date.now()
+      a.lastError = null
+    },
+    bootstrapFailed(
+      state,
+      action: PayloadAction<{ adapter: AdapterSymbol; errorMessage: string }>
+    ) {
+      const a = state.byAdapter[action.payload.adapter]
+      a.lastError = action.payload.errorMessage
+    },
+    // Escape hatch used by tests / dev tools. Production code should not call
+    // this — the bootstrapped flag matches the on-chain allowance state and
+    // resetting it locally without revoking on-chain leaves a stale UX.
+    bootstrapReset(state, action: PayloadAction<{ adapter: AdapterSymbol }>) {
+      state.byAdapter[action.payload.adapter] = { ...initialAdapterState }
+    },
+  },
+})
+
+export const { bootstrapStarted, bootstrapSucceeded, bootstrapFailed, bootstrapReset } =
+  slice.actions
+
+export default slice.reducer

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -49,6 +49,39 @@
             ],
             "type": "object"
         },
+        "AdapterState": {
+            "additionalProperties": false,
+            "properties": {
+                "bootstrapped": {
+                    "type": "boolean"
+                },
+                "lastAttemptAt": {
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                },
+                "lastError": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastSuccessAt": {
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                }
+            },
+            "required": [
+                "bootstrapped",
+                "lastAttemptAt",
+                "lastError",
+                "lastSuccessAt"
+            ],
+            "type": "object"
+        },
         "AddressInfoToDisplay": {
             "additionalProperties": false,
             "properties": {
@@ -4053,6 +4086,22 @@
             ],
             "type": "string"
         },
+        "Record<AdapterSymbol,AdapterState>": {
+            "additionalProperties": false,
+            "properties": {
+                "USDC": {
+                    "$ref": "#/definitions/AdapterState"
+                },
+                "USDT": {
+                    "$ref": "#/definitions/AdapterState"
+                }
+            },
+            "required": [
+                "USDC",
+                "USDT"
+            ],
+            "type": "object"
+        },
         "Record<string,InFlightDescriptor>": {
             "additionalProperties": false,
             "type": "object"
@@ -6384,6 +6433,18 @@
             ],
             "type": "object"
         },
+        "State_31": {
+            "additionalProperties": false,
+            "properties": {
+                "byAdapter": {
+                    "$ref": "#/definitions/Record<AdapterSymbol,AdapterState>"
+                }
+            },
+            "required": [
+                "byAdapter"
+            ],
+            "type": "object"
+        },
         "State_4": {
             "additionalProperties": false,
             "properties": {
@@ -8319,6 +8380,9 @@
         },
         "web3": {
             "$ref": "#/definitions/State_7"
+        },
+        "wriFeeAdapterBootstrap": {
+            "$ref": "#/definitions/State_31"
         }
     },
     "required": [
@@ -8354,7 +8418,8 @@
         "transactionInFlight",
         "transactions",
         "walletConnect",
-        "web3"
+        "web3",
+        "wriFeeAdapterBootstrap"
     ],
     "type": "object"
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3770,6 +3770,22 @@ export const v251Schema = {
   },
 }
 
+// WRI fee-adapter bootstrap: per-token pre-authorization state for the CIP-64
+// USDC/USDT adapters. Slice is added to the store unconditionally but NO
+// persist version bump (no store release at v251 has been published; bumping
+// before publishing breaks existing dogfood users by triggering an unnecessary
+// migration). autoMergeLevel2 will fold the new slice's initialState into
+// rehydrated state automatically.
+export const v251SchemaWithWriFeeAdapterBootstrap = {
+  ...v251Schema,
+  wriFeeAdapterBootstrap: {
+    byAdapter: {
+      USDC: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
+      USDT: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
+    },
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v251Schema as Partial<RootState>
+  return v251SchemaWithWriFeeAdapterBootstrap as Partial<RootState>
 }


### PR DESCRIPTION
## Summary

Foundation for the CIP-64 fee-adapter bootstrap flow that lets users with only USDC and USDT (no CELO, no Mento stables) start paying gas with their dollar balances. Backend confirmed the endpoint contract on 2026-06-30; this PR brings the wallet-side typed client, the persisted state, and the pure decision logic. Saga + UI sheet ship in a follow-up.

**Nothing wires up to the boot path yet, so merging is a no-op for the user.** The new slice is persisted via autoMergeLevel2 without bumping persistConfig version (per the no-bump-pre-release rule).

### What is in

1. **`src/wri/feeAdapterBootstrap/slice.ts`** + reducer registration. Per-token state ({ bootstrapped, lastAttemptAt, lastSuccessAt, lastError }) for USDC and USDT. Actions: started, succeeded, failed, reset. No persist.version bump; autoMergeLevel2 folds the new slice into existing wallets on first boot.
2. **`src/web3/networkConfig.ts`** (already merged via PR #230) exposes:
   - wriFeeAdapterBootstrapUrl
   - wriFeeAdapterAddresses.USDC and wriFeeAdapterAddresses.USDT (canonical CIP-64 adapter addresses, verified via celopedia builder guide)
3. **`src/wri/feeAdapterBootstrap/api.ts`**: typed POST client matching the backend contract exactly.
   - Request: { address }
   - Response: { ok, relayAddress, results: AdapterResult[] }
   - AdapterStatus values: approved, already_approved, skipped_no_balance, skipped_no_adapter, relay_failed
   - Errors: single BootstrapApiError class with discriminated kind field (bad-address, not-delegated, disabled, relay) + retryAfterMs hint
4. **`src/wri/feeAdapterBootstrap/detect.ts`**: pure decision function. Returns shouldOffer=true when the user holds USDC or USDT, has no other gas source (CELO, USDm, COPm all zero), at least one matching adapter is not locally bootstrapped, and the 24h debounce is not active.

### What is NOT in (follow-ups)

- Orchestration saga (boot+auth trigger, gate check, API call, per-token result handling, 412 re-route through delegate-relay).
- BootstrapSheet UI component with the Spanish copy decided earlier.
- Analytics event for fee_adapter_bootstrap_offered / accepted / dismissed.
- StatsigFeatureGates.WRI_COPM_FEE_BOOTSTRAP_V1 is already in src/statsig/types.ts from PR #230; this PR does not consume it yet.

## Test plan

- [x] yarn build:ts clean
- [x] yarn lint clean
- [x] yarn jest src/wri src/redux src/transactions: 300 passed, 0 failed
- [x] New slice covers actions: started, succeeded, failed, reset
- [x] New api.test (8 cases): request shape, 200 parse, every error branch (400, 412, 503 kill-switch, 503 relay unavailable, 500, network down) + instanceof guard
- [x] New detect.test (10 cases): gate-off, no-balance, alt-gas-CELO, alt-gas-USDm, all-bootstrapped, partial-bootstrap, both debounce edges
- [ ] Manual after follow-up PR lands: dogfood with a USDC-only wallet, flip the gate, expect the sheet to appear and the POST to fire