### PR TITLE
fix(feed): tx detail row layout is amount-icon-label + Pesos logo

### DIFF
--- a/src/components/TokenAmountWithBrand.tsx
+++ b/src/components/TokenAmountWithBrand.tsx
@@ -9,42 +9,54 @@ import DollarsIcon from 'src/icons/tokens/DollarsIcon'
 import { Spacing } from 'src/styles/styles'
 import { getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { useTokenInfo } from 'src/tokens/hooks'
+import networkConfig from 'src/web3/networkConfig'
 
 interface Props {
   amount: string
   tokenId: string
   testID: string
   textStyle: object
+  showApprox?: boolean
 }
 
-// Renders the on-chain amount (via TokenDisplay, which already caps decimals
-// and routes through `getTokenSymbol`) and appends the correct label:
-// - Virtual "Dolares" tokenId (used for multi-swap aggregates) -> "Dolares".
-// - Concrete dollar-family tokens (USDT / USDC / USDm / USAT) -> their ticker,
+// Renders `amount` `[icon]` `label`, in that order, per the project label
+// convention:
+// - Virtual "Dolares" (multi-swap aggregate) -> DollarsIcon + "Dolares".
+// - Concrete dollar-family (USDT / USDC / USDm / USAT) -> token icon + ticker,
 //   because "Dolares" is reserved for the aggregate view and the specific
 //   ticker is the canonical way to distinguish them elsewhere in the app
 //   (swap picker, tokens.md rule).
-// - Everything else -> TokenDisplay default (uses on-chain symbol).
-export default function TokenAmountWithBrand({ amount, tokenId, testID, textStyle }: Props) {
+// - COPm -> token icon + "Pesos".
+// - Everything else -> token icon + on-chain symbol via TokenDisplay default.
+export default function TokenAmountWithBrand({
+  amount,
+  tokenId,
+  testID,
+  textStyle,
+  showApprox,
+}: Props) {
   const { t } = useTranslation()
   const tokenInfo = useTokenInfo(tokenId)
   const ticker = getDollarTokenTicker(tokenId)
+  const approxPrefix = showApprox ? '≈ ' : ''
 
   if (tokenId === DOLARES_VIRTUAL_TOKEN_ID) {
     return (
       <View style={styles.brandRow}>
-        <DollarsIcon size={24} testID={`${testID}/Icon`} />
         <Text style={textStyle} testID={testID}>
-          {`${formatValueToDisplay(new BigNumber(amount))} ${t('assets.dollars')}`}
+          {`${approxPrefix}${formatValueToDisplay(new BigNumber(amount))}`}
         </Text>
+        <DollarsIcon size={24} testID={`${testID}/Icon`} />
+        <Text style={textStyle}>{t('assets.dollars')}</Text>
       </View>
     )
   }
 
+  const explicitLabel = ticker ?? (tokenId === networkConfig.copmTokenId ? t('assets.pesos') : null)
+
   return (
     <View style={styles.brandRow}>
-      {tokenInfo && <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />}
-      {ticker ? (
+      {explicitLabel ? (
         <>
           <TokenDisplay
             amount={amount}
@@ -52,20 +64,30 @@ export default function TokenAmountWithBrand({ amount, tokenId, testID, textStyl
             showLocalAmount={false}
             showSymbol={false}
             hideSign={true}
+            showApprox={showApprox}
             style={textStyle}
             testID={testID}
           />
-          <Text style={textStyle}>{` ${ticker}`}</Text>
+          {tokenInfo && (
+            <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />
+          )}
+          <Text style={textStyle}>{explicitLabel}</Text>
         </>
       ) : (
-        <TokenDisplay
-          amount={amount}
-          tokenId={tokenId}
-          showLocalAmount={false}
-          hideSign={true}
-          style={textStyle}
-          testID={testID}
-        />
+        <>
+          {tokenInfo && (
+            <TokenIcon token={tokenInfo} size={IconSize.SMALL} testID={`${testID}/Icon`} />
+          )}
+          <TokenDisplay
+            amount={amount}
+            tokenId={tokenId}
+            showLocalAmount={false}
+            hideSign={true}
+            showApprox={showApprox}
+            style={textStyle}
+            testID={testID}
+          />
+        </>
       )}
     </View>
   )

--- a/src/transactions/feed/detailContent/SwapContent.tsx
+++ b/src/transactions/feed/detailContent/SwapContent.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import RowDivider from 'src/components/RowDivider'
 import TokenAmountWithBrand from 'src/components/TokenAmountWithBrand'
-import TokenDisplay, { formatValueToDisplay } from 'src/components/TokenDisplay'
+import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -60,26 +60,20 @@ export default function SwapContent({ transaction }: Props) {
       ) : (
         <View style={styles.row}>
           <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapFrom')}</Text>
-          <TokenDisplay
-            style={styles.currencyAmountPrimaryText}
-            amount={transaction.outAmount.value}
+          <TokenAmountWithBrand
+            amount={transaction.outAmount.value.toString()}
             tokenId={transaction.outAmount.tokenId}
-            showLocalAmount={false}
-            showSymbol={true}
-            hideSign={true}
+            textStyle={styles.currencyAmountPrimaryText}
             testID="SwapContent/swapFrom"
           />
         </View>
       )}
       <View style={styles.row}>
         <Text style={styles.bodyText}>{t('swapTransactionDetailPage.swapTo')}</Text>
-        <TokenDisplay
-          style={styles.currencyAmountPrimaryText}
-          amount={transaction.inAmount.value}
+        <TokenAmountWithBrand
+          amount={transaction.inAmount.value.toString()}
           tokenId={transaction.inAmount.tokenId}
-          showLocalAmount={false}
-          showSymbol={true}
-          hideSign={true}
+          textStyle={styles.currencyAmountPrimaryText}
           showApprox={
             !!transaction.inAmount.value && transaction.status === TransactionStatus.Pending
           }


### PR DESCRIPTION
## Change

Every row of the tx detail (and the tx success screen breakdown) now reads left-to-right as `amount`, `token icon`, `label`, and the "Cambiar a" COPm row picks up the Pesos icon + `Pesos` label instead of falling through to a plain amount.

Before / after for the multi-leg $3 spike v2 batch:

```
before                             after
Cambiar de   [icon] 0.91 USDT      Cambiar de   0.91 [icon] USDT
Cambiar de   [icon] 1.04 USDC      Cambiar de   1.04 [icon] USDC
Cambiar de   [icon] 1.04 USDm      Cambiar de   1.04 [icon] USDm
Cambiar a    9,991.88 Pesos        Cambiar a    9,991.88 [icon] Pesos
```

## Implementation

- Reorder the JSX inside [TokenAmountWithBrand](src/components/TokenAmountWithBrand.tsx) to `amount` -> `icon` -> `label` for the dollar-family branch, the fallback branch, and the virtual-Dolares branch.
- Add the COPm case: `tokenId === copmTokenId` -> explicit `Pesos` label so the row reads "amount, Pesos icon, Pesos".
- Add a `showApprox` pass-through so pending cross-chain swaps still prefix `≈` (existing test asserts this).
- Wire `TokenAmountWithBrand` into [SwapContent.tsx](src/transactions/feed/detailContent/SwapContent.tsx) for the single-leg `Cambiar de` row and the `Cambiar a` row. Both used to be bare `TokenDisplay`. Now every row goes through one component so the layout is consistent across single-leg, multi-leg, dollar-family, COPm, and unknown-token cases.

## Verification

- `yarn build:ts` clean (12.6s)
- `yarn lint src/` clean (26.6s)
- `yarn jest src/transactions src/components/BalanceCard` 178 pass, 14 skipped, 20 suites green (including the pending cross-chain `≈ 0.00003 ETH` assertion that the first pass broke, now passing again after adding `showApprox`)
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim