### PR TITLE
feat(wri/watch): include walletCreatedAt for full backfill

### DIFF
--- a/src/transactions/registerWatchSaga.test.ts
+++ b/src/transactions/registerWatchSaga.test.ts
@@ -1,4 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan'
+import { select } from 'redux-saga/effects'
+import { accountCreationTimeSelector } from 'src/account/selectors'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { registerWalletForFeedWatch } from 'src/transactions/registerWatchSaga'
@@ -13,6 +15,10 @@ jest.mock('src/utils/fetchWithTimeout', () => ({
 }))
 
 const MOCK_WALLET = '0x1234567890abcdef1234567890abcdef12345678'
+const MOCK_CREATION_TIME_MS = 1739664000000 // 2025-02-16T00:00:00.000Z
+const MOCK_CREATION_TIME_ISO = '2025-02-16T00:00:00.000Z'
+// Sentinel from src/account/reducer.ts initial state -- means "not set yet".
+const ACCOUNT_CREATION_SENTINEL = 99999999999999
 
 describe('registerWalletForFeedWatch', () => {
   beforeEach(() => {
@@ -26,20 +32,51 @@ describe('registerWalletForFeedWatch', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('POSTs the address to wriTxWatchUrl when the gate is on', async () => {
+  it('POSTs address + walletCreatedAt when the gate is on and creation time is set', async () => {
     jest
       .mocked(getFeatureGate)
       .mockImplementation((g) => g === StatsigFeatureGates.WRI_TX_FEED_TUCOP_V1)
     jest
       .mocked(fetchWithTimeout)
       .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
-    await expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()
+    await expectSaga(registerWalletForFeedWatch, MOCK_WALLET)
+      .provide([[select(accountCreationTimeSelector), MOCK_CREATION_TIME_MS]])
+      .run()
 
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
     const [url, opts] = jest.mocked(fetchWithTimeout).mock.calls[0]
     expect(url).toBe(networkConfig.wriTxWatchUrl)
     expect(opts?.method).toBe('POST')
     expect(opts?.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(opts?.body).toBe(
+      JSON.stringify({ address: MOCK_WALLET, walletCreatedAt: MOCK_CREATION_TIME_ISO })
+    )
+  })
+
+  it('omits walletCreatedAt when the account creation time is the not-set sentinel', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    await expectSaga(registerWalletForFeedWatch, MOCK_WALLET)
+      .provide([[select(accountCreationTimeSelector), ACCOUNT_CREATION_SENTINEL]])
+      .run()
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    const [, opts] = jest.mocked(fetchWithTimeout).mock.calls[0]
+    expect(opts?.body).toBe(JSON.stringify({ address: MOCK_WALLET }))
+  })
+
+  it('omits walletCreatedAt when the account creation time is zero (corrupt state)', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest
+      .mocked(fetchWithTimeout)
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    await expectSaga(registerWalletForFeedWatch, MOCK_WALLET)
+      .provide([[select(accountCreationTimeSelector), 0]])
+      .run()
+
+    const [, opts] = jest.mocked(fetchWithTimeout).mock.calls[0]
     expect(opts?.body).toBe(JSON.stringify({ address: MOCK_WALLET }))
   })
 
@@ -48,14 +85,22 @@ describe('registerWalletForFeedWatch', () => {
     jest
       .mocked(fetchWithTimeout)
       .mockResolvedValue(new Response('Internal Server Error', { status: 503 }))
-    // The saga must not bubble — it's a fire-and-forget side effect that
+    // The saga must not bubble -- it's a fire-and-forget side effect that
     // retries on the next boot.
-    await expect(expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()).resolves.not.toThrow()
+    await expect(
+      expectSaga(registerWalletForFeedWatch, MOCK_WALLET)
+        .provide([[select(accountCreationTimeSelector), MOCK_CREATION_TIME_MS]])
+        .run()
+    ).resolves.not.toThrow()
   })
 
   it('does not throw when fetchWithTimeout itself throws (network down / abort)', async () => {
     jest.mocked(getFeatureGate).mockReturnValue(true)
     jest.mocked(fetchWithTimeout).mockRejectedValue(new Error('network unreachable'))
-    await expect(expectSaga(registerWalletForFeedWatch, MOCK_WALLET).run()).resolves.not.toThrow()
+    await expect(
+      expectSaga(registerWalletForFeedWatch, MOCK_WALLET)
+        .provide([[select(accountCreationTimeSelector), MOCK_CREATION_TIME_MS]])
+        .run()
+    ).resolves.not.toThrow()
   })
 })

--- a/src/transactions/registerWatchSaga.ts
+++ b/src/transactions/registerWatchSaga.ts
@@ -1,4 +1,5 @@
 import { call, delay, select, spawn, take, takeEvery } from 'typed-redux-saga'
+import { accountCreationTimeSelector } from 'src/account/selectors'
 import { Actions as Web3Actions } from 'src/web3/actions'
 import { walletAddressSelector } from 'src/web3/selectors'
 import networkConfig from 'src/web3/networkConfig'
@@ -42,6 +43,21 @@ export function* registerWalletForFeedWatch(walletAddress: string) {
     return
   }
 
+  // walletCreatedAt lets the backend extend its 10k-block default backfill all
+  // the way back to the wallet's first day, so the user does not see "lost
+  // history" when the gate flips. The reducer default is 99999999999999 (a
+  // sentinel meaning "not set yet" -- import flows briefly hit this state
+  // before SET_ACCOUNT fills in the real time). Drop the field when we have
+  // anything that is not a plausible past epoch ms so the backend backfill
+  // falls through to its default. Backend tolerates the field being absent OR
+  // present-but-unknown (extra body fields are ignored today; real support
+  // ships shortly after this code lands).
+  const accountCreationTime: number = yield* select(accountCreationTimeSelector)
+  const isPlausibleEpochMs = accountCreationTime > 0 && accountCreationTime < Date.now()
+  const walletCreatedAt = isPlausibleEpochMs
+    ? new Date(accountCreationTime).toISOString()
+    : undefined
+
   try {
     const response: Response = yield* call(
       fetchWithTimeout,
@@ -49,7 +65,10 @@ export function* registerWalletForFeedWatch(walletAddress: string) {
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ address: walletAddress }),
+        body: JSON.stringify({
+          address: walletAddress,
+          ...(walletCreatedAt && { walletCreatedAt }),
+        }),
       },
       WATCH_TIMEOUT_MS
     )


### PR DESCRIPTION
## Summary

Extend `POST /api/transactions/watch` body with the wallet's local creation
time (`walletCreatedAt`, ISO 8601). Backend uses it as the lower bound when
extending its default 10k-block backfill, so users with months of history
see their full feed when `WRI_TX_FEED_TUCOP_V1` flips on.

Behavior:
- Reads `accountCreationTimeSelector` from `src/account/selectors.ts`
- Sends `walletCreatedAt` only when the local time is plausible (`> 0` and
  `< Date.now()`). Skipped when the value is the "not set" sentinel
  (`99999999999999`), zero (corrupt state), or future
- Backend tolerates the field being absent OR present-but-unknown today;
  real validation lands in the next backend deploy (commit hash + diff TBA)
- The field only EXTENDS the backfill window, never shrinks it
- Behind the same `WRI_TX_FEED_TUCOP_V1` gate already governing the watch
  call -- no flag change required

Spec context: section 5.1 of `docs/specs/2026-06-30-wri-tx-feed-and-fee-bootstrap.md`
(local-only).

## Test plan

- [x] yarn build:ts
- [x] yarn lint
- [x] yarn jest src/transactions/registerWatchSaga.test.ts (6/6 pass)
  - skips POST when gate off
  - POSTs { address, walletCreatedAt } with valid time
  - POSTs { address } only when sentinel
  - POSTs { address } only when zero
  - silent on 5xx
  - silent on network error
- [ ] Manual smoke once merged: gate ON in dev, intercept /watch call in
  Charles/Proxyman, confirm body shape