### PR TITLE
feat(feed): render multi-token WRI batches via fromTokenAmounts

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1345,6 +1345,7 @@
   "feedItemGoldReceived": "Received from {{displayName}}",
   "feedItemSwapTitle": "Swapped",
   "feedItemSwapPath": "{{token1}} to {{token2}}",
+  "feedItemSwapPathMulti": "{{count}} tokens to {{token2}}",
   "feedItemJumpstartTitle": "Live Link",
   "feedItemJumpstartSentSubtitle": "Invitation",
   "feedItemJumpstartReceivedSubtitle": "Funds received",

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -1350,6 +1350,7 @@
   "feedItemGoldReceived": "Received from {{displayName}}",
   "feedItemSwapTitle": "Swapped",
   "feedItemSwapPath": "{{token1}} to {{token2}}",
+  "feedItemSwapPathMulti": "{{count}} tokens to {{token2}}",
   "feedItemJumpstartTitle": "Live Link",
   "feedItemJumpstartSentSubtitle": "Invitation",
   "feedItemJumpstartReceivedSubtitle": "Funds received",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -1350,6 +1350,7 @@
   "feedItemGoldReceived": "Recibidos de {{displayName}}",
   "feedItemSwapTitle": "Intercambio",
   "feedItemSwapPath": "{{token1}} > {{token2}}",
+  "feedItemSwapPathMulti": "{{count}} monedas a {{token2}}",
   "feedItemJumpstartTitle": "Enlace activo",
   "feedItemJumpstartSentSubtitle": "Invitación",
   "feedItemJumpstartReceivedSubtitle": "Fondos recibidos",

--- a/src/transactions/feed/SwapFeedItem.test.tsx
+++ b/src/transactions/feed/SwapFeedItem.test.tsx
@@ -95,6 +95,48 @@ describe('SwapFeedItem', () => {
     })
   })
 
+  it('falls back to single-leg path when fromTokenAmounts has length 1', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <SwapFeedItem
+          transaction={{
+            ...swapTransaction,
+            fromTokenAmounts: [{ tokenId: mockCusdTokenId, value: '2.87' }],
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent(
+      'feedItemSwapPath, {"token1":"assets.dollars","token2":"Celo Euros"}'
+    )
+    expect(getByTestId('SwapFeedItem/outgoingAmount')).toHaveTextContent('-2.87 cUSD')
+  })
+
+  it('renders multi-leg subtitle when fromTokenAmounts has length > 1 (atomic 7702 batch)', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <SwapFeedItem
+          transaction={{
+            ...swapTransaction,
+            fromTokenAmounts: [
+              { tokenId: mockCusdTokenId, value: '1.005987' },
+              { tokenId: mockCusdTokenId, value: '1.006823' },
+              { tokenId: mockCusdTokenId, value: '0.988972' },
+            ],
+          }}
+        />
+      </Provider>
+    )
+
+    // Subtitle collapses to the multi-token count + destination
+    expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent(
+      'feedItemSwapPathMulti, {"count":3,"token2":"Celo Euros"}'
+    )
+    // Outgoing amount still shows the largest-value leg (outAmount unchanged)
+    expect(getByTestId('SwapFeedItem/outgoingAmount')).toHaveTextContent('-2.87 cUSD')
+  })
+
   it('renders correctly for pending cross-chain swap with no inAmount value', async () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={createMockStore()}>

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -36,6 +36,13 @@ function SwapFeedItem({ transaction }: Props) {
   }
 
   const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction
+  // EIP-7702 atomic batches from the TuCop indexer feed populate
+  // fromTokenAmounts with every leg of the batch. When >1, the subtitle
+  // collapses to a count ("3 monedas a Pesos") so the user understands the
+  // tx moved multiple inputs at once. The outgoing amount row keeps showing
+  // the largest leg (which is what outAmount already holds for these txs).
+  const fromLegCount = transaction.fromTokenAmounts?.length ?? 0
+  const isMultiLegSwap = fromLegCount > 1
 
   // Get friendly token name - also accepts tokenId for when token info isn't available.
   // Per .claude/rules/tokens.md the entire USAT/USDm/USDC/USDT group is shown as
@@ -125,10 +132,15 @@ function SwapFeedItem({ transaction }: Props) {
             <Text style={styles.subtitle} testID={'SwapFeedItem/subtitle'} numberOfLines={1}>
               {isCrossChainSwap
                 ? t('transactionFeed.crossChainSwapTransactionLabel')
-                : t('feedItemSwapPath', {
-                    token1: getTokenName(outgoingTokenInfo, transaction.outAmount.tokenId),
-                    token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
-                  })}
+                : isMultiLegSwap
+                  ? t('feedItemSwapPathMulti', {
+                      count: fromLegCount,
+                      token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
+                    })
+                  : t('feedItemSwapPath', {
+                      token1: getTokenName(outgoingTokenInfo, transaction.outAmount.tokenId),
+                      token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
+                    })}
             </Text>
             <TokenDisplay
               amount={-transaction.outAmount.value}

--- a/src/transactions/feed/detailContent/SwapContent.tsx
+++ b/src/transactions/feed/detailContent/SwapContent.tsx
@@ -28,8 +28,15 @@ export default function SwapContent({ transaction }: Props) {
   const fromToken = tokensList.find((token) => token.tokenId === transaction.outAmount.tokenId)
   const toToken = tokensList.find((token) => token.tokenId === transaction.inAmount.tokenId)
   const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction
+  // EIP-7702 atomic batches list every leg in fromTokenAmounts. When >1, the
+  // detail screen renders one "swapFrom" row per leg so the user sees the full
+  // breakdown. Exchange rate is suppressed because there is no single rate
+  // when the inputs are heterogeneous.
+  const fromLegs = transaction.fromTokenAmounts ?? []
+  const isMultiLegSwap = fromLegs.length > 1
 
   const showExchangeRate =
+    !isMultiLegSwap &&
     transaction.status === TransactionStatus.Complete &&
     !new BigNumber(transaction.inAmount.value).isNaN() &&
     !!fromToken &&
@@ -37,18 +44,35 @@ export default function SwapContent({ transaction }: Props) {
 
   return (
     <View style={styles.contentContainer}>
-      <View style={styles.row}>
-        <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapFrom')}</Text>
-        <TokenDisplay
-          style={styles.currencyAmountPrimaryText}
-          amount={transaction.outAmount.value}
-          tokenId={transaction.outAmount.tokenId}
-          showLocalAmount={false}
-          showSymbol={true}
-          hideSign={true}
-          testID="SwapContent/swapFrom"
-        />
-      </View>
+      {isMultiLegSwap ? (
+        fromLegs.map((leg, idx) => (
+          <View style={styles.row} key={`${leg.tokenId}-${idx}`}>
+            <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapFrom')}</Text>
+            <TokenDisplay
+              style={styles.currencyAmountPrimaryText}
+              amount={leg.value}
+              tokenId={leg.tokenId}
+              showLocalAmount={false}
+              showSymbol={true}
+              hideSign={true}
+              testID={`SwapContent/swapFrom/${idx}`}
+            />
+          </View>
+        ))
+      ) : (
+        <View style={styles.row}>
+          <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapFrom')}</Text>
+          <TokenDisplay
+            style={styles.currencyAmountPrimaryText}
+            amount={transaction.outAmount.value}
+            tokenId={transaction.outAmount.tokenId}
+            showLocalAmount={false}
+            showSymbol={true}
+            hideSign={true}
+            testID="SwapContent/swapFrom"
+          />
+        </View>
+      )}
       <View style={styles.row}>
         <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapTo')}</Text>
         <TokenDisplay

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -207,6 +207,12 @@ export interface TokenExchange {
   block: string
   inAmount: TokenAmount
   outAmount: TokenAmount
+  // Populated by the TuCop indexer feed for EIP-7702 atomic batches that
+  // spend N tokens in one tx (WRI dollars-spend). When present and length>1,
+  // outAmount holds the largest-value leg for backwards compatibility and
+  // this array carries every leg. Absent for single-leg swaps and for the
+  // Valora feed shape.
+  fromTokenAmounts?: TokenAmount[]
   metadata?: TokenExchangeMetadata
   fees: Fee[]
   status: TransactionStatus

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3450,6 +3450,12 @@
                 "feeCurrencyId": {
                     "type": "string"
                 },
+                "fromTokenAmounts": {
+                    "items": {
+                        "$ref": "#/definitions/TokenAmount"
+                    },
+                    "type": "array"
+                },
                 "inAmount": {
                     "$ref": "#/definitions/TokenAmount"
                 },
@@ -4631,6 +4637,12 @@
                         "fees": {
                             "items": {
                                 "$ref": "#/definitions/Fee"
+                            },
+                            "type": "array"
+                        },
+                        "fromTokenAmounts": {
+                            "items": {
+                                "$ref": "#/definitions/TokenAmount"
                             },
                             "type": "array"
                         },
@@ -7198,6 +7210,12 @@
                 "fees": {
                     "items": {
                         "$ref": "#/definitions/Fee"
+                    },
+                    "type": "array"
+                },
+                "fromTokenAmounts": {
+                    "items": {
+                        "$ref": "#/definitions/TokenAmount"
                     },
                     "type": "array"
                 },


### PR DESCRIPTION
## Summary

Render EIP-7702 atomic batches that spend N tokens in one tx with all
legs visible. The TuCop indexer feed (PR #230) emits a new optional
`fromTokenAmounts: TokenAmount[]` field on `TokenExchange` for these
batches; today the wallet ignores it and the user only sees the largest
leg.

Changes:

**Type:** add `fromTokenAmounts?: TokenAmount[]` to `TokenExchange` in
`src/transactions/types.ts`. Optional, so single-leg swaps and the
Valora feed fall through to the existing render unchanged.

**List view (`SwapFeedItem`):** when length > 1, subtitle collapses to
`"{count} monedas a {token2}"` (en: `"{count} tokens to {token2}"`).
Outgoing amount row keeps showing `outAmount` (the largest-value leg)
for visual continuity.

**Detail view (`SwapContent`):** when length > 1, render one `swapFrom`
row per leg with each leg's own `TokenDisplay` (`testID
SwapContent/swapFrom/{idx}`). Exchange rate row is suppressed (no
single rate when inputs are heterogeneous).

**i18n:** new key `feedItemSwapPathMulti` in `base`, `en-US`, `es-419`.

No flag of its own -- implicitly gated by `WRI_TX_FEED_TUCOP_V1` because
the Valora feed never populates `fromTokenAmounts`.

Spec context: section 5.3 of
`docs/specs/2026-06-30-wri-tx-feed-and-fee-bootstrap.md` (local-only).

## Test plan

- [x] `yarn build:ts`
- [x] `yarn lint`
- [x] `yarn jest src/transactions/feed/SwapFeedItem.test.tsx` (5/5)
  - new: falls back to single-leg path when length 1
  - new: multi-leg subtitle when length 3 (atomic 7702 batch)
- [x] `yarn jest src/transactions/feed/TransactionDetailsScreen.test.tsx`
  (48/48, no regressions in single-leg)
- [ ] Manual smoke once `WRI_TX_FEED_TUCOP_V1` is ON: open Activity, find
  the multi-token WRI batch
  `0xbefe73327f874c2e60ef95939499ecbb72c2a61478eb20f011ff9e4d745be5d8`
  (from backend smoke test), confirm 3 from-tokens listed in the detail
- [ ] Manual smoke: single-leg batch
  `0x5d42cee6c982473e2cd87beae75d6acd24bd901f5604cac86975b63d908c11b2`
  renders as before