### PR TITLE
fix(wri/7702): success screen shows aggregate Dolares + per-leg breakdown

### DIFF
--- a/src/dollarsSpend/saga7702.ts
+++ b/src/dollarsSpend/saga7702.ts
@@ -13,6 +13,7 @@ import {
   multiSwapStepSucceeded,
   multiSwapTransitionComplete,
 } from 'src/dollarsSpend/slice'
+import { DOLARES_VIRTUAL_TOKEN_ID } from 'src/dollarsSpend/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { fetchSwapQuoteForExecution } from 'src/swap/useSwapQuote'
@@ -517,17 +518,33 @@ export function* executeDollarsSpend7702Saga(action: PayloadAction<ExecuteMultiS
     // directly, skipping the success screen entirely and breaking parity
     // with every other transaction flow in the wallet.
     //
-    // Aggregate amounts: fromAmount is total USD spent (1:1 USDm), toAmount
-    // is total COPm received, fromTokenId is pinned to USDm (renders as
-    // "Dolares" via the brand label resolver).
+    // When the batch had more than one leg, use the synthetic virtual
+    // "Dolares" tokenId so the header row renders as "3.00 Dolares" (via
+    // the DOLARES_VIRTUAL_TOKEN_ID branch of TokenAmountWithBrand) instead
+    // of naming one specific stablecoin. The per-leg breakdown is passed
+    // through `legs` so the screen shows the concrete USDT / USDC / USDm
+    // amounts under the aggregate. Single-leg batches keep the concrete
+    // tokenId so the header just shows "1.04 USDm" with no breakdown.
+    const isMultiLeg = stepOutcomes.length > 1
+    const successLegs = isMultiLeg
+      ? stepOutcomes.map((o) => ({
+          fromTokenId: o.tokenId,
+          fromAmount: o.outAmountTokenWhole.toFixed(),
+          toAmount: o.inAmountTokenWhole.toFixed(),
+          transactionHash: hash,
+        }))
+      : undefined
     navigate(Screens.TransactionSuccessScreen, {
-      fromTokenId: networkConfig.usdmTokenId,
+      fromTokenId: isMultiLeg ? DOLARES_VIRTUAL_TOKEN_ID : stepOutcomes[0].tokenId,
       toTokenId,
-      fromAmount: totalOutUsd.toFixed(),
+      fromAmount: isMultiLeg
+        ? totalOutUsd.toFixed()
+        : stepOutcomes[0].outAmountTokenWhole.toFixed(),
       toAmount: totalInAmount.toFixed(),
       transactionHash: hash,
       networkId: NetworkId['celo-mainnet'],
       type: 'swap' as const,
+      ...(successLegs && { legs: successLegs }),
     })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Bug

For a multi-token 7702 atomic batch (e.g. $3.40 = USDT + USDC + USDm), the success screen rendered the "De" row as `3.40 USDm` with no breakdown. The user cannot tell which stablecoins were actually spent.

## Root cause

[saga7702.ts](src/dollarsSpend/saga7702.ts) hardcoded `fromTokenId: networkConfig.usdmTokenId` on the `navigate(TransactionSuccessScreen)` call. The legacy dollarsSpend saga uses the virtual `DOLARES_VIRTUAL_TOKEN_ID` + `legs[]` array shape which `TransactionSuccessScreen` already renders correctly (aggregate `[amount] [DollarsIcon] Dolares` header + per-leg breakdown). The 7702 path had drifted after PR #239 shipped the aggregate flow for the legacy path only.

## Fix

Restore parity:
- `stepOutcomes.length > 1` -> `fromTokenId: DOLARES_VIRTUAL_TOKEN_ID` + `legs[]` derived from `stepOutcomes`. All legs share the batch hash because the tx is atomic.
- Single-leg batches keep the concrete tokenId + no `legs` field, so the header still reads e.g. `1.04 USDm` without an unnecessary breakdown block.

## Result

Multi-token batch success screen now reads:

```
De    3.40  [DollarsIcon]  Dolares
A     11,324.84  [Pesos icon]  Pesos

DETALLE POR MONEDA
[USDT icon] 0.91  ->  3,034 [Pesos icon]
[USDC icon] 1.04  ->  3,478 [Pesos icon]
[USDm icon] 1.04  ->  3,479 [Pesos icon]
```

Single-leg batches read as before, no breakdown.

## Verification

- `yarn build:ts` clean (12.6s)
- `yarn lint src/` clean (28s)
- `yarn jest src/dollarsSpend src/transactions` 225 pass, 14 skipped, 31 suites green
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim