### PR TITLE
fix(wri): Forno-stale 412 retry + feed shape-diff runner

### DIFF
--- a/scripts/wri-feed-shape-diff.mjs
+++ b/scripts/wri-feed-shape-diff.mjs
@@ -229,11 +229,15 @@ async function main() {
   }
 
   if (allDiffs.length === 0) {
-    stdout.write('== Field-level diff ==\n  No deltas on common transactions after normalization.\n')
+    stdout.write(
+      '== Field-level diff ==\n  No deltas on common transactions after normalization.\n'
+    )
     return
   }
 
-  stdout.write(`== Field-level diff (${allDiffs.length} total, showing first ${args.maxDeltas}) ==\n`)
+  stdout.write(
+    `== Field-level diff (${allDiffs.length} total, showing first ${args.maxDeltas}) ==\n`
+  )
   for (const d of allDiffs.slice(0, args.maxDeltas)) {
     stdout.write(`  ${d.path}\n`)
     stdout.write(`    valora: ${preview(d.valora)}\n`)

--- a/scripts/wri-feed-shape-diff.mjs
+++ b/scripts/wri-feed-shape-diff.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/* eslint-env node */
+// WRI feed shape diff: compare /getWalletTransactions (Valora legacy) against
+// /api/transactions/feed (TuCop backend) for a given wallet, so we know what
+// the flip of WRI_TX_FEED_TUCOP_V1 will change in the user's view before it
+// hits prod.
+//
+// Usage:
+//   node scripts/wri-feed-shape-diff.mjs <address> [--currency=USD|COP] [--include-deferred]
+//
+// The script:
+//   1. Hits both endpoints with the same query params.
+//   2. Normalizes both responses (lowercase all hex, sort tx by hash, fill
+//      missing localAmount as null on the TuCop side).
+//   3. Filters out backend-deferred types (NFT_*, CROSS_CHAIN_SWAP_TRANSACTION,
+//      DEPOSIT / WITHDRAW / CLAIM_REWARD) from BOTH sides by default so the
+//      comparison is apples-to-apples. Pass --include-deferred to keep them.
+//   4. Prints: address counts, missing txs per side, and up to 10 concrete
+//      field-level deltas for txs present on both sides.
+
+import { argv, exit, stdout } from 'node:process'
+
+const VALORA_URL = 'https://api.mainnet.valora.xyz/getWalletTransactions'
+const TUCOP_URL = 'https://tucop-backend-production.up.railway.app/api/transactions/feed'
+
+const INCLUDE_TYPES = [
+  'RECEIVED',
+  'SENT',
+  'NFT_RECEIVED',
+  'NFT_SENT',
+  'SWAP_TRANSACTION',
+  'CROSS_CHAIN_SWAP_TRANSACTION',
+  'APPROVAL',
+  'DEPOSIT',
+  'WITHDRAW',
+  'CLAIM_REWARD',
+].join(',')
+
+const DEFERRED_TYPES = new Set([
+  'NFT_RECEIVED',
+  'NFT_SENT',
+  'CROSS_CHAIN_SWAP_TRANSACTION',
+  'DEPOSIT',
+  'WITHDRAW',
+  'CLAIM_REWARD',
+])
+
+const NETWORK_IDS = 'celo-mainnet'
+
+function parseArgs(rawArgs) {
+  const positional = []
+  const flags = { currency: 'USD', includeDeferred: false, maxDeltas: 10 }
+  for (const arg of rawArgs) {
+    if (arg.startsWith('--currency=')) {
+      flags.currency = arg.slice('--currency='.length).toUpperCase()
+    } else if (arg === '--include-deferred') {
+      flags.includeDeferred = true
+    } else if (arg.startsWith('--max-deltas=')) {
+      flags.maxDeltas = Number(arg.slice('--max-deltas='.length))
+    } else if (arg.startsWith('--')) {
+      throw new Error(`unknown flag ${arg}`)
+    } else {
+      positional.push(arg)
+    }
+  }
+  if (positional.length !== 1) {
+    throw new Error('exactly one positional argument required: <wallet address>')
+  }
+  const [address] = positional
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    throw new Error(`address does not look like an EVM address: ${address}`)
+  }
+  return { address, ...flags }
+}
+
+async function fetchFeed(url, { address, currency }) {
+  const params = new URLSearchParams({
+    address,
+    networkIds: NETWORK_IDS,
+    includeTypes: INCLUDE_TYPES,
+    localCurrencyCode: currency,
+  })
+  const full = `${url}?${params.toString()}`
+  const res = await fetch(full, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`${url} returned ${res.status}: ${await res.text()}`)
+  }
+  return res.json()
+}
+
+// Recursively lowercase every string that looks like a hex identifier.
+// Regex is intentionally broad: anything starting with 0x followed by hex.
+// This normalizes address casing (Valora emits EIP-55 checksummed, TuCop
+// emits lowercase) so a byte-exact diff does not fill with false positives.
+function normalizeHexCase(value) {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') {
+    return /^0x[a-fA-F0-9]+$/.test(value) ? value.toLowerCase() : value
+  }
+  if (Array.isArray(value)) return value.map(normalizeHexCase)
+  if (typeof value === 'object') {
+    const out = {}
+    for (const [k, v] of Object.entries(value)) out[k] = normalizeHexCase(v)
+    return out
+  }
+  return value
+}
+
+// TuCop omits localAmount when the token has no peg match; Valora emits it as
+// null. To keep the diff focused on real deltas, fill missing localAmount with
+// explicit null on any TokenAmount-shaped object we can identify.
+function alignLocalAmountPresence(value) {
+  if (value === null || value === undefined) return value
+  if (Array.isArray(value)) return value.map(alignLocalAmountPresence)
+  if (typeof value === 'object') {
+    const looksLikeTokenAmount =
+      Object.prototype.hasOwnProperty.call(value, 'value') &&
+      Object.prototype.hasOwnProperty.call(value, 'tokenId')
+    const out = {}
+    for (const [k, v] of Object.entries(value)) out[k] = alignLocalAmountPresence(v)
+    if (looksLikeTokenAmount && !Object.prototype.hasOwnProperty.call(out, 'localAmount')) {
+      out.localAmount = null
+    }
+    return out
+  }
+  return value
+}
+
+function filterDeferredTypes(transactions) {
+  return transactions.filter((tx) => !DEFERRED_TYPES.has(tx.type))
+}
+
+// Naive recursive diff. Returns array of { path, valora, tucop } tuples.
+// Not smart about ordering inside arrays: we assume both sides sort tx by hash
+// before diffing, so element-wise comparison is meaningful.
+function deepDiff(a, b, path = '') {
+  const diffs = []
+  if (a === b) return diffs
+  if (a === null || b === null || typeof a !== typeof b) {
+    diffs.push({ path: path || '<root>', valora: a, tucop: b })
+    return diffs
+  }
+  if (typeof a !== 'object') {
+    diffs.push({ path: path || '<root>', valora: a, tucop: b })
+    return diffs
+  }
+  if (Array.isArray(a) !== Array.isArray(b)) {
+    diffs.push({ path: path || '<root>', valora: a, tucop: b })
+    return diffs
+  }
+  if (Array.isArray(a)) {
+    const maxLen = Math.max(a.length, b.length)
+    for (let i = 0; i < maxLen; i += 1) {
+      diffs.push(...deepDiff(a[i], b[i], `${path}[${i}]`))
+    }
+    return diffs
+  }
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+  for (const k of keys) {
+    diffs.push(...deepDiff(a[k], b[k], path ? `${path}.${k}` : k))
+  }
+  return diffs
+}
+
+function preview(value) {
+  if (value === undefined) return '<absent>'
+  if (value === null) return 'null'
+  const s = typeof value === 'string' ? value : JSON.stringify(value)
+  return s.length > 80 ? `${s.slice(0, 77)}...` : s
+}
+
+async function main() {
+  const args = parseArgs(argv.slice(2))
+  stdout.write(`WRI feed shape-diff for ${args.address} (currency=${args.currency})\n`)
+  stdout.write(`  Valora: ${VALORA_URL}\n`)
+  stdout.write(`  TuCop:  ${TUCOP_URL}\n\n`)
+
+  const [valoraRaw, tucopRaw] = await Promise.all([
+    fetchFeed(VALORA_URL, args),
+    fetchFeed(TUCOP_URL, args),
+  ])
+
+  const normalize = (raw) => {
+    const withHex = normalizeHexCase(raw)
+    const withLocalAmount = alignLocalAmountPresence(withHex)
+    const txs = withLocalAmount.transactions ?? []
+    return args.includeDeferred ? txs : filterDeferredTypes(txs)
+  }
+
+  const valoraTxs = normalize(valoraRaw)
+  const tucopTxs = normalize(tucopRaw)
+
+  const valoraByHash = new Map(valoraTxs.map((tx) => [tx.transactionHash, tx]))
+  const tucopByHash = new Map(tucopTxs.map((tx) => [tx.transactionHash, tx]))
+
+  const onlyValora = [...valoraByHash.keys()].filter((h) => !tucopByHash.has(h))
+  const onlyTucop = [...tucopByHash.keys()].filter((h) => !valoraByHash.has(h))
+  const common = [...valoraByHash.keys()].filter((h) => tucopByHash.has(h))
+
+  stdout.write('== Counts ==\n')
+  stdout.write(`  Valora transactions: ${valoraTxs.length}\n`)
+  stdout.write(`  TuCop  transactions: ${tucopTxs.length}\n`)
+  stdout.write(`  Common (by hash):    ${common.length}\n`)
+  stdout.write(`  Only in Valora:      ${onlyValora.length}\n`)
+  stdout.write(`  Only in TuCop:       ${onlyTucop.length}\n\n`)
+
+  if (onlyValora.length > 0) {
+    stdout.write(`== Missing in TuCop (first 5) ==\n`)
+    for (const h of onlyValora.slice(0, 5)) {
+      const tx = valoraByHash.get(h)
+      stdout.write(`  ${h}  type=${tx.type}  block=${tx.block}\n`)
+    }
+    stdout.write('\n')
+  }
+
+  if (onlyTucop.length > 0) {
+    stdout.write(`== Extra in TuCop (first 5) ==\n`)
+    for (const h of onlyTucop.slice(0, 5)) {
+      const tx = tucopByHash.get(h)
+      stdout.write(`  ${h}  type=${tx.type}  block=${tx.block}\n`)
+    }
+    stdout.write('\n')
+  }
+
+  let allDiffs = []
+  for (const h of common) {
+    const diffs = deepDiff(valoraByHash.get(h), tucopByHash.get(h), h)
+    allDiffs = allDiffs.concat(diffs)
+  }
+
+  if (allDiffs.length === 0) {
+    stdout.write('== Field-level diff ==\n  No deltas on common transactions after normalization.\n')
+    return
+  }
+
+  stdout.write(`== Field-level diff (${allDiffs.length} total, showing first ${args.maxDeltas}) ==\n`)
+  for (const d of allDiffs.slice(0, args.maxDeltas)) {
+    stdout.write(`  ${d.path}\n`)
+    stdout.write(`    valora: ${preview(d.valora)}\n`)
+    stdout.write(`    tucop:  ${preview(d.tucop)}\n`)
+  }
+}
+
+main().catch((err) => {
+  stdout.write(`error: ${err.message}\n`)
+  exit(1)
+})

--- a/src/wri/feeAdapterBootstrap/saga.test.ts
+++ b/src/wri/feeAdapterBootstrap/saga.test.ts
@@ -45,6 +45,12 @@ describe('handleAccept', () => {
     jest.clearAllMocks()
   })
 
+  // Redux-saga's `delay` effect resolves via the internal `delayP` function.
+  // expectSaga executes real timers by default, so a 1s sleep would blow past
+  // the 5s test timeout. This provider intercepts every `delayP` call and
+  // resolves instantly, keeping the retry-with-sleep path fast under test.
+  const provideDelay = ({ fn }: { fn: any }, next: any) => (fn.name === 'delayP' ? null : next())
+
   it('marks every candidate started then succeeded for approved + already_approved tokens', async () => {
     jest.mocked(postFeeAdapterBootstrap).mockResolvedValue({
       ok: true,
@@ -153,13 +159,77 @@ describe('handleAccept', () => {
     expect(postFeeAdapterBootstrap).toHaveBeenCalledTimes(2)
   })
 
-  it('marks failed when delegate-relay succeeds but the bootstrap retry still throws 412', async () => {
-    // Edge case: relay says delegated but a stale state read makes the retry
-    // also throw not-delegated. Should mark failed, hide sheet, debounce.
+  it('marks failed when delegate-relay succeeds but both post-delegate retries still throw 412', async () => {
+    // Edge case: relay says delegated but a stale state read makes both
+    // retries also throw not-delegated. After delegate-relay + 1st retry
+    // (412) + 1s sleep + 2nd retry (still 412), give up: mark failed,
+    // hide sheet, debounce.
     jest
       .mocked(postFeeAdapterBootstrap)
       .mockRejectedValueOnce(new BootstrapApiError('not-delegated', 'first 412'))
       .mockRejectedValueOnce(new BootstrapApiError('not-delegated', 'retry still 412'))
+      .mockRejectedValueOnce(new BootstrapApiError('not-delegated', 'second retry still 412'))
+
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC'] }))
+      .provide([
+        { call: provideDelay },
+        [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+        [matchers.call.fn(signAndRelayDelegation), true],
+      ])
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put.actionType(bootstrapFailed.type)
+      .put(bootstrapSheetHidden())
+      .run()
+
+    expect(postFeeAdapterBootstrap).toHaveBeenCalledTimes(3)
+  })
+
+  it('recovers when the first post-delegate retry is 412 but the second one succeeds', async () => {
+    // Forno LB rotation edge case: delegate-relay confirms on-chain, first
+    // bootstrap retry is served by a stale follower and returns 412, then
+    // after a 1s wait the follower has caught up and the second retry
+    // succeeds. Wallet should end in bootstrapSucceeded, not failed.
+    const succeededResponse = {
+      ok: true as const,
+      relayAddress: '0xrelay',
+      results: [
+        {
+          tokenSymbol: 'USDC' as const,
+          tokenAddress: '0xceba9300f2b948710d2653dd7b07f33a8b32118c',
+          adapterAddress: '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+          status: 'approved' as const,
+          txHash: '0xtx-second-retry',
+          alreadyApproved: false,
+        },
+      ],
+    }
+    jest
+      .mocked(postFeeAdapterBootstrap)
+      .mockRejectedValueOnce(new BootstrapApiError('not-delegated', 'first 412'))
+      .mockRejectedValueOnce(new BootstrapApiError('not-delegated', 'stale follower 412'))
+      .mockResolvedValueOnce(succeededResponse)
+
+    await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC'] }))
+      .provide([
+        { call: provideDelay },
+        [matchers.select.selector(walletAddressSelector), MOCK_WALLET],
+        [matchers.call.fn(signAndRelayDelegation), true],
+      ])
+      .put(bootstrapStarted({ adapter: 'USDC' }))
+      .put(bootstrapSucceeded({ adapter: 'USDC' }))
+      .put(bootstrapSheetHidden())
+      .run()
+
+    expect(postFeeAdapterBootstrap).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not do the extra Forno retry when the first retry throws a non-412 error', async () => {
+    // Guard: the extra 1s-sleep retry only kicks in for 'not-delegated'.
+    // If the first retry throws e.g. 500 relay-error, fail immediately.
+    jest
+      .mocked(postFeeAdapterBootstrap)
+      .mockRejectedValueOnce(new BootstrapApiError('not-delegated', 'first 412'))
+      .mockRejectedValueOnce(new BootstrapApiError('relay', 'backend 500'))
 
     await expectSaga(handleAccept, bootstrapAccepted({ candidates: ['USDC'] }))
       .provide([

--- a/src/wri/feeAdapterBootstrap/saga.ts
+++ b/src/wri/feeAdapterBootstrap/saga.ts
@@ -136,6 +136,12 @@ function* applyBootstrapResults(results: AdapterResult[]) {
 // sheet from re-nagging on the next boot.
 const DELEGATE_RELAY_TIMEOUT_MS = 20_000
 
+// If the first bootstrap retry (post delegate-relay) still returns 412, wait
+// this long before trying one more time. Absorbs the rare case where Forno
+// load-balances the wallet's getCode read to a follower that has not yet
+// caught up with the delegate mined a few hundred ms ago.
+const FORNO_PROPAGATION_RETRY_MS = 1_000
+
 // Sign an EIP-7702 authorization for the BatchExecutor and ask the backend's
 // sponsored relay to submit it. Returns true when the relay confirms the EOA
 // is delegated. Kept lean (single attempt, no Retry-After or 502 re-check)
@@ -250,10 +256,25 @@ export function* handleAccept(action: PayloadAction<{ candidates: AdapterSymbol[
           // a plain failure message instead of treating it like another 412.
           throw new Error('delegation-failed: delegate-relay did not delegate')
         }
-        // Single retry. If this also throws (super rare; e.g. relay confirmed
-        // delegated but the wallet's view of state is stale), the outer catch
-        // marks failed and the 24h debounce takes over.
-        response = yield* call(postFeeAdapterBootstrap, walletAddress)
+        // First retry. If this throws 412 too, the most likely cause is a
+        // Forno LB rotation serving a follower slightly behind: the same
+        // getCode singleton the backend used to confirm the delegate can
+        // return stale code for a brief window. Wait 1s and try once more
+        // before giving up. Expected activation: <0.1% of prod attempts.
+        try {
+          response = yield* call(postFeeAdapterBootstrap, walletAddress)
+        } catch (retryErr) {
+          if (retryErr instanceof BootstrapApiError && retryErr.kind === 'not-delegated') {
+            Logger.info(
+              TAG,
+              '412 on first post-delegate retry; waiting 1s for Forno propagation and retrying once more'
+            )
+            yield* delay(FORNO_PROPAGATION_RETRY_MS)
+            response = yield* call(postFeeAdapterBootstrap, walletAddress)
+          } else {
+            throw retryErr
+          }
+        }
       } else {
         throw firstErr
       }


### PR DESCRIPTION
## Summary

Rollout prep for `WRI_TX_FEED_TUCOP_V1` and hardening on top of PR #236 based on backend's latest guidance (2026-07-05).

**Retry robustness** (commit 1): backend's `/delegate-relay` does an internal `getCode` poll before returning `delegated`, so the same Forno singleton the wallet uses for the follow-up `/fee-adapter-bootstrap` should see the effect. But if Forno rotates its LB to a follower slightly behind, the retry can still get 412 even though the delegate is signed and mined. Backend estimated this at < 0.1% in prod and recommended a second retry with a 1s sleep. This adds `FORNO_PROPAGATION_RETRY_MS = 1_000` and wraps the post-delegate retry accordingly. If the second attempt also fails, the saga falls through to the outer catch and the 24h debounce takes over.

**Shape-diff runner** (commit 2): standalone Node script to compare `/getWalletTransactions` (Valora legacy) against `/api/transactions/feed` (tucop-backend) on the same wallet, so we can catch un-announced diffs during the rollout window before flipping the gate in prod. Normalizes hex casing + `localAmount` presence + filters deferred tx types by default.

## Changes

- `src/wri/feeAdapterBootstrap/saga.ts`: add `FORNO_PROPAGATION_RETRY_MS = 1_000`, wrap the post-delegate retry so a 412 triggers one more attempt after a 1s sleep.
- `src/wri/feeAdapterBootstrap/saga.test.ts`: add `provideDelay` matcher so `expectSaga` resolves `delayP` instantly under test; modify the existing "both retries 412" case to expect 3 calls instead of 2; add "recovers on second retry" happy path and "does not do extra retry on non-412" guard.
- `scripts/wri-feed-shape-diff.mjs`: new standalone Node script for feed shape-diff against a wallet address.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn jest src/wri/feeAdapterBootstrap/saga.test.ts` -> 14/14 passed
- [x] `yarn jest src/transactions/feed src/wri` -> 168 passed, 14 skipped, 0 failed
- [x] `yarn lint` on modified files -> clean
- [x] `node --check scripts/wri-feed-shape-diff.mjs` -> syntax ok
- [ ] Run `scripts/wri-feed-shape-diff.mjs` against 3 internal test wallets before the rollout window opens.