### PR TITLE
fix(feed): tx detail multi-swap shows concrete token brand per leg

### DIFF
--- a/scripts/wri-feed-shape-diff.mjs
+++ b/scripts/wri-feed-shape-diff.mjs
@@ -73,19 +73,37 @@ function parseArgs(rawArgs) {
   return { address, ...flags }
 }
 
+// Both /getWalletTransactions (Valora) and /api/transactions/feed (TuCop) return
+// pageInfo.endCursor + hasNextPage; a single call caps at ~20 (TuCop) or ~48
+// (Valora). Without pagination, the diff over any wallet with real history
+// silently compares only the most-recent page and reports every older tx as
+// "missing" on whichever side has the shorter first page. Follow the cursor
+// until hasNextPage is false, hard-stopping at 20 pages so a broken cursor
+// cannot loop forever.
 async function fetchFeed(url, { address, currency }) {
-  const params = new URLSearchParams({
+  const baseParams = {
     address,
     networkIds: NETWORK_IDS,
     includeTypes: INCLUDE_TYPES,
     localCurrencyCode: currency,
-  })
-  const full = `${url}?${params.toString()}`
-  const res = await fetch(full, { headers: { Accept: 'application/json' } })
-  if (!res.ok) {
-    throw new Error(`${url} returned ${res.status}: ${await res.text()}`)
   }
-  return res.json()
+  const allTransactions = []
+  let cursor
+  for (let page = 0; page < 20; page += 1) {
+    const params = new URLSearchParams(baseParams)
+    if (cursor) params.set('afterCursor', cursor)
+    const full = `${url}?${params.toString()}`
+    const res = await fetch(full, { headers: { Accept: 'application/json' } })
+    if (!res.ok) {
+      throw new Error(`${url} returned ${res.status}: ${await res.text()}`)
+    }
+    const body = await res.json()
+    allTransactions.push(...(body.transactions ?? []))
+    const pageInfo = body.pageInfo ?? {}
+    if (!pageInfo.hasNextPage || !pageInfo.endCursor) break
+    cursor = pageInfo.endCursor
+  }
+  return { transactions: allTransactions }
 }
 
 // Recursively lowercase every string that looks like a hex identifier.

--- a/src/components/TokenAmountWithBrand.tsx
+++ b/src/components/TokenAmountWithBrand.tsx
@@ -1,0 +1,81 @@
+import BigNumber from 'bignumber.js'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import TokenDisplay, { formatValueToDisplay } from 'src/components/TokenDisplay'
+import TokenIcon, { IconSize } from 'src/components/TokenIcon'
+import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend'
+import DollarsIcon from 'src/icons/tokens/DollarsIcon'
+import { Spacing } from 'src/styles/styles'
+import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { useTokenInfo } from 'src/tokens/hooks'
+
+interface Props {
+  amount: string
+  tokenId: string
+  testID: string
+  textStyle: object
+}
+
+// Renders the on-chain amount (via TokenDisplay, which already caps decimals
+// and routes through `getTokenSymbol`) and appends the brand-specific dollar
+// label when the token is one of the four dollar stablecoins (USDT / USDC /
+// USDm / USAT). This way the caller reads e.g. "0.04 Tether USD" instead of
+// the generic "0.04 Dolares" — the user can tell which concrete brand
+// actually landed in their wallet.
+//
+// Special-cases the virtual "Dolares" tokenId used for multi-swap aggregates
+// (no on-chain registry entry) with a plain amount + "Dolares" label.
+export default function TokenAmountWithBrand({ amount, tokenId, testID, textStyle }: Props) {
+  const { t } = useTranslation()
+  const tokenInfo = useTokenInfo(tokenId)
+  const brandLabelKey = getDollarTokenLabelKey(tokenId)
+
+  if (tokenId === DOLARES_VIRTUAL_TOKEN_ID) {
+    return (
+      <View style={styles.brandRow}>
+        <DollarsIcon size={24} testID={`${testID}/Icon`} />
+        <Text style={textStyle} testID={testID}>
+          {`${formatValueToDisplay(new BigNumber(amount))} ${t('assets.dollars')}`}
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.brandRow}>
+      {tokenInfo && <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />}
+      {brandLabelKey ? (
+        <>
+          <TokenDisplay
+            amount={amount}
+            tokenId={tokenId}
+            showLocalAmount={false}
+            showSymbol={false}
+            hideSign={true}
+            style={textStyle}
+            testID={testID}
+          />
+          <Text style={textStyle}>{` ${t(brandLabelKey)}`}</Text>
+        </>
+      ) : (
+        <TokenDisplay
+          amount={amount}
+          tokenId={tokenId}
+          showLocalAmount={false}
+          hideSign={true}
+          style={textStyle}
+          testID={testID}
+        />
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  brandRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.Smallest8,
+  },
+})

--- a/src/transactions/TransactionSuccessScreen.tsx
+++ b/src/transactions/TransactionSuccessScreen.tsx
@@ -6,15 +6,10 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnSizes } from 'src/components/Button'
 import StateCard from 'src/components/StateCard'
 import StickyCtaBottom from 'src/components/StickyCtaBottom'
-import TokenDisplay, { formatValueToDisplay } from 'src/components/TokenDisplay'
-import TokenIcon, { IconSize } from 'src/components/TokenIcon'
+import TokenAmountWithBrand from 'src/components/TokenAmountWithBrand'
+import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
 import ArrowRightThick from 'src/icons/navigation/ArrowRightThick'
-import DollarsIcon from 'src/icons/tokens/DollarsIcon'
-import BigNumber from 'bignumber.js'
-import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
-import { useTokenInfo } from 'src/tokens/hooks'
 import { noHeaderGestureDisabled } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -186,72 +181,6 @@ function TransactionSuccessScreen({ route }: Props) {
   )
 }
 
-// Renders the on-chain amount (via TokenDisplay, which already caps decimals
-// and routes through `getTokenSymbol`) and appends the brand-specific dollar
-// label when the token is one of the four dollar stablecoins (USDT / USDC /
-// USDm / USAT). This way the success screen reads e.g. "0.04 Tether USD"
-// instead of the generic "0.04 Dolares" - the user can tell which concrete
-// brand actually landed in their wallet.
-function TokenAmountWithBrand({
-  amount,
-  tokenId,
-  testID,
-  textStyle,
-}: {
-  amount: string
-  tokenId: string
-  testID: string
-  textStyle: object
-}) {
-  const { t } = useTranslation()
-  const tokenInfo = useTokenInfo(tokenId)
-  const brandLabelKey = getDollarTokenLabelKey(tokenId)
-  // Multi-swap aggregates arrive with the virtual "Dolares" tokenId so the
-  // header row renders as "3.00 Dolares" instead of picking one specific
-  // stablecoin brand. There is no on-chain token registered for the virtual
-  // id (useTokenInfo returns undefined), so we short-circuit here with a
-  // plain amount + "Dolares" label. The per-leg breakdown further down uses
-  // the concrete tokenIds and still routes through the normal brand path.
-  if (tokenId === DOLARES_VIRTUAL_TOKEN_ID) {
-    return (
-      <View style={styles.brandRow}>
-        <DollarsIcon size={24} testID={`${testID}/Icon`} />
-        <Text style={textStyle} testID={testID}>
-          {`${formatValueToDisplay(new BigNumber(amount))} ${t('assets.dollars')}`}
-        </Text>
-      </View>
-    )
-  }
-  return (
-    <View style={styles.brandRow}>
-      {tokenInfo && <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />}
-      {brandLabelKey ? (
-        <>
-          <TokenDisplay
-            amount={amount}
-            tokenId={tokenId}
-            showLocalAmount={false}
-            showSymbol={false}
-            hideSign={true}
-            style={textStyle}
-            testID={testID}
-          />
-          <Text style={textStyle}>{` ${t(brandLabelKey)}`}</Text>
-        </>
-      ) : (
-        <TokenDisplay
-          amount={amount}
-          tokenId={tokenId}
-          showLocalAmount={false}
-          hideSign={true}
-          style={textStyle}
-          testID={testID}
-        />
-      )}
-    </View>
-  )
-}
-
 TransactionSuccessScreen.navigationOptions = () => ({
   ...noHeaderGestureDisabled,
 })
@@ -330,11 +259,6 @@ const styles = StyleSheet.create({
   explorerLinkText: {
     ...typeScale.labelSmall,
     color: Colors.primary,
-  },
-  brandRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.Smallest8,
   },
 })
 

--- a/src/transactions/feed/detailContent/SwapContent.tsx
+++ b/src/transactions/feed/detailContent/SwapContent.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import RowDivider from 'src/components/RowDivider'
+import TokenAmountWithBrand from 'src/components/TokenAmountWithBrand'
 import TokenDisplay, { formatValueToDisplay } from 'src/components/TokenDisplay'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
@@ -48,13 +49,10 @@ export default function SwapContent({ transaction }: Props) {
         fromLegs.map((leg, idx) => (
           <View style={styles.row} key={`${leg.tokenId}-${idx}`}>
             <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapFrom')}</Text>
-            <TokenDisplay
-              style={styles.currencyAmountPrimaryText}
-              amount={leg.value}
+            <TokenAmountWithBrand
+              amount={leg.value.toString()}
               tokenId={leg.tokenId}
-              showLocalAmount={false}
-              showSymbol={true}
-              hideSign={true}
+              textStyle={styles.currencyAmountPrimaryText}
               testID={`SwapContent/swapFrom/${idx}`}
             />
           </View>


### PR DESCRIPTION
## What

Multi-leg atomic 7702 Dolares -> Pesos swaps now show the concrete stablecoin brand for each leg on the tx detail screen, matching the breakdown the success screen already renders.

Before, each leg row said just "Dolares" (0.91 Dolares / 1.04 Dolares / 1.04 Dolares) which failed to tell the user which of USDT / USDC / USDm actually funded each portion.

## How

- Extract `TokenAmountWithBrand` from [src/transactions/TransactionSuccessScreen.tsx](src/transactions/TransactionSuccessScreen.tsx) (where it was inline) to a new shared component at [src/components/TokenAmountWithBrand.tsx](src/components/TokenAmountWithBrand.tsx).
- Use it in [src/transactions/feed/detailContent/SwapContent.tsx](src/transactions/feed/detailContent/SwapContent.tsx) for the per-leg breakdown rows when `isMultiLegSwap`.
- Single-leg swaps and the "swapTo" row are untouched.
- Success screen retains identical behavior via the imported component.

## Result

Detail screen for the spike v2 batch `0xce958ce0...` now reads:

```
Cambiar de   0.91 Tether USD
Cambiar de   1.04 USD Coin
Cambiar de   1.04 Dolar Mento
Cambiar a    9,991.88 Pesos
```

Instead of three ambiguous "0.91 Dolares / 1.04 Dolares / 1.04 Dolares" rows.

## Verification

- `yarn build:ts` clean (12.9s)
- `yarn lint src/` clean (26s)
- `yarn jest src/transactions src/dollarsSpend` 225 pass, 14 skipped, 31 suites green
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim