### PR TITLE
chore(scripts): paginate WRI feed shape-diff across both endpoints

### DIFF
--- a/scripts/wri-feed-shape-diff.mjs
+++ b/scripts/wri-feed-shape-diff.mjs
@@ -73,19 +73,37 @@ function parseArgs(rawArgs) {
   return { address, ...flags }
 }
 
+// Both /getWalletTransactions (Valora) and /api/transactions/feed (TuCop) return
+// pageInfo.endCursor + hasNextPage; a single call caps at ~20 (TuCop) or ~48
+// (Valora). Without pagination, the diff over any wallet with real history
+// silently compares only the most-recent page and reports every older tx as
+// "missing" on whichever side has the shorter first page. Follow the cursor
+// until hasNextPage is false, hard-stopping at 20 pages so a broken cursor
+// cannot loop forever.
 async function fetchFeed(url, { address, currency }) {
-  const params = new URLSearchParams({
+  const baseParams = {
     address,
     networkIds: NETWORK_IDS,
     includeTypes: INCLUDE_TYPES,
     localCurrencyCode: currency,
-  })
-  const full = `${url}?${params.toString()}`
-  const res = await fetch(full, { headers: { Accept: 'application/json' } })
-  if (!res.ok) {
-    throw new Error(`${url} returned ${res.status}: ${await res.text()}`)
   }
-  return res.json()
+  const allTransactions = []
+  let cursor
+  for (let page = 0; page < 20; page += 1) {
+    const params = new URLSearchParams(baseParams)
+    if (cursor) params.set('afterCursor', cursor)
+    const full = `${url}?${params.toString()}`
+    const res = await fetch(full, { headers: { Accept: 'application/json' } })
+    if (!res.ok) {
+      throw new Error(`${url} returned ${res.status}: ${await res.text()}`)
+    }
+    const body = await res.json()
+    allTransactions.push(...(body.transactions ?? []))
+    const pageInfo = body.pageInfo ?? {}
+    if (!pageInfo.hasNextPage || !pageInfo.endCursor) break
+    cursor = pageInfo.endCursor
+  }
+  return { transactions: allTransactions }
 }
 
 // Recursively lowercase every string that looks like a hex identifier.


### PR DESCRIPTION
## Summary

Both `/getWalletTransactions` (Valora) and `/api/transactions/feed` (TuCop) return `pageInfo.endCursor` + `hasNextPage`. A single call caps at ~20 (TuCop) or ~48 (Valora), so without pagination the diff over any wallet with real history silently compared only the most-recent page and flagged every older tx as missing on whichever side had the shorter first page.

This is what produced the false "28 missing" spike v2 report we sent to the backend. Once the cursor is followed on both sides the numbers land at Valora=116, TuCop=116, Common=105, Only-in-Valora=11, Only-in-TuCop=11 (near parity, all deltas explained by structural CELO / activation-window backfill boundary / 7702 execute path).

## Changes

- `scripts/wri-feed-shape-diff.mjs`: `fetchFeed` now loops with `afterCursor` until `hasNextPage=false`, capped at 20 pages so a broken cursor cannot loop forever.

## Test plan

- [x] Ran against spike v2 (`0x81dCf9160237D0EF0d4db27CFb2EA9743547f882`) pre-fix: Valora 47, TuCop 20, Missing 28.
- [x] Ran against spike v2 post-fix: Valora 116, TuCop 116, Common 105, Missing 11, Extra 11.
- [x] `yarn eslint scripts/wri-feed-shape-diff.mjs` clean.
- [ ] Optional: rerun against a legacy wallet once #106 backfill catches up to confirm the 4 fundAndRunMulticall from the activation window get absorbed.