### PR TITLE
fix(feed): blockscout classifier populates fromTokenAmounts for multi-leg batches

### DIFF
--- a/src/transactions/blockscoutApi.ts
+++ b/src/transactions/blockscoutApi.ts
@@ -214,9 +214,27 @@ function processBlockscoutTransaction(
 
   // Determine transaction type
   if (outTokens.length > 0 && inTokens.length > 0) {
-    // SWAP: tokens going out and coming in
-    const outToken = outAmounts[outTokens[0]]
+    // SWAP: tokens going out and coming in.
+    //
+    // EIP-7702 atomic batches from the WRI dollarsSpend flow move multiple
+    // dollar-family stablecoins (USDm + USDC + USDT) out of the user's EOA in
+    // one tx. Blockscout's Transfer log surfaces every leg, but naively
+    // picking outTokens[0] shows a single-leg swap of one of the three legs
+    // (whichever came back first from Blockscout, non-deterministic) and hides
+    // the other two. That misrepresents the amount ("-0.91 Dolares" for what
+    // was actually a $3 swap) and stops SwapFeedItem from switching to the
+    // multi-leg "N monedas a Pesos" subtitle.
+    //
+    // When there is more than one outgoing token, mirror the TuCop indexer
+    // shape: keep outAmount as the largest USD leg for backwards compatibility
+    // and populate fromTokenAmounts with every leg. SwapFeedItem uses
+    // fromTokenAmounts.length > 1 to render the aggregate copy.
+    const outTokenList = outTokens.map((symbol) => outAmounts[symbol])
     const inToken = inAmounts[inTokens[0]]
+    const primaryOut =
+      outTokenList.length > 1
+        ? outTokenList.reduce((a, b) => (b.value > a.value ? b : a))
+        : outTokenList[0]
 
     const exchange: TokenExchange = {
       networkId: NetworkId['celo-mainnet'],
@@ -225,13 +243,19 @@ function processBlockscoutTransaction(
       timestamp,
       block,
       outAmount: {
-        value: outToken.value.toString(),
-        tokenId: outToken.tokenId,
+        value: primaryOut.value.toString(),
+        tokenId: primaryOut.tokenId,
       },
       inAmount: {
         value: inToken.value.toString(),
         tokenId: inToken.tokenId,
       },
+      ...(outTokenList.length > 1 && {
+        fromTokenAmounts: outTokenList.map((o) => ({
+          value: o.value.toString(),
+          tokenId: o.tokenId,
+        })),
+      }),
       fees: [],
       status: TransactionStatus.Complete,
     }


### PR DESCRIPTION
## What

Fix the Blockscout swap classifier in [src/transactions/blockscoutApi.ts](src/transactions/blockscoutApi.ts#L215-L262) so it emits `fromTokenAmounts` when an EIP-7702 atomic batch moves more than one dollar-family stablecoin out of the user's EOA in a single tx.

## Why

The Activity tab's feed pipeline goes through `useFetchTransactions()` (`queryHelper.ts`) which combines Valora GraphQL with `fetchAllBlockscoutTransfers()`. The Valora GraphQL fragment does not select `fromTokenAmounts` and Valora's indexer does not even see 7702 atomic batches (`tx.from == tx.to == user EOA calling execute()` is opaque to it). Blockscout does surface every ERC20 Transfer inside the batch, but the classifier only used `outTokens[0]` and dropped the rest.

Verified against spike v2 tx `0xce958ce00b79f1ca9d6c81bace6912a79094612a254cb3f8ce2c207e7a4a3a33`:
- Real batch outflow: USDm 1.044 + USDC 1.044 + USDT 0.911 = $3.00
- Wallet redux persist stored: `outAmount = 0.911746 USDT`, no `fromTokenAmounts`
- Activity feed rendered: `"Dolares (USDT) > Pesos -0.91 Dolares"` for a $3 swap

After the fix, the same Blockscout response yields a swap with `outAmount = USDm 1.044` (largest USD leg, matches TuCop indexer convention) and `fromTokenAmounts` populated with all three legs. `SwapFeedItem.isMultiLegSwap` fires and the subtitle collapses to `"3 monedas a Pesos"`.

## Scope

- Single-leg swaps are unchanged: `outTokenList.length === 1` -> no `fromTokenAmounts` emitted -> same output shape as before.
- Non-swap classifications (RECEIVE / SEND) are unchanged.
- Aligns Blockscout output with the TuCop indexer's shape so the wallet does not diverge depending on which source served the tx.

## Follow-up context

Companion to PR #240 (fix on the optimistic standby side). Together they close the "-0.91 Dolares" misrender both before and after the indexer catches up.

## Verification

- `yarn build:ts` clean (12.7s)
- `yarn lint src/` clean (26s)
- `yarn jest src/transactions/blockscoutApi src/transactions/feed/SwapFeedItem src/dollarsSpend/saga7702` 12/12 pass (no existing suite for blockscoutApi; the fix mirrors the existing pattern)