### PR TITLE
fix(wri/7702): standby subtitle shows 'N monedas' for multi-token batches

### DIFF
--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -466,6 +466,20 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
       // Value convention: whole tokens with decimal (Valora-compatible). The
       // wallet's UI assumes whole-token strings; emitting wei here would
       // display amounts 10^decimals too large.
+      //
+      // fromTokenAmounts mirrors the TuCop indexer shape for atomic 7702
+      // batches: one entry per leg with its concrete tokenId + whole-token
+      // amount. SwapFeedItem uses .length > 1 to switch the subtitle to the
+      // aggregate multi-token copy ("3 monedas a Pesos") instead of naming a
+      // single dollar-family stablecoin. Without this, the standby shows
+      // "Dolares (USDm) > Pesos" for a batch that actually pulled USDm +
+      // USDC + USDT, misrepresenting the swap until the indexer catches up.
+      // outAmount stays pinned to USDm+total for backwards compatibility
+      // (matches the "largest leg" convention on the indexer side).
+      const fromTokenAmounts = stepOutcomes.map((o) => ({
+        tokenId: o.tokenId,
+        value: o.outAmountTokenWhole.toFixed(),
+      }))
       yield* put(
         addStandbyTransaction({
           context: newTransactionContext(TAG, 'Dolares -> Pesos atomic batch'),
@@ -480,6 +494,7 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
             tokenId: networkConfig.usdmTokenId,
             value: totalOutUsd.toFixed(),
           },
+          fromTokenAmounts,
           ...(feeCurrencyId && { feeCurrencyId }),
         })
       )


### PR DESCRIPTION
## What

Add `fromTokenAmounts` to the optimistic standby transaction fired by the atomic 7702 batch saga in [src/dollarsSpend/saga7702.ts](src/dollarsSpend/saga7702.ts#L469-L499). The array carries one entry per step outcome with the concrete leg tokenId + whole-token amount.

## Why

`SwapFeedItem` decides between single-leg (`"Dolares (USDm) > Pesos"`) and multi-leg (`"3 monedas a Pesos"`) subtitles by checking `transaction.fromTokenAmounts?.length > 1`. The standby that surfaced immediately after a 7702 batch had no `fromTokenAmounts`, so a $3 swap that pulled USDm + USDC + USDT rendered as if only USDm had been touched. The TuCop indexer eventually classified the tx with the correct 3-leg shape and the standby got replaced, but during the intermediate window the user saw a misleading label.

Reproduced with tx `0xce958ce00b79f1ca9d6c81bace6912a79094612a254cb3f8ce2c207e7a4a3a33` (spike v2, block 71572588). Feed indexer already reports `fromTokenAmounts` with USDm 1.044, USDC 1.044, USDT 0.912; the standby now mirrors that shape from the moment the batch commits.

## Scope

- `outAmount` stays pinned to USDm + total for backwards compatibility with the "largest leg" convention on the indexer.
- Single-leg batches (`stepOutcomes.length === 1`) are unaffected: `fromTokenAmounts.length === 1` -> `isMultiLegSwap === false`, same rendering as before.
- Legacy multi-swap path (non-7702) is unchanged: each leg is its own on-chain tx and its own feed row.

## Verification

- `yarn build:ts` clean (12.6s)
- `yarn lint src/` clean (28s)
- `yarn jest src/dollarsSpend/saga7702.test.ts src/transactions/feed/SwapFeedItem.test.tsx` 12/12 pass

## Not covered here

Manual smoke on sim to confirm the standby subtitle flips to `"3 monedas a Pesos"` before the indexer refresh. Requires a fresh 7702 batch with legs in more than one dollar-family stablecoin.