### PR TITLE
fix(feed): dollar-family tokens display as ticker not brand full-name

### DIFF
--- a/src/components/TokenAmountWithBrand.tsx
+++ b/src/components/TokenAmountWithBrand.tsx
@@ -7,7 +7,7 @@ import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend'
 import DollarsIcon from 'src/icons/tokens/DollarsIcon'
 import { Spacing } from 'src/styles/styles'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { useTokenInfo } from 'src/tokens/hooks'
 
 interface Props {
@@ -18,18 +18,17 @@ interface Props {
 }
 
 // Renders the on-chain amount (via TokenDisplay, which already caps decimals
-// and routes through `getTokenSymbol`) and appends the brand-specific dollar
-// label when the token is one of the four dollar stablecoins (USDT / USDC /
-// USDm / USAT). This way the caller reads e.g. "0.04 Tether USD" instead of
-// the generic "0.04 Dolares" — the user can tell which concrete brand
-// actually landed in their wallet.
-//
-// Special-cases the virtual "Dolares" tokenId used for multi-swap aggregates
-// (no on-chain registry entry) with a plain amount + "Dolares" label.
+// and routes through `getTokenSymbol`) and appends the correct label:
+// - Virtual "Dolares" tokenId (used for multi-swap aggregates) -> "Dolares".
+// - Concrete dollar-family tokens (USDT / USDC / USDm / USAT) -> their ticker,
+//   because "Dolares" is reserved for the aggregate view and the specific
+//   ticker is the canonical way to distinguish them elsewhere in the app
+//   (swap picker, tokens.md rule).
+// - Everything else -> TokenDisplay default (uses on-chain symbol).
 export default function TokenAmountWithBrand({ amount, tokenId, testID, textStyle }: Props) {
   const { t } = useTranslation()
   const tokenInfo = useTokenInfo(tokenId)
-  const brandLabelKey = getDollarTokenLabelKey(tokenId)
+  const ticker = getDollarTokenTicker(tokenId)
 
   if (tokenId === DOLARES_VIRTUAL_TOKEN_ID) {
     return (
@@ -45,7 +44,7 @@ export default function TokenAmountWithBrand({ amount, tokenId, testID, textStyl
   return (
     <View style={styles.brandRow}>
       {tokenInfo && <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />}
-      {brandLabelKey ? (
+      {ticker ? (
         <>
           <TokenDisplay
             amount={amount}
@@ -56,7 +55,7 @@ export default function TokenAmountWithBrand({ amount, tokenId, testID, textStyl
             style={textStyle}
             testID={testID}
           />
-          <Text style={textStyle}>{` ${t(brandLabelKey)}`}</Text>
+          <Text style={textStyle}>{` ${ticker}`}</Text>
         </>
       ) : (
         <TokenDisplay

--- a/src/tokens/dollarGroup.ts
+++ b/src/tokens/dollarGroup.ts
@@ -36,6 +36,21 @@ export function getDollarTokenLabelKey(tokenId: string): string | null {
   return null
 }
 
+// Concrete ticker for a dollar-family tokenId (USDT / USDC / USDm / USAT).
+// Used in the tx feed detail breakdown so the user sees "0.91 USDT" instead
+// of the localized brand name "0.91 Tether USD". Tickers are locale-neutral
+// and match the canonical asset names in .claude/rules/tokens.md; keep them
+// as literal strings, not i18n keys.
+export function getDollarTokenTicker(tokenId: string): string | null {
+  if (tokenId === networkConfig.usdtTokenId) return 'USDT'
+  if (tokenId === networkConfig.usdcTokenId) return 'USDC'
+  if (tokenId === networkConfig.usdmTokenId) return 'USDm'
+  if (networkConfig.usatTokenId && tokenId === networkConfig.usatTokenId) {
+    return 'USAT'
+  }
+  return null
+}
+
 // Fixed display order for dollar tokens inside any picker that surfaces them.
 // USDT first (most liquid / default settlement), then USDC, USAT, USDm. The
 // order is independent of SPEND_ORDER (which controls spending priority) -


### PR DESCRIPTION
## Rule

Aggregate view of USDT / USDC / USDm / USAT = `Dolares`. Specific-token label = ticker (`USDT`, `USDC`, `USDm`, `USAT`). Never brand full names like `Tether USD` or `Dolar Mento`.

## Change

- Add `getDollarTokenTicker` in [src/tokens/dollarGroup.ts](src/tokens/dollarGroup.ts) alongside the existing `getDollarTokenLabelKey`. Returns the literal ticker string, not an i18n key (tickers are locale-neutral).
- Switch [src/components/TokenAmountWithBrand.tsx](src/components/TokenAmountWithBrand.tsx) to `getDollarTokenTicker`. Both callers of this component (`TransactionSuccessScreen` breakdown + `SwapContent` detail rows) now surface the ticker.

`getDollarTokenLabelKey` is kept because six other UI sites still reference it: `BalanceCard`, `TokenBalanceItem`, `SwapTransactionDetails`, `GoldBuyEnterAmount`, `GoldSellEnterAmount`, `GoldSellConfirmation`. Those migrate as they get touched.

## Result

Multi-leg 7702 batch detail (spike v2 tx `0xce958ce0...`):

```
Cambiar de   0.91 USDT
Cambiar de   1.04 USDC
Cambiar de   1.04 USDm
Cambiar a    9,991.88 Pesos
```

Success screen breakdown identical (uses same component).

## Verification

- `yarn build:ts` clean (14.5s)
- `yarn jest src/transactions/feed src/transactions/TransactionSuccessScreen` 135 pass, 14 skipped, 12 suites green
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim

## Follow-up

Same treatment could apply to the six other call sites of `getDollarTokenLabelKey` if the ticker-not-brand rule generalizes. Not touched here to keep the diff scoped.