### PR TITLE
fix(labels): migrate all dollar-family displays to ticker

### DIFF
--- a/src/components/BalanceCard.test.tsx
+++ b/src/components/BalanceCard.test.tsx
@@ -143,10 +143,10 @@ describe('BalanceCard', () => {
       fireEvent.press(getByTestId('BalanceCard/dolares/Behind'))
       fireEvent.press(getByTestId('BalanceCard/Toggle'))
       expect(getByTestId('BalanceCard/Breakdown')).toBeTruthy()
-      // USDT row present (balance=10) - i18n mock returns the key
-      expect(queryByText('assets.tetherUsd')).toBeTruthy()
-      // USDm row present (balance=5) - i18n mock returns the key
-      expect(queryByText('assets.mentoDollar')).toBeTruthy()
+      // USDT row present (balance=10) - concrete ticker used as label
+      expect(queryByText('USDT')).toBeTruthy()
+      // USDm row present (balance=5) - concrete ticker used as label
+      expect(queryByText('USDm')).toBeTruthy()
     })
 
     it('does not show USDC row in breakdown when USDC balance is 0', () => {

--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -18,7 +18,7 @@ import { useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { useCOPm, useDollarTokensWithBalance, useDollarUsdBalance } from 'src/tokens/hooks'
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -252,8 +252,8 @@ export default function BalanceCard({ testID }: Props) {
       return (
         <>
           {dollarTokensWithBalance.map(({ tokenInfo, usdValue }) => {
-            const labelKey = getDollarTokenLabelKey(tokenInfo.tokenId)
-            const label = labelKey ? t(labelKey) : tokenInfo.symbol
+            const ticker = getDollarTokenTicker(tokenInfo.tokenId)
+            const label = ticker ?? tokenInfo.symbol
             return (
               <View key={tokenInfo.tokenId} style={styles.breakdownRow}>
                 <Text style={rowLabelStyle} numberOfLines={1}>

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -43,7 +43,7 @@ import {
   DOLARES_VIRTUAL_TOKEN_ID,
   useDollarBalanceSnapshots,
 } from 'src/dollarsSpend'
-import { DOLLAR_TOKEN_IDS, getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { DOLLAR_TOKEN_IDS, getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -99,9 +99,9 @@ export default function GoldBuyEnterAmount({ route }: Props) {
     if (token.tokenId === networkConfig.copmTokenId) {
       return t('assets.pesos')
     }
-    const brandLabelKey = getDollarTokenLabelKey(token.tokenId)
-    if (brandLabelKey) {
-      return t(brandLabelKey)
+    const ticker = getDollarTokenTicker(token.tokenId)
+    if (ticker) {
+      return ticker
     }
     if (token.tokenId === networkConfig.xaut0TokenId) {
       return t('goldFlow.gold')

--- a/src/gold/GoldSellConfirmation.tsx
+++ b/src/gold/GoldSellConfirmation.tsx
@@ -23,7 +23,7 @@ import { useDispatch, useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { useTokenInfo } from 'src/tokens/hooks'
 import { TokenBalance } from 'src/tokens/slice'
 import { getInputDecimalsForToken } from 'src/utils/formatting'
@@ -56,9 +56,9 @@ export default function GoldSellConfirmation({ route }: Props) {
     if (token.tokenId === networkConfig.copmTokenId) {
       return t('assets.pesos')
     }
-    const brandLabelKey = getDollarTokenLabelKey(token.tokenId)
-    if (brandLabelKey) {
-      return t(brandLabelKey)
+    const ticker = getDollarTokenTicker(token.tokenId)
+    if (ticker) {
+      return ticker
     }
     const symbol = token.symbol?.toLowerCase() || ''
     if (symbol === 'ccop' || symbol === 'copm') {

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -53,11 +53,11 @@ export default function GoldSellEnterAmount(_props: Props) {
   const insets = useSafeAreaInsets()
   const { decimalSeparator } = getNumberFormatSettings()
 
-  // Get user-friendly display name for tokens. The brand label wins for the
-  // four concrete dollar tokens (Tether USD / USD Coin / Dolar Mento /
-  // Tether America USD) so the chip stays consistent with the picker rows
-  // and the success screen. Falls back to "Dolares" for the synthetic
-  // virtual aggregator (no brand label), and to the token name otherwise.
+  // Get user-friendly display name for tokens. The ticker wins for the four
+  // concrete dollar tokens (USDT / USDC / USDm / USAT) so the chip stays
+  // consistent with the picker rows, the success screen, and the tx feed.
+  // Falls back to "Dolares" for the synthetic virtual aggregator, and to
+  // the token name otherwise.
   const getTokenName = (token: TokenBalance | null) => {
     if (!token) return ''
     if (token.tokenId === networkConfig.copmTokenId) {

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -10,7 +10,7 @@ import { GoldEvents } from 'src/analytics/Events'
 import { buildDolaresVirtualToken } from 'src/dollarsSpend/dolaresVirtualToken'
 import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend/types'
 import { useDollarBalanceSnapshots } from 'src/dollarsSpend/useDollarBalanceSnapshots'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import BackButton from 'src/components/BackButton'
 import { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
@@ -63,9 +63,9 @@ export default function GoldSellEnterAmount(_props: Props) {
     if (token.tokenId === networkConfig.copmTokenId) {
       return t('assets.pesos')
     }
-    const brandLabelKey = getDollarTokenLabelKey(token.tokenId)
-    if (brandLabelKey) {
-      return t(brandLabelKey)
+    const ticker = getDollarTokenTicker(token.tokenId)
+    if (ticker) {
+      return ticker
     }
     const symbol = token.symbol?.toLowerCase() || ''
     if (symbol === 'ccop' || symbol === 'copm') {
@@ -353,10 +353,10 @@ export default function GoldSellEnterAmount(_props: Props) {
                 <TokenIcon token={settlementTokenForVirtual} size={IconSize.XSMALL} />
                 <Text style={styles.settlementHintBrandText}>
                   {(() => {
-                    const key = getDollarTokenLabelKey(settlementTokenForVirtual.tokenId)
-                    return key
-                      ? t(key)
-                      : (settlementTokenForVirtual.name ?? settlementTokenForVirtual.symbol)
+                    const ticker = getDollarTokenTicker(settlementTokenForVirtual.tokenId)
+                    return (
+                      ticker ?? settlementTokenForVirtual.name ?? settlementTokenForVirtual.symbol
+                    )
                   })()}
                 </Text>
               </View>

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -8,7 +8,7 @@ import { SwapEvents } from 'src/analytics/Events'
 import { SwapShowInfoType } from 'src/analytics/Properties'
 import { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import { formatValueToDisplay, getTokenSymbol } from 'src/components/TokenDisplay'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { getTokenDisplayName } from 'src/tokens/utils'
 import Touchable from 'src/components/Touchable'
 import InfoIcon from 'src/icons/status/InfoIcon'
@@ -215,8 +215,8 @@ export function SwapTransactionDetails({
           <Text style={styles.label}>{t('swapScreen.transactionDetails.receivingIn')}</Text>
           <Text style={styles.value} testID="SwapTransactionDetails/SettlementToken/Value">
             {(() => {
-              const labelKey = getDollarTokenLabelKey(settlementToken.tokenId)
-              return labelKey ? t(labelKey) : (settlementToken.name ?? settlementToken.symbol)
+              const ticker = getDollarTokenTicker(settlementToken.tokenId)
+              return ticker ?? settlementToken.name ?? settlementToken.symbol
             })()}
           </Text>
         </View>

--- a/src/tokens/TokenBalanceItem.tsx
+++ b/src/tokens/TokenBalanceItem.tsx
@@ -8,7 +8,7 @@ import Warning from 'src/icons/status/Warning'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import { getDollarTokenLabelKey } from 'src/tokens/dollarGroup'
+import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { TokenBalance } from 'src/tokens/slice'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -37,13 +37,13 @@ export const TokenBalanceItem = ({
     if (token.tokenId === networkConfig.copmTokenId) {
       return t('assets.pesos')
     }
-    // Concrete dollar tokens (USDT/USDC/USDm/USAT) render with their specific
-    // brand name so the swap picker can distinguish them from the aggregated
-    // "Dolares" virtual row (tokenId='virtual:dolares', falls through to
+    // Concrete dollar tokens (USDT/USDC/USDm/USAT) render with their ticker
+    // so the swap picker can distinguish them from the aggregated "Dolares"
+    // virtual row (tokenId='virtual:dolares', falls through to
     // token.name = 'Dolares') that appears alongside them.
-    const dollarLabelKey = getDollarTokenLabelKey(token.tokenId)
-    if (dollarLabelKey) {
-      return t(dollarLabelKey)
+    const ticker = getDollarTokenTicker(token.tokenId)
+    if (ticker) {
+      return ticker
     }
     return token.name
   }

--- a/src/tokens/dollarGroup.ts
+++ b/src/tokens/dollarGroup.ts
@@ -19,23 +19,6 @@ export function getDollarTokenIds(): string[] {
   return Array.from(DOLLAR_TOKEN_IDS)
 }
 
-// Maps a concrete dollar tokenId to the i18n key for its specific brand name
-// (Tether USD / USD Coin / Dolar Mento / Tether America USD). Returns null
-// when the tokenId is not one of the four concrete dollar tokens; callers
-// fall back to the generic "Dolares" label or to `token.name`.
-//
-// Used so the swap picker can show distinct rows when both the aggregated
-// "Dolares" virtual token AND its underlying brands appear together.
-export function getDollarTokenLabelKey(tokenId: string): string | null {
-  if (tokenId === networkConfig.usdtTokenId) return 'assets.tetherUsd'
-  if (tokenId === networkConfig.usdcTokenId) return 'assets.usdCoin'
-  if (tokenId === networkConfig.usdmTokenId) return 'assets.mentoDollar'
-  if (networkConfig.usatTokenId && tokenId === networkConfig.usatTokenId) {
-    return 'assets.tetherAmericaUsd'
-  }
-  return null
-}
-
 // Concrete ticker for a dollar-family tokenId (USDT / USDC / USDm / USAT).
 // Used in the tx feed detail breakdown so the user sees "0.91 USDT" instead
 // of the localized brand name "0.91 Tether USD". Tickers are locale-neutral


### PR DESCRIPTION
## Rule

Aggregate view of USDT / USDC / USDm / USAT = "Dolares". Specific-token label = ticker (`USDT`, `USDC`, `USDm`, `USAT`). Never brand full names (`Tether USD`, `USD Coin`, `Dolar Mento`, `Tether America USD`).

## Change

Extend the ticker convention across the remaining six UI sites so the whole app follows the rule:

- [src/components/BalanceCard.tsx](src/components/BalanceCard.tsx) - home screen dolares breakdown rows.
- [src/tokens/TokenBalanceItem.tsx](src/tokens/TokenBalanceItem.tsx) - portfolio / token-list rows.
- [src/swap/SwapTransactionDetails.tsx](src/swap/SwapTransactionDetails.tsx) - pre-swap "Recibirás en" row.
- [src/gold/GoldBuyEnterAmount.tsx](src/gold/GoldBuyEnterAmount.tsx) - gold buy amount input label.
- [src/gold/GoldSellEnterAmount.tsx](src/gold/GoldSellEnterAmount.tsx) - gold sell amount input label + virtual settlement hint below the input.
- [src/gold/GoldSellConfirmation.tsx](src/gold/GoldSellConfirmation.tsx) - gold sell confirmation label.

`getDollarTokenLabelKey` had no live callers after the migration, so it is removed from [src/tokens/dollarGroup.ts](src/tokens/dollarGroup.ts). The i18n keys (`assets.tetherUsd`, `assets.usdCoin`, `assets.mentoDollar`, `assets.tetherAmericaUsd`) stay in the locale files for now; a follow-up pass can prune them once we confirm no external consumer references them.

## Verification

- `yarn build:ts` clean (13.5s)
- `yarn lint src/` clean (27s)
- `yarn jest src/{components,tokens,swap,gold,transactions}` 96 suites / 744 tests pass, 14 skipped.
- BalanceCard test assertion updated from `assets.tetherUsd` / `assets.mentoDollar` i18n key mocks to the literal ticker strings `USDT` / `USDm`.
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim.

## Result

The rule is now enforced app-wide. Every place the app used to say "Tether USD" / "USD Coin" / "Dolar Mento" / "Tether America USD" now says "USDT" / "USDC" / "USDm" / "USAT". The aggregate label "Dolares" is unchanged.