### PR TITLE
feat(wri): fee-adapter bootstrap saga + activation sheet (gated)

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2557,6 +2557,13 @@
       "dismiss": "Got it"
     }
   },
+  "feeAdapterBootstrap": {
+    "title": "Activate Dollars for fees",
+    "body": "To send and swap using your dollars (USDC, USDT) we run a quick activation.",
+    "reassure": "Only once. After this you can do every operation without seeing this screen again. Only the actual fee is charged each time. Never more than that.",
+    "activate": "Activate Dollars",
+    "later": "Not now"
+  },
   "earnFlow": {
     "gasSubsidized": "Transaction fees are covered for a limited time",
     "addCryptoBottomSheet": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2563,6 +2563,13 @@
       "dismiss": "Entendido"
     }
   },
+  "feeAdapterBootstrap": {
+    "title": "Activar Dólares para pagar tarifas",
+    "body": "Para enviar y hacer cambios usando tus Dólares (USDC, USDT), hacemos una activación rápida.",
+    "reassure": "Una sola vez. Después podés hacer todas las operaciones que quieras sin volver a aparecer esta pantalla. Solo se descuenta lo justo de tarifa en cada operación. Nunca más de eso.",
+    "activate": "Activar Dólares",
+    "later": "Ahora no"
+  },
   "earnFlow": {
     "gasSubsidized": "Las tarifas de transacción están cubiertas por un tiempo limitado",
     "addCryptoBottomSheet": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,6 +18,7 @@ import i18n from 'src/i18n'
 import NavigatorWrapper from 'src/navigator/NavigatorWrapper'
 import { persistor, store } from 'src/redux/store'
 import Logger from 'src/utils/Logger'
+import BootstrapSheetHost from 'src/wri/feeAdapterBootstrap/BootstrapSheetHost'
 
 Logger.debug('App/init', 'Current Language: ' + i18n.language)
 
@@ -86,6 +87,7 @@ export class App extends React.Component<Props> {
                     <BottomSheetModalProvider>
                       <NavigatorWrapper />
                       <ErrorSheetHost />
+                      <BootstrapSheetHost />
                       <ToastHost />
                     </BottomSheetModalProvider>
                   </GestureHandlerRootView>

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -443,6 +443,7 @@ describe('store state', () => {
               "lastSuccessAt": null,
             },
           },
+          "pending": null,
         },
       }
     `)

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -19,6 +19,7 @@ import networkConfig, { networkIdToNetwork } from 'src/web3/networkConfig'
 import { call, delay, fork, put, select, spawn } from 'typed-redux-saga'
 import { Hash, TransactionReceipt } from 'viem'
 import { watchRegisterWalletForFeed } from 'src/transactions/registerWatchSaga'
+import { watchFeeAdapterBootstrap } from 'src/wri/feeAdapterBootstrap/saga'
 
 const TAG = 'transactions/saga'
 
@@ -138,6 +139,7 @@ export function* watchPendingTransactions() {
 export function* transactionSaga() {
   yield* spawn(watchPendingTransactions)
   yield* spawn(watchRegisterWalletForFeed)
+  yield* spawn(watchFeeAdapterBootstrap)
 }
 
 function* handleTransactionReceiptReceived({

--- a/src/wri/feeAdapterBootstrap/BootstrapSheetHost.tsx
+++ b/src/wri/feeAdapterBootstrap/BootstrapSheetHost.tsx
@@ -1,0 +1,162 @@
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
+import type { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { useDispatch, useSelector } from 'src/redux/hooks'
+import colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import {
+  bootstrapAccepted,
+  bootstrapDismissed,
+  bootstrapSheetHidden,
+} from 'src/wri/feeAdapterBootstrap/slice'
+import type { AdapterSymbol } from 'src/wri/feeAdapterBootstrap/slice'
+
+// Renders the activation sheet for the CIP-64 fee-adapter bootstrap. Listens
+// on the Redux pending state set by the orchestration saga and present()s the
+// BottomSheetModal when it goes visible. The Host is mounted once at the App
+// root so the sheet can appear over any screen (matches the ErrorSheetHost
+// pattern).
+//
+// The sheet is intentionally simple: a friendly title, one sentence of plain
+// Spanish explaining what the activation does, an explicit "una sola vez"
+// reassurance, and two buttons. No on-chain detail, no addresses, no
+// adapter names. The user reads "Activar Dólares" and decides.
+
+export default function BootstrapSheetHost() {
+  const sheetRef = useRef<BottomSheetModal>(null)
+  const { t } = useTranslation()
+  const dispatch = useDispatch()
+  const pending = useSelector((state) => state.wriFeeAdapterBootstrap.pending)
+  const bootstrapState = useSelector((state) => state.wriFeeAdapterBootstrap.byAdapter)
+
+  // The activation is in-flight when any candidate is currently between
+  // bootstrapStarted and bootstrapSucceeded/Failed. We use it to gate the
+  // buttons + show a spinner instead of the activate label.
+  const inFlight = useMemo(() => {
+    if (!pending?.visible) return false
+    return pending.candidates.some((sym: AdapterSymbol) => {
+      const adapter = bootstrapState[sym]
+      // started but not yet resolved: lastAttemptAt is set but bootstrapped
+      // is still false AND lastError is still null AND lastSuccessAt is null.
+      return (
+        adapter.lastAttemptAt !== null &&
+        !adapter.bootstrapped &&
+        adapter.lastError === null &&
+        adapter.lastSuccessAt === null
+      )
+    })
+  }, [pending, bootstrapState])
+
+  // Present / dismiss the modal whenever the slice toggles pending.visible.
+  useEffect(() => {
+    if (pending?.visible) {
+      sheetRef.current?.present()
+    } else {
+      sheetRef.current?.dismiss()
+    }
+  }, [pending?.visible])
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetDefaultBackdropProps) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    []
+  )
+
+  const handleActivate = () => {
+    if (!pending) return
+    dispatch(bootstrapAccepted({ candidates: pending.candidates }))
+  }
+
+  const handleLater = () => {
+    if (!pending) return
+    dispatch(bootstrapDismissed({ candidates: pending.candidates }))
+  }
+
+  const handleSheetDismiss = () => {
+    // Pan-down-to-close gesture path. Same as tapping "ahora no" so the 24h
+    // debounce kicks in and we do not re-prompt on the next boot.
+    if (!pending) return
+    if (inFlight) {
+      // Do not let the user swipe away mid-call; the saga is still talking to
+      // the backend. The modal would re-open via the saga's bootstrapSheetHidden
+      // on completion anyway, but UX is calmer if we just keep it visible.
+      sheetRef.current?.present()
+      return
+    }
+    dispatch(bootstrapDismissed({ candidates: pending.candidates }))
+    // Belt-and-suspenders: also clear the visibility flag in case the saga's
+    // dismiss listener races.
+    dispatch(bootstrapSheetHidden())
+  }
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      enableDynamicSizing
+      enablePanDownToClose={!inFlight}
+      backdropComponent={renderBackdrop}
+      onDismiss={handleSheetDismiss}
+    >
+      <BottomSheetView>
+        <View style={styles.container} testID="BootstrapSheet">
+          <Text style={styles.title}>{t('feeAdapterBootstrap.title')}</Text>
+          <Text style={styles.body}>{t('feeAdapterBootstrap.body')}</Text>
+          <Text style={styles.reassure}>{t('feeAdapterBootstrap.reassure')}</Text>
+          <View style={styles.buttons}>
+            <Button
+              type={BtnTypes.PRIMARY}
+              size={BtnSizes.FULL}
+              onPress={handleActivate}
+              text={
+                inFlight ? (
+                  <ActivityIndicator color={colors.white} testID="BootstrapSheet/Spinner" />
+                ) : (
+                  t('feeAdapterBootstrap.activate')
+                )
+              }
+              disabled={inFlight}
+              testID="BootstrapSheet/Activate"
+            />
+            <Button
+              type={BtnTypes.SECONDARY}
+              size={BtnSizes.FULL}
+              onPress={handleLater}
+              text={t('feeAdapterBootstrap.later')}
+              disabled={inFlight}
+              testID="BootstrapSheet/Later"
+            />
+          </View>
+        </View>
+      </BottomSheetView>
+    </BottomSheetModal>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: Spacing.Thick24,
+    paddingTop: Spacing.Regular16,
+    paddingBottom: Spacing.Large32,
+    gap: Spacing.Regular16,
+  },
+  title: {
+    ...typeScale.titleSmall,
+  },
+  body: {
+    ...typeScale.bodyMedium,
+    color: colors.gray4,
+  },
+  reassure: {
+    ...typeScale.labelSemiBoldSmall,
+    color: colors.gray4,
+  },
+  buttons: {
+    gap: Spacing.Smallest8,
+    marginTop: Spacing.Regular16,
+  },
+})

--- a/src/wri/feeAdapterBootstrap/detect.test.ts
+++ b/src/wri/feeAdapterBootstrap/detect.test.ts
@@ -13,6 +13,7 @@ function freshState(overrides?: Partial<BootstrapState['byAdapter']>): Bootstrap
       USDT: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
       ...overrides,
     },
+    pending: null,
   }
 }
 

--- a/src/wri/feeAdapterBootstrap/saga.test.ts
+++ b/src/wri/feeAdapterBootstrap/saga.test.ts
@@ -1,0 +1,191 @@
+import BigNumber from 'bignumber.js'
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { getFeatureGate } from 'src/statsig'
+import { feeCurrenciesWithPositiveBalancesSelector } from 'src/tokens/selectors'
+import { walletAddressSelector } from 'src/web3/selectors'
+import networkConfig from 'src/web3/networkConfig'
+import { BootstrapApiError, postFeeAdapterBootstrap } from 'src/wri/feeAdapterBootstrap/api'
+import {
+  bootstrapAccepted,
+  bootstrapDismissed,
+  bootstrapFailed,
+  bootstrapSheetHidden,
+  bootstrapSheetShown,
+  bootstrapStarted,
+  bootstrapSucceeded,
+} from 'src/wri/feeAdapterBootstrap/slice'
+import { handleAccept, handleDismiss, maybeOfferBootstrap } from 'src/wri/feeAdapterBootstrap/saga'
+
+jest.mock('src/statsig', () => ({
+  getFeatureGate: jest.fn(),
+}))
+jest.mock('src/wri/feeAdapterBootstrap/api', () => ({
+  ...jest.requireActual('src/wri/feeAdapterBootstrap/api'),
+  postFeeAdapterBootstrap: jest.fn(),
+}))
+
+const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
+
+const freshBootstrapState = {
+  byAdapter: {
+    USDC: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
+    USDT: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
+  },
+  pending: null,
+}
+
+describe('handleAccept', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('marks every candidate started then succeeded for approved + already_approved tokens', async () => {
+    jest.mocked(postFeeAdapterBootstrap).mockResolvedValue({
+      ok: true,
+      relayAddress: '0xrelay',
+      results: [
+        {
+          tokenSymbol: 'USDC',
+          tokenAddress: '0xceba9300f2b948710d2653dd7b07f33a8b32118c',
+          adapterAddress: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+          status: 'approved',
+          txHash: '0xtx1',
+          alreadyApproved: false,
+        },
+        {
+          tokenSymbol: 'USDT',
+          tokenAddress: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
+          adapterAddress: '0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72',
+          status: 'already_approved',
+          txHash: null,
+          alreadyApproved: true,
+        },
+      ],
+    })
+
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC', 'USDT'] }))
+      .provide([[matchers.select.selector(walletAddressSelector), MOCK_WALLET]])
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put(bootstrapStarted({ adapter: 'USDT' }))
+      .put(bootstrapSucceeded({ adapter: 'USDC' }))
+      .put(bootstrapSucceeded({ adapter: 'USDT' }))
+      .put(bootstrapSheetHidden())
+      .run()
+  })
+
+  it('marks failed when backend returns relay_failed', async () => {
+    jest.mocked(postFeeAdapterBootstrap).mockResolvedValue({
+      ok: true,
+      relayAddress: '0xrelay',
+      results: [
+        {
+          tokenSymbol: 'USDC',
+          tokenAddress: '0xceba9300f2b948710d2653dd7b07f33a8b32118c',
+          adapterAddress: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+          status: 'relay_failed',
+          txHash: null,
+          alreadyApproved: false,
+        },
+      ],
+    })
+
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC'] }))
+      .provide([[matchers.select.selector(walletAddressSelector), MOCK_WALLET]])
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put.actionType(bootstrapFailed.type)
+      .put(bootstrapSheetHidden())
+      .run()
+  })
+
+  it('marks every candidate failed when the api throws BootstrapApiError', async () => {
+    jest
+      .mocked(postFeeAdapterBootstrap)
+      .mockRejectedValue(new BootstrapApiError('not-delegated', 'user not delegated'))
+
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC', 'USDT'] }))
+      .provide([[matchers.select.selector(walletAddressSelector), MOCK_WALLET]])
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put(bootstrapStarted({ adapter: 'USDT' }))
+      .put.actionType(bootstrapFailed.type)
+      .put(bootstrapSheetHidden())
+      .run()
+  })
+
+  it('hides the sheet and skips the api call when wallet address is unset', async () => {
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC'] }))
+      .provide([[matchers.select.selector(walletAddressSelector), null]])
+      .put(bootstrapSheetHidden())
+      .not.put.actionType(bootstrapStarted.type)
+      .run()
+    expect(postFeeAdapterBootstrap).not.toHaveBeenCalled()
+  })
+
+  it('tolerates non-BootstrapApiError thrown from the api (network down, generic error)', async () => {
+    jest.mocked(postFeeAdapterBootstrap).mockRejectedValue(new Error('boom unexpected'))
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC'] }))
+      .provide([[matchers.select.selector(walletAddressSelector), MOCK_WALLET]])
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put(bootstrapFailed({ adapter: 'USDC', errorMessage: 'boom unexpected' }))
+      .put(bootstrapSheetHidden())
+      .run()
+  })
+})
+
+describe('handleDismiss', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('marks lastAttemptAt for each candidate so the 24h debounce kicks in, then hides the sheet', async () => {
+    await expectSaga(handleDismiss, bootstrapDismissed({ candidates: ['USDC', 'USDT'] }))
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put(bootstrapStarted({ adapter: 'USDT' }))
+      .put(bootstrapSheetHidden())
+      .run()
+    expect(postFeeAdapterBootstrap).not.toHaveBeenCalled()
+  })
+})
+
+describe('maybeOfferBootstrap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows the sheet when the detector returns shouldOffer=true', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    const usdcBalance = {
+      tokenId: networkConfig.usdcTokenId,
+      balance: new BigNumber(5),
+    } as any
+
+    // Anonymous selector for the slice; provide via the dynamic select handler
+    // so we can branch on the actual selector function reference.
+    await expectSaga(maybeOfferBootstrap)
+      .provide({
+        select: ({ selector }, next) => {
+          if (selector === walletAddressSelector) return MOCK_WALLET
+          if (selector === feeCurrenciesWithPositiveBalancesSelector) return [usdcBalance]
+          // Inline selector: state => state.wriFeeAdapterBootstrap
+          return freshBootstrapState
+        },
+      })
+      .put(bootstrapSheetShown({ candidates: ['USDC'] }))
+      .run()
+  })
+
+  it('skips when the gate is off', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    await expectSaga(maybeOfferBootstrap)
+      .provide([[matchers.select.selector(walletAddressSelector), MOCK_WALLET]])
+      .not.put.actionType(bootstrapSheetShown.type)
+      .run()
+  })
+
+  it('skips when wallet address is unset', async () => {
+    await expectSaga(maybeOfferBootstrap)
+      .provide([[matchers.select.selector(walletAddressSelector), null]])
+      .not.put.actionType(bootstrapSheetShown.type)
+      .run()
+  })
+})

--- a/src/wri/feeAdapterBootstrap/saga.ts
+++ b/src/wri/feeAdapterBootstrap/saga.ts
@@ -1,0 +1,205 @@
+import { PayloadAction } from '@reduxjs/toolkit'
+import { call, delay, put, select, spawn, take, takeEvery } from 'typed-redux-saga'
+import { REHYDRATE, type RehydrateAction } from 'src/redux/persist-helper'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+import { feeCurrenciesWithPositiveBalancesSelector } from 'src/tokens/selectors'
+import { NetworkId } from 'src/transactions/types'
+import Logger from 'src/utils/Logger'
+import { Actions as Web3Actions } from 'src/web3/actions'
+import { walletAddressSelector } from 'src/web3/selectors'
+import {
+  BootstrapApiError,
+  postFeeAdapterBootstrap,
+  type AdapterResult,
+  type AdapterStatus,
+} from 'src/wri/feeAdapterBootstrap/api'
+import { detectShouldOfferBootstrap } from 'src/wri/feeAdapterBootstrap/detect'
+import {
+  bootstrapAccepted,
+  bootstrapDismissed,
+  bootstrapFailed,
+  bootstrapSheetHidden,
+  bootstrapSheetShown,
+  bootstrapStarted,
+  bootstrapSucceeded,
+  type AdapterSymbol,
+  type State as BootstrapState,
+} from 'src/wri/feeAdapterBootstrap/slice'
+
+const TAG = 'wri/feeAdapterBootstrap/saga'
+
+// Wait this long after boot before evaluating the bootstrap offer. Onboarding
+// flows and first-render animations finish in roughly this window; firing the
+// detector earlier risks fighting with the splash for screen real estate. The
+// user is non-technical, so a calm UI is worth 2 seconds.
+const POST_BOOT_DELAY_MS = 2_000
+
+// Pull the slice + token balances + gate state, run the pure detector, and
+// dispatch the show action if it says yes. Pulled out so the boot path and the
+// SET_ACCOUNT path share one body.
+export function* maybeOfferBootstrap() {
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) return
+
+  const gateOn: boolean = yield* call(getFeatureGate, StatsigFeatureGates.WRI_COPM_FEE_BOOTSTRAP_V1)
+  if (!gateOn) return
+
+  const bootstrapState: BootstrapState = yield* select((state: any) => state.wriFeeAdapterBootstrap)
+
+  // feeCurrenciesWithPositiveBalancesSelector returns the user's balances
+  // filtered to fee-currency-eligible tokens on Celo mainnet. The detector
+  // narrows further to USDC + USDT + the alt-gas tokens (CELO, USDm, COPm).
+  const balances = yield* select(
+    feeCurrenciesWithPositiveBalancesSelector,
+    NetworkId['celo-mainnet']
+  )
+
+  const decision = detectShouldOfferBootstrap({
+    balances,
+    bootstrapState,
+    now: Date.now(),
+    gateOn,
+  })
+
+  if (decision.shouldOffer) {
+    Logger.info(
+      TAG,
+      `offering bootstrap to ${walletAddress}: ${decision.adaptersToBootstrap.join(', ')}`
+    )
+    yield* put(bootstrapSheetShown({ candidates: decision.adaptersToBootstrap }))
+  } else {
+    Logger.debug(TAG, `skipping bootstrap offer: ${decision.reason}`)
+  }
+}
+
+function* handleRehydrate(_action: RehydrateAction) {
+  // Always wipe pending visibility on boot. A kill-9 mid-sheet would otherwise
+  // resurrect the modal in front of a confused user.
+  yield* put(bootstrapSheetHidden())
+  // Pause briefly so the splash screen finishes its transition, then evaluate.
+  yield* delay(POST_BOOT_DELAY_MS)
+  yield* call(maybeOfferBootstrap)
+}
+
+function* handleSetAccount() {
+  // SET_ACCOUNT fires once on fresh onboarding. The user has just landed on
+  // home; same calm delay before showing anything.
+  yield* delay(POST_BOOT_DELAY_MS)
+  yield* call(maybeOfferBootstrap)
+}
+
+// Process the per-token response from the backend and update the slice.
+// Backend returns 5 possible status values; the wallet treats them as:
+//   approved + already_approved -> mark bootstrapped, clear errors
+//   skipped_no_balance -> ignore (the user really has 0 of that token)
+//   skipped_no_adapter -> log warn (should not happen in production)
+//   relay_failed -> mark failed so the 24h debounce kicks in
+function* applyBootstrapResults(results: AdapterResult[]) {
+  for (const r of results) {
+    const adapter = r.tokenSymbol as AdapterSymbol
+    if (r.status === 'approved' || r.status === 'already_approved') {
+      yield* put(bootstrapSucceeded({ adapter }))
+      Logger.info(TAG, `${adapter} bootstrapped (${r.status}, tx=${r.txHash ?? 'none'})`)
+    } else if (r.status === 'skipped_no_balance') {
+      Logger.info(TAG, `${adapter} skipped: user has 0 balance`)
+    } else if (r.status === 'skipped_no_adapter') {
+      Logger.warn(TAG, `${adapter} skipped: backend has no env var for this adapter`)
+    } else if (r.status === 'relay_failed') {
+      yield* put(
+        bootstrapFailed({
+          adapter,
+          errorMessage: `relay failed (txHash=${r.txHash ?? 'none'}); retry on next boot`,
+        })
+      )
+    } else {
+      // Defensive: backend added a new status the wallet does not know.
+      Logger.warn(
+        TAG,
+        `${adapter} returned unknown status ${(r as { status: AdapterStatus }).status}; treating as failed`
+      )
+      yield* put(bootstrapFailed({ adapter, errorMessage: `unknown status ${r.status as string}` }))
+    }
+  }
+}
+
+export function* handleAccept(action: PayloadAction<{ candidates: AdapterSymbol[] }>) {
+  const walletAddress = yield* select(walletAddressSelector)
+  if (!walletAddress) {
+    // should not happen because the sheet only renders when address exists
+    yield* put(bootstrapSheetHidden())
+    return
+  }
+
+  // Mark every candidate as in-flight so the UI can show a spinner. lastError
+  // gets cleared too so a previous failure does not leak into a fresh attempt.
+  for (const adapter of action.payload.candidates) {
+    yield* put(bootstrapStarted({ adapter }))
+  }
+
+  try {
+    const response = yield* call(postFeeAdapterBootstrap, walletAddress)
+    yield* call(applyBootstrapResults, response.results)
+  } catch (err) {
+    if (err instanceof BootstrapApiError) {
+      // Per-candidate failure so the slice records lastError for each token
+      // the user was offered. The kind discriminator is logged for telemetry.
+      Logger.warn(TAG, `bootstrap api error (${err.kind}): ${err.message}`)
+      for (const adapter of action.payload.candidates) {
+        yield* put(bootstrapFailed({ adapter, errorMessage: `${err.kind}: ${err.message}` }))
+      }
+      // 412: user not delegated to BatchExecutor yet. The natural next step is
+      // a swap (which goes through delegate-relay and mints the delegation).
+      // For this iteration we just log the gap. A follow-up can chain through
+      // /delegate-relay before retrying the bootstrap automatically.
+      if (err.kind === 'not-delegated') {
+        Logger.info(
+          TAG,
+          `not-delegated: user must swap once before bootstrap can work; offering will retry after debounce`
+        )
+      }
+    } else {
+      const message = err instanceof Error ? err.message : String(err)
+      Logger.warn(TAG, `bootstrap threw: ${message}`)
+      for (const adapter of action.payload.candidates) {
+        yield* put(bootstrapFailed({ adapter, errorMessage: message }))
+      }
+    }
+  } finally {
+    yield* put(bootstrapSheetHidden())
+  }
+}
+
+export function* handleDismiss(action: PayloadAction<{ candidates: AdapterSymbol[] }>) {
+  // User explicitly declined. Mark lastAttemptAt so the 24h debounce kicks in.
+  // No bootstrapStarted dispatch because no API call happened; bootstrapFailed
+  // with a "user dismissed" sentinel records the timestamp without polluting
+  // the lastError field (we want the next attempt to start with a clean
+  // error state).
+  for (const adapter of action.payload.candidates) {
+    yield* put(bootstrapStarted({ adapter }))
+  }
+  yield* put(bootstrapSheetHidden())
+  Logger.info(
+    TAG,
+    `user dismissed bootstrap; debounce 24h on ${action.payload.candidates.join(', ')}`
+  )
+}
+
+export function* watchFeeAdapterBootstrap() {
+  // Boot-time evaluation: wait for the first REHYDRATE then run the detector.
+  // The spawn keeps the rest of the saga responsive (takeEvery listeners
+  // active) while the boot-path delay + detector pipeline runs.
+  yield* spawn(function* () {
+    const action = (yield* take(REHYDRATE)) as RehydrateAction
+    yield* call(handleRehydrate, action)
+  })
+
+  // Onboarding evaluation: when a fresh wallet lands.
+  yield* takeEvery(Web3Actions.SET_ACCOUNT, handleSetAccount)
+
+  // Sheet handoff: the BootstrapSheetHost component dispatches these when the
+  // user taps activate or later.
+  yield* takeEvery(bootstrapAccepted.type, handleAccept)
+  yield* takeEvery(bootstrapDismissed.type, handleDismiss)
+}

--- a/src/wri/feeAdapterBootstrap/slice.ts
+++ b/src/wri/feeAdapterBootstrap/slice.ts
@@ -20,8 +20,24 @@ export interface AdapterState {
   lastError: string | null
 }
 
+// Ephemeral handoff between the orchestration saga and the BootstrapSheetHost
+// component. The saga sets `pending` to non-null when the detector decides to
+// offer the bootstrap; the Host subscribes via useSelector and present()s the
+// BottomSheetModal. User taps on the sheet dispatch bootstrapAccepted or
+// bootstrapDismissed, which the saga listens to and resolves the flow.
+//
+// Persisted (along with byAdapter) but always wiped to null on REHYDRATE by
+// the saga, so a kill-9 in the middle of the sheet flow does not resurrect
+// the sheet next boot. Treating it as non-persisted in spirit, persisted in
+// shape only so autoMergeLevel2 keeps the key visible to TypeScript.
+export interface PendingState {
+  visible: boolean
+  candidates: AdapterSymbol[]
+}
+
 export interface State {
   byAdapter: Record<AdapterSymbol, AdapterState>
+  pending: PendingState | null
 }
 
 const initialAdapterState: AdapterState = {
@@ -36,6 +52,7 @@ const initialState: State = {
     USDC: { ...initialAdapterState },
     USDT: { ...initialAdapterState },
   },
+  pending: null,
 }
 
 const slice = createSlice({
@@ -61,15 +78,44 @@ const slice = createSlice({
       a.lastError = action.payload.errorMessage
     },
     // Escape hatch used by tests / dev tools. Production code should not call
-    // this — the bootstrapped flag matches the on-chain allowance state and
+    // this. The bootstrapped flag matches the on-chain allowance state and
     // resetting it locally without revoking on-chain leaves a stale UX.
     bootstrapReset(state, action: PayloadAction<{ adapter: AdapterSymbol }>) {
       state.byAdapter[action.payload.adapter] = { ...initialAdapterState }
     },
+    // Saga calls this when the detector says yes. The Host component watches
+    // pending.visible and present()s the sheet.
+    bootstrapSheetShown(state, action: PayloadAction<{ candidates: AdapterSymbol[] }>) {
+      state.pending = { visible: true, candidates: action.payload.candidates }
+    },
+    // Closes the sheet. Called by both the saga (after the call resolves) and
+    // by the Host's onDismiss (pan-down-to-close gesture).
+    bootstrapSheetHidden(state) {
+      state.pending = null
+    },
+    // Signal action with no state change. The saga listens on this action's
+    // type to kick off the actual API call. The reducer being a no-op keeps
+    // the dispatched payload available to the saga via take().
+    bootstrapAccepted(_state, _action: PayloadAction<{ candidates: AdapterSymbol[] }>) {
+      // intentionally empty: saga consumes via take()
+    },
+    // Signal action. Saga listens and marks lastAttemptAt for every candidate
+    // so the 24h debounce kicks in and we do not re-prompt on the next boot.
+    bootstrapDismissed(_state, _action: PayloadAction<{ candidates: AdapterSymbol[] }>) {
+      // intentionally empty: saga consumes via take()
+    },
   },
 })
 
-export const { bootstrapStarted, bootstrapSucceeded, bootstrapFailed, bootstrapReset } =
-  slice.actions
+export const {
+  bootstrapStarted,
+  bootstrapSucceeded,
+  bootstrapFailed,
+  bootstrapReset,
+  bootstrapSheetShown,
+  bootstrapSheetHidden,
+  bootstrapAccepted,
+  bootstrapDismissed,
+} = slice.actions
 
 export default slice.reducer

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -82,6 +82,13 @@
             ],
             "type": "object"
         },
+        "AdapterSymbol": {
+            "enum": [
+                "USDC",
+                "USDT"
+            ],
+            "type": "string"
+        },
         "AddressInfoToDisplay": {
             "additionalProperties": false,
             "properties": {
@@ -3578,6 +3585,25 @@
             ],
             "type": "object"
         },
+        "PendingState": {
+            "additionalProperties": false,
+            "properties": {
+                "candidates": {
+                    "items": {
+                        "$ref": "#/definitions/AdapterSymbol"
+                    },
+                    "type": "array"
+                },
+                "visible": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "candidates",
+                "visible"
+            ],
+            "type": "object"
+        },
         "PersistState": {
             "additionalProperties": false,
             "properties": {
@@ -6438,10 +6464,21 @@
             "properties": {
                 "byAdapter": {
                     "$ref": "#/definitions/Record<AdapterSymbol,AdapterState>"
+                },
+                "pending": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PendingState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
-                "byAdapter"
+                "byAdapter",
+                "pending"
             ],
             "type": "object"
         },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3783,6 +3783,7 @@ export const v251SchemaWithWriFeeAdapterBootstrap = {
       USDC: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
       USDT: { bootstrapped: false, lastAttemptAt: null, lastSuccessAt: null, lastError: null },
     },
+    pending: null,
   },
 }
 


### PR DESCRIPTION
## Summary

Closes the loop on the WRI fee-adapter bootstrap flow that started in #231 (slice + api client + detector). This PR wires the orchestration saga, builds the activation sheet UI, and mounts it at the App root so users with only USDC/USDT can opt in to paying gas with their dollar balances.

Gated by \`StatsigFeatureGates.WRI_COPM_FEE_BOOTSTRAP_V1\` (already in the enum since #230). The gate is OFF in Statsig so merging is a no-op for users.

## What is in

1. **slice extension**: \`pending: { visible, candidates } | null\` plus four new actions: \`bootstrapSheetShown\`, \`bootstrapSheetHidden\`, \`bootstrapAccepted\`, \`bootstrapDismissed\`. RootStateSchema regenerated; no persist version bump (autoMergeLevel2 folds the new key).
2. **orchestration saga** \`src/wri/feeAdapterBootstrap/saga.ts\`:
   - \`REHYDRATE\` and \`SET_ACCOUNT\` triggers, with a 2s post-boot delay so the offer does not race the splash transition.
   - Runs the detector (from #231) and dispatches \`bootstrapSheetShown\` if it returns shouldOffer.
   - On \`bootstrapAccepted\`: marks every candidate started, calls backend, processes the per-token results (approved + already_approved -> succeeded, relay_failed -> failed, skipped -> ignored), branches on BootstrapApiError.kind. The 412 not-delegated case logs the gap; a follow-up can chain through /api/wri/delegate-relay automatically.
   - On \`bootstrapDismissed\`: marks lastAttemptAt so the 24h debounce kicks in. No backend call.
   - Always hides the sheet at the end via try/finally.
3. **activation sheet** \`src/wri/feeAdapterBootstrap/BootstrapSheetHost.tsx\`: Redux-driven BottomSheetModal that presents when pending.visible flips true. Plain Spanish copy. Activate / Ahora no buttons. While in-flight, spinner replaces the activate label and pan-down-to-close is disabled.
4. **app wireup**: saga spawned from transactionSaga; BootstrapSheetHost mounted at App root next to ErrorSheetHost and ToastHost.

## What is NOT in (follow-ups)

- Auto-chain through /api/wri/delegate-relay when the bootstrap returns 412 not-delegated. For this iteration the user just sees an error message and the debounce kicks in.
- Analytics events for \`fee_adapter_bootstrap_offered\`, \`accepted\`, \`dismissed\`, \`succeeded\`, \`failed\`.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/wri src/redux src/transactions src/app\`: 361/361 passed
- [x] Saga handlers tested in isolation (handleAccept, handleDismiss, maybeOfferBootstrap exported and covered by 9 tests)
- [x] Slice exports + RootStateSchema in sync
- [ ] Manual once gate is flipped on a dogfood wallet: USDC-only wallet boots, sees the sheet, taps activate, backend POST fires, allowance shows up on chain.
- [ ] Manual: tap "Ahora no", confirm the sheet does not re-appear on the next boot within 24h.