### PR TITLE
fix(feed): multi-dollar 7702 swap renders as 'Dolares > Pesos' with SUM

### DIFF
--- a/src/transactions/blockscoutApi.ts
+++ b/src/transactions/blockscoutApi.ts
@@ -21,8 +21,25 @@ const SYSTEM_CONTRACTS = new Set([
   '0x0000000000000000000000000000000000000000', // Null address (mints/burns)
 ])
 
-// Tokens we care about
-const MAIN_TOKENS = new Set(['COPm', 'USDT', 'XAUt0', 'USDC', 'USDm', 'CELO'])
+// Tokens we care about, keyed by canonical contract address (lowercase). Symbol
+// matching was fragile: Blockscout mirrors on-chain ERC20 `symbol()` output
+// verbatim, so USDm arrives as `CUSD` (all caps, its Mento contract symbol),
+// USDT sometimes as `USD₮`, and any future rebrand can silently drop a leg
+// from the atomic 7702 batch classifier. Address is the canonical identity.
+const MAIN_TOKEN_ADDRESSES = new Set(
+  [
+    networkConfig.copmTokenId,
+    networkConfig.usdtTokenId,
+    networkConfig.usdcTokenId,
+    networkConfig.usdmTokenId,
+    networkConfig.usatTokenId,
+    networkConfig.xaut0TokenId,
+    networkConfig.celoTokenId,
+  ]
+    .filter(Boolean)
+    .map((tokenId) => tokenId.split(':')[1]?.toLowerCase())
+    .filter(Boolean)
+)
 
 interface BlockscoutTransfer {
   transaction_hash: string
@@ -180,32 +197,35 @@ function processBlockscoutTransaction(
 
   if (meaningfulTransfers.length === 0) return null
 
-  // Calculate net amounts per token
+  // Calculate net amounts per token, keyed by contract address (canonical).
+  // Using symbol as the key silently merges tokens with the same symbol from
+  // different contracts (or, worse, silently drops a leg when the symbol has
+  // an aliased casing like USDm-contract returning `CUSD`).
   const outAmounts: Record<string, { value: number; tokenId: string; symbol: string }> = {}
   const inAmounts: Record<string, { value: number; tokenId: string; symbol: string }> = {}
 
   for (const transfer of meaningfulTransfers) {
-    const symbol = transfer.token.symbol
-    if (!MAIN_TOKENS.has(symbol)) continue
+    const tokenAddress = transfer.token.address_hash.toLowerCase()
+    if (!MAIN_TOKEN_ADDRESSES.has(tokenAddress)) continue
 
+    const symbol = transfer.token.symbol
     const decimals = parseInt(transfer.token.decimals, 10)
     const value = parseFloat(transfer.total.value) / Math.pow(10, decimals)
-    const tokenAddress = transfer.token.address_hash.toLowerCase()
     const tokenId = `${networkConfig.defaultNetworkId}:${tokenAddress}`
 
     const from = transfer.from.hash.toLowerCase()
     const to = transfer.to.hash.toLowerCase()
 
     if (from === userAddress) {
-      if (!outAmounts[symbol]) {
-        outAmounts[symbol] = { value: 0, tokenId, symbol }
+      if (!outAmounts[tokenAddress]) {
+        outAmounts[tokenAddress] = { value: 0, tokenId, symbol }
       }
-      outAmounts[symbol].value += value
+      outAmounts[tokenAddress].value += value
     } else if (to === userAddress) {
-      if (!inAmounts[symbol]) {
-        inAmounts[symbol] = { value: 0, tokenId, symbol }
+      if (!inAmounts[tokenAddress]) {
+        inAmounts[tokenAddress] = { value: 0, tokenId, symbol }
       }
-      inAmounts[symbol].value += value
+      inAmounts[tokenAddress].value += value
     }
   }
 

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -36,13 +36,32 @@ function SwapFeedItem({ transaction }: Props) {
   }
 
   const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction
-  // EIP-7702 atomic batches from the TuCop indexer feed populate
-  // fromTokenAmounts with every leg of the batch. When >1, the subtitle
-  // collapses to a count ("3 monedas a Pesos") so the user understands the
-  // tx moved multiple inputs at once. The outgoing amount row keeps showing
-  // the largest leg (which is what outAmount already holds for these txs).
+  // EIP-7702 atomic batches from the TuCop indexer feed (and from the
+  // fetch-Blockscout classifier for the same batches) populate
+  // fromTokenAmounts with every leg of the batch. When every leg is a
+  // dollar-family token (USDT/USDC/USDm/USAT), the user's mental model
+  // treats the whole thing as one "Dolares -> Pesos" swap of the total,
+  // matching the swap flow UI where the aggregate is picked as "Dolares".
+  // We collapse the subtitle to "Dolares > Pesos" and show the summed
+  // outgoing amount as "Dolares", ignoring the per-leg tokenIds.
   const fromLegCount = transaction.fromTokenAmounts?.length ?? 0
   const isMultiLegSwap = fromLegCount > 1
+  const DOLLAR_FAMILY_TOKEN_IDS = new Set(
+    [
+      networkConfig.usdtTokenId,
+      networkConfig.usdcTokenId,
+      networkConfig.usdmTokenId,
+      networkConfig.usatTokenId,
+    ].filter(Boolean)
+  )
+  const isMultiDollarSwap =
+    isMultiLegSwap &&
+    (transaction.fromTokenAmounts ?? []).every((leg) => DOLLAR_FAMILY_TOKEN_IDS.has(leg.tokenId))
+  const multiDollarOutgoingTotal = isMultiDollarSwap
+    ? (transaction.fromTokenAmounts ?? [])
+        .reduce((sum, leg) => sum.plus(new BigNumber(leg.value)), new BigNumber(0))
+        .toFixed()
+    : null
 
   // Get friendly token name - also accepts tokenId for when token info isn't available.
   // Per .claude/rules/tokens.md the entire USAT/USDm/USDC/USDT group is shown as
@@ -155,25 +174,36 @@ function SwapFeedItem({ transaction }: Props) {
             >
               {isCrossChainSwap
                 ? t('transactionFeed.crossChainSwapTransactionLabel')
-                : isMultiLegSwap
-                  ? t('feedItemSwapPathMulti', {
-                      count: fromLegCount,
+                : isMultiDollarSwap
+                  ? t('feedItemSwapPath', {
+                      token1: t('assets.dollars'),
                       token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
                     })
-                  : t('feedItemSwapPath', {
-                      token1: getTokenName(outgoingTokenInfo, transaction.outAmount.tokenId),
-                      token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
-                    })}
+                  : isMultiLegSwap
+                    ? t('feedItemSwapPathMulti', {
+                        count: fromLegCount,
+                        token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
+                      })
+                    : t('feedItemSwapPath', {
+                        token1: getTokenName(outgoingTokenInfo, transaction.outAmount.tokenId),
+                        token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
+                      })}
             </Text>
-            <TokenDisplay
-              amount={-transaction.outAmount.value}
-              tokenId={transaction.outAmount.tokenId}
-              showLocalAmount={false}
-              showSymbol={true}
-              hideSign={false}
-              style={styles.tokenAmount}
-              testID={'SwapFeedItem/outgoingAmount'}
-            />
+            {isMultiDollarSwap && multiDollarOutgoingTotal ? (
+              <Text style={styles.tokenAmount} testID={'SwapFeedItem/outgoingAmount'}>
+                {`-${new BigNumber(multiDollarOutgoingTotal).toFixed(2)} ${t('assets.dollars')}`}
+              </Text>
+            ) : (
+              <TokenDisplay
+                amount={-transaction.outAmount.value}
+                tokenId={transaction.outAmount.tokenId}
+                showLocalAmount={false}
+                showSymbol={true}
+                hideSign={false}
+                style={styles.tokenAmount}
+                testID={'SwapFeedItem/outgoingAmount'}
+              />
+            )}
           </View>
           {/* Row 3: Timestamp */}
           <Text style={styles.timestamp} testID={'SwapFeedItem/timestamp'}>


### PR DESCRIPTION
## Two connected fixes for the multi-token Dolares -> Pesos atomic 7702 batch display

### 1) Blockscout classifier switched from symbol-based to address-based identity

[src/transactions/blockscoutApi.ts](src/transactions/blockscoutApi.ts) previously used `MAIN_TOKENS.has(symbol)` for the accept filter and `outAmounts[symbol]` as the aggregation key. Blockscout mirrors on-chain `symbol()` verbatim, so the Mento USDm contract returns `CUSD` (all caps). The case-sensitive symbol Set silently dropped USDm from a 3-leg batch, leaving the classifier producing a 2-leg swap with $2.09 total when the user actually spent $3.00.

Now the classifier keys on lowercase contract address. Addresses are canonical: the underlying identity of a token cannot drift, aliased casing cannot fragment aggregation, and future on-chain symbol changes cannot silently break the accept filter.

Verified against tx `0xce958ce00b79f1ca9d6c81bace6912a79094612a254cb3f8ce2c207e7a4a3a33`. Blockscout raw response:
- leg 4: `symbol=USDT` at `0x48065fbBE2` -> 0.911746 ✓ passed
- leg 6: `symbol=USDC` at `0xcebA9300f2` -> 1.044478 ✓ passed
- leg 8: `symbol=CUSD` at `0x765DE81684` -> 1.044442245 ✗ dropped (all-caps vs `cUSD` in the old Set)

### 2) SwapFeedItem collapses multi-dollar swaps to `Dolares > Pesos`

Even after the Blockscout fix delivered 3 legs, the row rendered `3 monedas a Pesos` and outgoing `-1.04 Dolares (USDm)` (largest leg). That splits Dolares into leg-level detail on a feed the rest of the app already presents as a single asset.

[SwapFeedItem.tsx](src/transactions/feed/SwapFeedItem.tsx) now detects `isMultiDollarSwap` (every leg in `fromTokenAmounts` is USDT/USDC/USDm/USAT). When true:
- subtitle: `Dolares > Pesos`
- outgoing: `-{sum} Dolares`

Non-dollar multi-leg and single-leg paths are untouched.

## Scope

- Blockscout classifier is now token-address-canonical for both single- and multi-leg paths.
- Multi-leg display collapses only when every leg belongs to the dollar family, so a hypothetical XAUt0 + USDT batch would still fall through to `feedItemSwapPathMulti`.
- No i18n string changes.

## Verification

- `yarn build:ts` clean (12.8s)
- `yarn lint src/` clean (28s)
- `yarn jest src/transactions/feed/SwapFeedItem src/dollarsSpend/saga7702` 12/12 pass
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim `6E9A949E-8A91-4468-9CFC-A394E8BF328F`

## Follow-up (not in this PR)

Codebase-wide audit turned up ~15 other symbol-based token comparisons across `src/gold/*`, `src/components/TokenIcon.tsx`, `src/components/TokenDisplay.tsx`, and `src/earn/marranitos/*`. Same shape as this bug (enumerating `USDT` / `USDt` / `USD₮` variants, or case-sensitive `COPm` / `cCOP` compares). Track separately.