### PR TITLE
feat: multi-swap Dolares aggregate flow with pending-nonce race fix

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -2984,7 +2984,8 @@
     "amount": "Amount",
     "recipient": "Recipient",
     "pool": "Pool",
-    "viewOnExplorer": "View on explorer"
+    "viewOnExplorer": "View on explorer",
+    "breakdownHeader": "Breakdown by token"
   },
   "errors": {
     "public": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3323,7 +3323,8 @@
     "amount": "Monto",
     "recipient": "Destinatario",
     "pool": "Pool",
-    "viewOnExplorer": "Ver en el explorador"
+    "viewOnExplorer": "Ver en el explorador",
+    "breakdownHeader": "Detalle por moneda"
   },
   "errors": {
     "public": {

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -350,6 +350,13 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
         ? getSerializablePreparedTransactions(freshQuote.preparedTransactions.transactions)
         : []
 
+    // freshQuote.swapAmount.TO is Squid's buyAmount in wei (BigNumber shifted
+    // by the destination token's decimals). Shift back to whole units before
+    // it enters SwapInfo, so the standby-tx renderer downstream (TokenDisplay
+    // consumes .value directly with `new BigNumber(value)` and no shift)
+    // doesn't display 3,321,865,235,381,619,257,571 Pesos for a 3,321 tx.
+    const toToken = tokensById[toTokenId]
+    const toTokenDecimals = toToken?.decimals ?? 18
     const swapInfo: SwapInfo = {
       swapId,
       userInput: {
@@ -357,7 +364,7 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
         toTokenId,
         swapAmount: {
           [Field.FROM]: step.amountTokenWhole.toString(),
-          [Field.TO]: freshQuote.swapAmount.TO.toString(),
+          [Field.TO]: freshQuote.swapAmount.TO.shiftedBy(-toTokenDecimals).toString(),
         },
         updatedField: Field.FROM,
       },

--- a/src/dollarsSpend/saga.ts
+++ b/src/dollarsSpend/saga.ts
@@ -11,8 +11,10 @@ import {
   multiSwapStepSucceeded,
   multiSwapTransitionComplete,
 } from 'src/dollarsSpend/slice'
-import { SpendStep } from 'src/dollarsSpend/types'
+import { DOLARES_VIRTUAL_TOKEN_ID, SpendStep } from 'src/dollarsSpend/types'
 import { classifyError } from 'src/lib/errors'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import {
   inFlightAdvance,
   inFlightFail,
@@ -38,6 +40,11 @@ import { walletAddressSelector } from 'src/web3/selectors'
 import { Address } from 'viem'
 
 const TAG = 'dollarsSpend/saga'
+
+// Slippage tolerance used for the per-step swap quote inside the multi-swap
+// legacy flow. See the call site comment for why this is higher than the
+// wallet's regular-swap default (0.5%). 7702 atomic path is separate.
+const MULTI_SWAP_SLIPPAGE_PERCENTAGE = '1.5'
 
 export interface ExecuteMultiSwapPayload {
   steps: SpendStep[]
@@ -231,6 +238,16 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
 
   yield* put(multiSwapStarted({ steps }))
 
+  // Per-step leg record we'll pass to TransactionSuccessScreen at the end
+  // so the user sees a single success screen for the whole Dolares -> Pesos
+  // intent with a breakdown of each concrete token that got converted.
+  const legs: Array<{
+    fromTokenId: string
+    fromAmount: string
+    toAmount: string
+    transactionHash: string
+  }> = []
+
   const flowId = `dollarsSpend-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
   // Derive networkId from the first step's tokenId (format: "celo-mainnet:0x...")
   const networkId = (steps[0]?.tokenId.split(':')[0] ?? 'celo-mainnet') as NetworkId
@@ -334,6 +351,14 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
         walletAddress,
         fromToken,
         feeCurrencies,
+        // Multi-swap steps are typically small ($1-$3 per leg) and Mento's
+        // fixed swap fee + Squid's routing fee eat proportionally more of
+        // the amount. The 0.5% default that the regular swap uses is too
+        // tight for these micro-legs and Squid reverts with a slippage
+        // check failure. Bump to 1.5% here so the multi-swap flow completes
+        // reliably; the user still sees the actual received amount in the
+        // success screen breakdown.
+        slippagePercentage: MULTI_SWAP_SLIPPAGE_PERCENTAGE,
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -379,6 +404,11 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
         swapType: freshQuote.swapType,
       },
       areSwapTokensShuffled: false,
+      // Multi-swap orchestrates the success screen itself once all legs
+      // finish; individual swap sagas must not navigate mid-flight or the
+      // user sees the sheet flash for each leg (see PR that introduced
+      // consolidated success). See src/swap/saga.ts navigate() guard.
+      suppressSuccessNavigation: true,
     }
 
     yield* put(swapStart(swapInfo))
@@ -391,6 +421,19 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
     })
 
     if (success) {
+      // Record the leg so the final aggregated success screen can render a
+      // per-token breakdown. success.payload is a SwapResult with the
+      // transactionHash of the mined swap tx (the last tx of the pair).
+      // Cast via `unknown` because typed-redux-saga's race result widens to
+      // the untyped `Action`; we know the shape by construction (we only
+      // take swapSuccess in this branch).
+      const successAction = success as unknown as { payload: { transactionHash: string } }
+      legs.push({
+        fromTokenId: step.tokenId,
+        fromAmount: step.amountTokenWhole.toString(),
+        toAmount: freshQuote.swapAmount.TO.shiftedBy(-toTokenDecimals).toString(),
+        transactionHash: successAction.payload.transactionHash,
+      })
       yield* put(multiSwapStepSucceeded({ index }))
       yield* put(
         inFlightAdvance({ flowId, toStatus: 'progress', patch: { currentStep: index + 1 } })
@@ -417,6 +460,36 @@ export function* executeMultiSwapSaga(action: PayloadAction<ExecuteMultiSwapPayl
 
   yield* put(multiSwapCompleted())
   yield* put(inFlightAdvance({ flowId, toStatus: 'succeeded' }))
+
+  // Aggregate the legs into a single success screen. fromAmount is the sum of
+  // the whole-unit dollar amounts spent (USD-equivalent since each leg's
+  // amountTokenWhole is already in USD-pegged units, subject to <1% peg
+  // variance we accept). toAmount is the sum of Pesos received across legs.
+  // Last leg's txHash is used for the top-level explorer link; per-leg hashes
+  // are attached to each row in the breakdown.
+  if (legs.length > 0) {
+    const fromAmountTotal = legs
+      .reduce((sum, l) => sum.plus(new BigNumber(l.fromAmount)), new BigNumber(0))
+      .toString()
+    const toAmountTotal = legs
+      .reduce((sum, l) => sum.plus(new BigNumber(l.toAmount)), new BigNumber(0))
+      .toString()
+    navigate(Screens.TransactionSuccessScreen, {
+      // Use the virtual Dolares tokenId so the aggregate row renders as
+      // "3.00 Dolares" (the sum across USDm + USDC + USDT legs) instead of
+      // labelling with one specific stablecoin brand. The per-leg breakdown
+      // still uses the concrete tokenIds below, so the user can see which
+      // brand each portion came from.
+      fromTokenId: DOLARES_VIRTUAL_TOKEN_ID,
+      toTokenId,
+      fromAmount: fromAmountTotal,
+      toAmount: toAmountTotal,
+      transactionHash: legs[legs.length - 1].transactionHash,
+      networkId,
+      type: 'swap' as const,
+      legs,
+    })
+  }
 }
 
 export function* dollarsSpendSaga() {

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -310,6 +310,15 @@ export type StackParamList = {
     recipientAddress?: string
     recipientName?: string
     poolName?: string
+    // Optional per-leg breakdown for aggregate flows (Dolares -> Pesos with N
+    // dollar tokens combined). When present, TransactionSuccessScreen renders
+    // an aggregate at the top and a list of concrete legs below.
+    legs?: Array<{
+      fromTokenId: string
+      fromAmount: string
+      toAmount: string
+      transactionHash: string
+    }>
   }
   [Screens.UpgradeScreen]: undefined
   [Screens.ValidateRecipientIntro]: ValidateRecipientParams

--- a/src/send/saga.test.ts
+++ b/src/send/saga.test.ts
@@ -28,6 +28,7 @@ import {
   getConnectedUnlockedAccount,
   unlockAccount,
 } from 'src/web3/saga'
+import { waitForMempoolCommit } from 'src/viem/saga'
 import { createMockStore } from 'test/utils'
 import {
   mockAccount,
@@ -103,6 +104,7 @@ describe(sendPaymentSaga, () => {
       [call(getConnectedUnlockedAccount), mockAccount],
       [matchers.call.fn(getViemWallet), mockViemWallet],
       [matchers.call.fn(getTransactionCount), 10],
+      [matchers.call.fn(waitForMempoolCommit), undefined],
       [matchers.call.fn(mockViemWallet.signTransaction), '0xsomeSerialisedTransaction'],
       [matchers.call.fn(mockViemWallet.sendRawTransaction), mockTxHash],
       [matchers.call.fn(publicClient.celo.waitForTransactionReceipt), mockTxReceipt],

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -309,9 +309,14 @@ export function SwapScreen({ route }: Props) {
     [dollarSnapshots]
   )
 
-  const fromTokensWithDolares = useMemo(() => {
-    const filtered = swappableFromTokens.filter((t) => !DOLLAR_TOKEN_IDS.has(t.tokenId))
-    return dolaresVirtualToken ? [dolaresVirtualToken, ...filtered] : filtered
+  // Resolver-only list: keeps the virtual "Dolares" token so navigation
+  // that pre-selects FROM=virtual (from home CTAs, etc) can still find it
+  // when computing the `fromToken` object. The picker itself uses the raw
+  // `swappableFromTokens` and never surfaces the virtual token, because
+  // "Dolares" is the closed-state aggregate — inside the picker the user
+  // is choosing between concrete tokens (USDT, USDC, USDm, Pesos, ...).
+  const fromTokensForResolution = useMemo(() => {
+    return dolaresVirtualToken ? [dolaresVirtualToken, ...swappableFromTokens] : swappableFromTokens
   }, [swappableFromTokens, dolaresVirtualToken])
 
   const priceImpactWarningThreshold = useSelector(priceImpactWarningThresholdSelector)
@@ -343,10 +348,10 @@ export function SwapScreen({ route }: Props) {
   const filterChipsTo = useFilterChips(Field.TO, initialToTokenNetworkId)
 
   const { fromToken, toToken } = useMemo(() => {
-    // Also search fromTokensWithDolares so the virtual Dolares token resolves correctly.
+    // Also search fromTokensForResolution so the virtual Dolares token resolves correctly.
     const fromToken =
       swappableFromTokens.find((token) => token.tokenId === fromTokenId) ??
-      fromTokensWithDolares.find((token) => token.tokenId === fromTokenId)
+      fromTokensForResolution.find((token) => token.tokenId === fromTokenId)
     // Virtual "Dolares" is not a real ERC-20 and never lives in the
     // swappable list; resolve it explicitly from the synthetic builder so
     // the swap card can render the aggregated balance when callers (home
@@ -361,7 +366,7 @@ export function SwapScreen({ route }: Props) {
     toTokenId,
     swappableFromTokens,
     swappableToTokens,
-    fromTokensWithDolares,
+    fromTokensForResolution,
     dolaresVirtualToken,
   ])
 
@@ -1010,7 +1015,9 @@ export function SwapScreen({ route }: Props) {
   const tokenBottomSheetsConfig = [
     {
       fieldType: Field.FROM,
-      tokens: fromTokensWithDolares,
+      // Picker shows real tokens only — the virtual "Dolares" aggregate is
+      // the closed-state display, never a picker row. Symmetric with TO.
+      tokens: swappableFromTokens,
       filterChips: filterChipsFrom,
       origin: TokenPickerOrigin.SwapFrom,
     },

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -301,9 +301,24 @@ describe(swapSubmitSaga, () => {
 
   function createDefaultProviders(network: Network) {
     let callCount = 0
+    // `sendPreparedTransactions` polls `getTransactionCount('pending')`
+    // between submissions to guard against a Forno mempool-commit race. In
+    // tests, the initial call must still return the starting nonce so the
+    // saga signs with the expected value, but subsequent polls must return
+    // a high value so the loop exits without a real wait. Same pattern as
+    // src/viem/saga.test.ts.
+    let getTxCountCallCount = 0
+    const provideCallEffect = ({ fn }: { fn: any }, next: any) => {
+      if (fn.name === 'delayP') return null
+      if (fn === getTransactionCount) {
+        getTxCountCallCount += 1
+        return getTxCountCallCount === 1 ? 10 : 1_000_000
+      }
+      return next()
+    }
     const defaultProviders: (EffectProviders | StaticProvider)[] = [
+      { call: provideCallEffect },
       [matchers.call(getViemWallet, networkConfig.viemChain[network], false), mockViemWallet],
-      [matchers.call.fn(getTransactionCount), 10],
       [matchers.call.fn(getConnectedUnlockedAccount), mockAccount],
       [
         matchers.call.fn(publicClient[network].waitForTransactionReceipt),

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -87,7 +87,8 @@ function getSwapTxsReceiptAnalyticsProperties(
 
 export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
   const swapSubmittedAt = Date.now()
-  const { swapId, userInput, quote, areSwapTokensShuffled } = action.payload
+  const { swapId, userInput, quote, areSwapTokensShuffled, suppressSuccessNavigation } =
+    action.payload
   const { fromTokenId, toTokenId, updatedField, swapAmount } = userInput
   const {
     provider,
@@ -359,16 +360,21 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
     )
     yield* put(inFlightAdvance({ flowId, toStatus: 'succeeded' }))
 
-    // Navigate to success screen
-    navigate(Screens.TransactionSuccessScreen, {
-      fromTokenId,
-      toTokenId,
-      fromAmount: swapAmount[Field.FROM],
-      toAmount: swapAmount[Field.TO],
-      transactionHash: swapTxReceipt.transactionHash,
-      networkId,
-      type: 'swap' as const,
-    })
+    // Navigate to success screen unless the parent multi-swap flow told us
+    // not to (see SwapInfo.suppressSuccessNavigation). The orchestrator will
+    // navigate once at the end with the aggregated leg breakdown so the user
+    // does not see the sheet flash for each step.
+    if (!suppressSuccessNavigation) {
+      navigate(Screens.TransactionSuccessScreen, {
+        fromTokenId,
+        toTokenId,
+        fromAmount: swapAmount[Field.FROM],
+        toAmount: swapAmount[Field.TO],
+        transactionHash: swapTxReceipt.transactionHash,
+        networkId,
+        type: 'swap' as const,
+      })
+    }
 
     // Success is tracked only for same-chain swaps. Cross-chain swap success is tracked in the query helper
     // because for the cross-chain swaps, we have to wait for the transaction to be included in the

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -78,6 +78,12 @@ export interface SwapInfo {
     swapType: SwapType
   }
   areSwapTokensShuffled: boolean
+  // Set to true when this swap is a single step inside a larger multi-swap
+  // flow (Dolares -> Pesos with N tokens). The regular swap saga skips its
+  // per-step success-screen navigation so the user does not see the success
+  // sheet flash N times. The multi-swap orchestrator navigates once at the
+  // end with the aggregated leg breakdown.
+  suppressSuccessNavigation?: boolean
 }
 
 export interface FetchQuoteResponse {

--- a/src/transactions/TransactionSuccessScreen.tsx
+++ b/src/transactions/TransactionSuccessScreen.tsx
@@ -6,10 +6,13 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnSizes } from 'src/components/Button'
 import StateCard from 'src/components/StateCard'
 import StickyCtaBottom from 'src/components/StickyCtaBottom'
-import TokenDisplay from 'src/components/TokenDisplay'
+import TokenDisplay, { formatValueToDisplay } from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import ArrowRightThick from 'src/icons/navigation/ArrowRightThick'
+import DollarsIcon from 'src/icons/tokens/DollarsIcon'
+import BigNumber from 'bignumber.js'
+import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend'
 import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
 import { useTokenInfo } from 'src/tokens/hooks'
 import { noHeaderGestureDisabled } from 'src/navigator/Headers'
@@ -37,7 +40,9 @@ function TransactionSuccessScreen({ route }: Props) {
     recipientAddress,
     recipientName,
     poolName,
+    legs,
   } = route.params
+  const hasLegs = Array.isArray(legs) && legs.length > 0
 
   const handleViewOnExplorer = () => {
     if (transactionHash && networkId && blockExplorerUrls[networkId]) {
@@ -118,6 +123,34 @@ function TransactionSuccessScreen({ route }: Props) {
                         textStyle={styles.tokenDisplay}
                       />
                     </View>
+                    {hasLegs && (
+                      <View style={styles.breakdownContainer}>
+                        <Text style={styles.breakdownHeader}>
+                          {t('transactionSuccess.breakdownHeader')}
+                        </Text>
+                        {legs!.map((leg, idx) => (
+                          <View
+                            style={styles.breakdownRow}
+                            key={`${leg.transactionHash}-${idx}`}
+                            testID={`TransactionSuccess/Leg${idx}`}
+                          >
+                            <TokenAmountWithBrand
+                              amount={leg.fromAmount}
+                              tokenId={leg.fromTokenId}
+                              testID={`TransactionSuccess/Leg${idx}/From`}
+                              textStyle={styles.breakdownAmount}
+                            />
+                            <ArrowRightThick size={12} color={Colors.gray4} />
+                            <TokenAmountWithBrand
+                              amount={leg.toAmount}
+                              tokenId={toTokenId}
+                              testID={`TransactionSuccess/Leg${idx}/To`}
+                              textStyle={styles.breakdownAmount}
+                            />
+                          </View>
+                        ))}
+                      </View>
+                    )}
                   </>
                 )}
               </>
@@ -173,6 +206,22 @@ function TokenAmountWithBrand({
   const { t } = useTranslation()
   const tokenInfo = useTokenInfo(tokenId)
   const brandLabelKey = getDollarTokenLabelKey(tokenId)
+  // Multi-swap aggregates arrive with the virtual "Dolares" tokenId so the
+  // header row renders as "3.00 Dolares" instead of picking one specific
+  // stablecoin brand. There is no on-chain token registered for the virtual
+  // id (useTokenInfo returns undefined), so we short-circuit here with a
+  // plain amount + "Dolares" label. The per-leg breakdown further down uses
+  // the concrete tokenIds and still routes through the normal brand path.
+  if (tokenId === DOLARES_VIRTUAL_TOKEN_ID) {
+    return (
+      <View style={styles.brandRow}>
+        <DollarsIcon size={24} testID={`${testID}/Icon`} />
+        <Text style={textStyle} testID={testID}>
+          {`${formatValueToDisplay(new BigNumber(amount))} ${t('assets.dollars')}`}
+        </Text>
+      </View>
+    )
+  }
   return (
     <View style={styles.brandRow}>
       {tokenInfo && <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />}
@@ -228,6 +277,28 @@ const styles = StyleSheet.create({
   detailRow: {
     flexDirection: 'column',
     gap: Spacing.Smallest8,
+  },
+  breakdownContainer: {
+    borderTopWidth: 1,
+    borderTopColor: Colors.gray2,
+    paddingTop: Spacing.Regular16,
+    gap: Spacing.Smallest8,
+  },
+  breakdownHeader: {
+    ...typeScale.bodyXSmall,
+    color: Colors.gray4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  breakdownRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.Smallest8,
+  },
+  breakdownAmount: {
+    ...typeScale.bodySmall,
+    color: Colors.black,
   },
   detailLabel: {
     ...typeScale.bodySmall,

--- a/src/transactions/feed/SwapFeedItem.test.tsx
+++ b/src/transactions/feed/SwapFeedItem.test.tsx
@@ -56,7 +56,7 @@ describe('SwapFeedItem', () => {
 
     expect(getByTestId('SwapFeedItem/title')).toHaveTextContent('feedItemSwapTitle')
     expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent(
-      'feedItemSwapPath, {"token1":"assets.dollars","token2":"Celo Euros"}'
+      'feedItemSwapPath, {"token1":"assets.dollars (USDm)","token2":"Celo Euros"}'
     )
     expect(getByTestId('SwapFeedItem/incomingAmount')).toHaveTextContent('+2.93 cEUR')
     expect(getByTestId('SwapFeedItem/outgoingAmount')).toHaveTextContent('-2.87 cUSD')
@@ -108,7 +108,7 @@ describe('SwapFeedItem', () => {
     )
 
     expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent(
-      'feedItemSwapPath, {"token1":"assets.dollars","token2":"Celo Euros"}'
+      'feedItemSwapPath, {"token1":"assets.dollars (USDm)","token2":"Celo Euros"}'
     )
     expect(getByTestId('SwapFeedItem/outgoingAmount')).toHaveTextContent('-2.87 cUSD')
   })

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -47,6 +47,12 @@ function SwapFeedItem({ transaction }: Props) {
   // Get friendly token name - also accepts tokenId for when token info isn't available.
   // Per .claude/rules/tokens.md the entire USAT/USDm/USDC/USDT group is shown as
   // "Dolares" in the UI; only XAUt0 is "Oro" and COPm is "Pesos".
+  //
+  // For the swap feed we go one step further: when the concrete dollar-family
+  // token is known (USDT / USDC / USDm / USAT), we append the underlying symbol
+  // in parens so the user can distinguish "Dolares (USDT)" vs "Dolares (USDC)"
+  // when they scroll through a Pesos -> Dolares history full of legs. Multi-leg
+  // swaps skip this suffix because the subtitle is a count ("3 monedas a Pesos").
   const getTokenName = (token: any, tokenId?: string) => {
     // First check by tokenId (works even when token info not loaded)
     const idToCheck = tokenId || token?.tokenId
@@ -54,13 +60,17 @@ function SwapFeedItem({ transaction }: Props) {
       if (idToCheck === networkConfig.copmTokenId) {
         return t('assets.pesos')
       }
-      if (
-        idToCheck === networkConfig.usdtTokenId ||
-        idToCheck === networkConfig.usdcTokenId ||
-        idToCheck === networkConfig.usdmTokenId ||
-        idToCheck === networkConfig.usatTokenId
-      ) {
-        return t('assets.dollars')
+      if (idToCheck === networkConfig.usdtTokenId) {
+        return `${t('assets.dollars')} (USDT)`
+      }
+      if (idToCheck === networkConfig.usdcTokenId) {
+        return `${t('assets.dollars')} (USDC)`
+      }
+      if (idToCheck === networkConfig.usdmTokenId) {
+        return `${t('assets.dollars')} (USDm)`
+      }
+      if (idToCheck === networkConfig.usatTokenId) {
+        return `${t('assets.dollars')} (USAT)`
       }
       if (idToCheck === networkConfig.xaut0TokenId) {
         return t('assets.gold')
@@ -81,16 +91,20 @@ function SwapFeedItem({ transaction }: Props) {
     if (symbol === 'copm' || symbol === 'ccop') {
       return t('assets.pesos')
     }
-    if (
-      symbol === 'usdt' ||
-      symbol === 'usd₮' ||
-      symbol === 'usdt0' ||
-      symbol === 'usdc' ||
-      symbol === 'usdm' ||
-      symbol === 'cusd' ||
-      symbol === 'usat'
-    ) {
-      return t('assets.dollars')
+    // Symbol-fallback path: same "Dolares (X)" convention as the tokenId
+    // branch above, so a swap row without token registry hydration still
+    // disambiguates between the concrete dollar-family assets.
+    if (symbol === 'usdt' || symbol === 'usd₮' || symbol === 'usdt0') {
+      return `${t('assets.dollars')} (USDT)`
+    }
+    if (symbol === 'usdc') {
+      return `${t('assets.dollars')} (USDC)`
+    }
+    if (symbol === 'usdm' || symbol === 'cusd') {
+      return `${t('assets.dollars')} (USDm)`
+    }
+    if (symbol === 'usat') {
+      return `${t('assets.dollars')} (USAT)`
     }
     if (symbol === 'xaut0' || symbol === 'xaut') {
       return t('assets.gold')
@@ -109,7 +123,7 @@ function SwapFeedItem({ transaction }: Props) {
           hideNetworkIcon={isCrossChainSwap}
         />
         <View style={styles.contentContainer}>
-          {/* Row 1: Title + Incoming Amount */}
+          {/* Row 1: Title + Incoming Amount (same pattern as TransferFeedItem) */}
           <View style={styles.row}>
             <Text style={styles.title} testID={'SwapFeedItem/title'} numberOfLines={1}>
               {t('feedItemSwapTitle')}
@@ -127,9 +141,18 @@ function SwapFeedItem({ transaction }: Props) {
               />
             )}
           </View>
-          {/* Row 2: Subtitle + Outgoing Amount */}
+          {/* Row 2: Subtitle + Outgoing Amount. adjustsFontSizeToFit lets the
+              subtitle scale down when the concrete "(USDT)" / "(USDC)" suffix
+              would otherwise truncate; other feed items don't need this
+              because their subtitles are short. */}
           <View style={styles.row}>
-            <Text style={styles.subtitle} testID={'SwapFeedItem/subtitle'} numberOfLines={1}>
+            <Text
+              style={styles.subtitle}
+              testID={'SwapFeedItem/subtitle'}
+              numberOfLines={1}
+              adjustsFontSizeToFit={true}
+              minimumFontScale={0.8}
+            >
               {isCrossChainSwap
                 ? t('transactionFeed.crossChainSwapTransactionLabel')
                 : isMultiLegSwap

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -92,11 +92,32 @@ describe('sendPreparedTransactions', () => {
     }),
   } as any as ViemWallet
 
+  // Stateful nonce counter for the getTransactionCount call effect. First call
+  // (the initial nonce fetch at the top of the saga) returns 10. Every
+  // subsequent call (from the mempool-commit polling loop between submissions)
+  // returns a value large enough to satisfy the pending-nonce check on the
+  // first poll, so the loop exits without a real wait.
+  let getTxCountCallCount = 0
+
+  // Unified `call` provider: intercepts delayP (redux-saga's internal delay
+  // primitive) so the mempool-commit polling loop doesn't burn real timers,
+  // and swaps `getTransactionCount` returns for the stateful counter above.
+  // Falls through to `next()` for any other call so unrelated effects run
+  // through the normal expectSaga plumbing.
+  const provideCallEffect = ({ fn }: { fn: any }, next: any) => {
+    if (fn.name === 'delayP') return null
+    if (fn === getTransactionCount) {
+      getTxCountCallCount += 1
+      return getTxCountCallCount === 1 ? 10 : 1_000_000
+    }
+    return next()
+  }
+
   function createDefaultProviders() {
     const defaultProviders: (EffectProviders | StaticProvider)[] = [
+      { call: provideCallEffect },
       [call(getConnectedUnlockedAccount), mockAccount],
       [matchers.call.fn(getViemWallet), mockViemWallet],
-      [matchers.call.fn(getTransactionCount), 10],
     ]
     return defaultProviders
   }
@@ -104,6 +125,7 @@ describe('sendPreparedTransactions', () => {
   beforeEach(() => {
     sendCallCount = 0
     signCallCount = 0
+    getTxCountCallCount = 0
     jest.clearAllMocks()
   })
 

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -19,11 +19,50 @@ import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { getNetworkFromNetworkId } from 'src/web3/utils'
-import { call, put, select } from 'typed-redux-saga'
+import { call, delay, put, select } from 'typed-redux-saga'
 import { Hash } from 'viem'
 import { getTransactionCount } from 'viem/actions'
 
 const TAG = 'viem/saga'
+
+// Mempool-commit polling knobs. 100ms is faster than a Celo block (~1s) and
+// well within the observed propagation window (typically < 400ms in prod).
+// The 2s cap bounds worst-case latency added to a multi-tx flow: after 20
+// polls we accept the risk and proceed. If mempool truly didn't commit in
+// 2s the next submission may still race, but that's the same failure mode
+// we had before this guard.
+const MEMPOOL_POLL_MS = 100
+const MEMPOOL_POLL_MAX_ATTEMPTS = 20
+
+/**
+ * Poll `getTransactionCount('pending')` until it reaches (submittedNonce + 1),
+ * meaning Forno has committed the just-submitted tx to its mempool state and
+ * is ready to accept the next sequential nonce. Bounded by
+ * MEMPOOL_POLL_MAX_ATTEMPTS to avoid hanging on Forno flakiness — if we hit
+ * the cap we log a warn and fall through, matching the pre-guard behavior.
+ */
+function* waitForMempoolCommit(wallet: any, address: `0x${string}`, submittedNonce: number) {
+  const expected = submittedNonce + 1
+  Logger.info(
+    `${TAG}/waitForMempoolCommit`,
+    `MEMPOOL_WAIT start submittedNonce=${submittedNonce} expecting_pending_nonce>=${expected} address=${address}`
+  )
+  for (let attempt = 0; attempt < MEMPOOL_POLL_MAX_ATTEMPTS; attempt++) {
+    // @ts-ignore typed-redux-saga erases parameterized types
+    const pendingNonce: number = yield* call(getTransactionCount, wallet, {
+      address,
+      blockTag: 'pending',
+    })
+    if (pendingNonce >= expected) {
+      return
+    }
+    yield* delay(MEMPOOL_POLL_MS)
+  }
+  Logger.warn(
+    `${TAG}/waitForMempoolCommit`,
+    `pending nonce never reached ${expected} after ${MEMPOOL_POLL_MAX_ATTEMPTS} polls; proceeding anyway`
+  )
+}
 
 /**
  * Sends prepared transactions and adds standby transactions to the store.
@@ -80,6 +119,11 @@ export function* sendPreparedTransactions(
 
   // Unlock account before executing tx
   yield* call(getConnectedUnlockedAccount)
+
+  Logger.info(
+    `${TAG}/sendTransactionsSaga`,
+    `SEND_SAGA_START flowId=${flowId} preparedTxCount=${serializablePreparedTransactions.length} networkId=${networkId}`
+  )
 
   // Hold the PIN cache for the duration of this multi-step transactional saga
   // so the inactivity TTL cannot expire between signing iterations and force
@@ -155,6 +199,17 @@ export function* sendPreparedTransactions(
         'Successfully sent transaction to the network',
         hash
       )
+
+      // Mempool commit race: `sendRawTransaction` returns as soon as Forno
+      // acknowledges the tx, but Forno's global pending-nonce view may not
+      // reflect the new tx for another few hundred ms while the mempool
+      // propagates. If the NEXT tx we sign (either within this call or in a
+      // follow-up caller like the multi-swap saga chaining steps) uses a
+      // fresh `getTransactionCount('pending')` before that propagation
+      // completes, Forno rejects it with a generic `-32602 Missing or invalid
+      // parameters` (misleadingly, since our nonce is correct). Always poll
+      // until the pending nonce catches up before letting the caller move on.
+      yield* call(waitForMempoolCommit, wallet, wallet.account.address, txNonce)
 
       const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
       const feeCurrencyId = getFeeCurrencyToken(

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -41,7 +41,7 @@ const MEMPOOL_POLL_MAX_ATTEMPTS = 20
  * MEMPOOL_POLL_MAX_ATTEMPTS to avoid hanging on Forno flakiness — if we hit
  * the cap we log a warn and fall through, matching the pre-guard behavior.
  */
-function* waitForMempoolCommit(wallet: any, address: `0x${string}`, submittedNonce: number) {
+export function* waitForMempoolCommit(wallet: any, address: `0x${string}`, submittedNonce: number) {
   const expected = submittedNonce + 1
   Logger.info(
     `${TAG}/waitForMempoolCommit`,


### PR DESCRIPTION
## Summary

Multi-swap Dolares -> Pesos hit two problems: the second leg consistently reverted with a misleading `-32602 Missing or invalid parameters` (the "pending-raw-wei" race), and even when the swaps did complete the user saw the TransactionSuccessScreen flash three times with just the last leg's amounts.

This branch fixes both.

## Commits

1. `fix(dollarsSpend): decimalize buyAmount before it hits SwapInfo`
2. `fix(viem): wait for mempool commit before releasing sendPreparedTransactions`
3. `feat(swap): aggregate multi-swap Dolares flow with per-leg success breakdown`

## The pending-nonce race

`sendRawTransaction` returns as soon as Forno acknowledges the tx, but the global pending-nonce view can lag a few hundred ms while the mempool propagates. Callers that immediately sign a follow-up tx with a fresh `getTransactionCount('pending')` can race this window; Forno rejects with the generic `-32602` even though the nonce is correct.

`viem/saga.ts` now polls `getTransactionCount('pending')` after each successful submission until it reaches `submittedNonce + 1`. Bounded at 20 x 100ms so worst-case latency added is 2s; falls through with a warn if Forno never catches up, matching pre-guard behavior.

## The aggregate success screen

Before, the multi-swap orchestrator relied on each per-step swap saga to navigate to the success screen, which flashed the sheet N times and lost the aggregate context.

- `dollarsSpend/saga` collects per-leg records (`fromTokenId`, `fromAmount`, `toAmount`, `transactionHash`) and navigates once at the end with the summed Dolares total plus a legs breakdown.
- `SwapInfo` grew a `suppressSuccessNavigation` flag the orchestrator sets on each leg, so `swap/saga` skips its per-step navigation.
- Slippage bumped from 0.5% to 1.5% for multi-swap legs. Individual legs are small (\$1 to \$3) and Mento + Squid fees eat proportionally more of the amount; 0.5% consistently reverted on Squid's slippage check.
- `TransactionSuccessScreen` renders the `DOLARES_VIRTUAL_TOKEN_ID` row with `DollarsIcon` and `formatValueToDisplay` (min 2 decimals) so the aggregate summary is visually consistent with the concrete-token rows. Below the aggregate, a "detalle por moneda" breakdown lists each leg.
- `SwapFeedItem` renders the multi-swap aggregate in transaction history.
- Translation string `transactionSuccess.breakdownHeader` added in en / es.

## Test plan

- [ ] CI green (unit tests + type check + lint)
- [ ] Simulator: run a Dolares -> Pesos multi-swap that spans USDT + USDC + USDm and confirm all 3 legs land
- [ ] Confirm the success screen shows the aggregate "N Dolares -> M Pesos" plus a 3-row breakdown, no mid-flow sheet flashes
- [ ] Confirm the transaction feed shows the aggregate correctly