### PR TITLE
feat(inputs): predictive over-balance red input + swap fix

### DIFF
--- a/src/components/TokenEnterAmount.tsx
+++ b/src/components/TokenEnterAmount.tsx
@@ -288,6 +288,7 @@ export default function TokenEnterAmount({
   onInputChange,
   toggleAmountType,
   onOpenTokenPicker,
+  hasError = false,
 }: {
   token?: TokenBalance
   inputValue: string
@@ -302,6 +303,11 @@ export default function TokenEnterAmount({
   onInputChange(value: string): void
   toggleAmountType?(): void
   onOpenTokenPicker?(): void
+  // Predictive visual signal that the typed amount crossed a validation
+  // threshold (over-balance, over-cap, etc.). When true, colors the amount
+  // red so the user sees the problem before submit — the inline warning
+  // below explains what happened.
+  hasError?: boolean
 }) {
   const { t } = useTranslation()
   // the startPosition and inputRef variables exist to ensure TextInput
@@ -410,6 +416,7 @@ export default function TokenEnterAmount({
               styles.primaryAmountText,
               inputStyle,
               Platform.select({ ios: { lineHeight: undefined } }),
+              hasError && styles.amountInputError,
             ]}
             onBlur={() => {
               handleSetStartPosition(0)
@@ -500,6 +507,9 @@ const styles = StyleSheet.create({
     paddingTop: 0,
     paddingBottom: 0,
     color: Colors.black,
+  },
+  amountInputError: {
+    color: Colors.error,
   },
   secondaryAmountText: {
     ...typeScale.bodyMedium,

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -432,6 +432,7 @@ function EarnEnterAmount({ route }: Props) {
                 autoFocus
                 placeholder={new BigNumber(0).toFormat(2)}
                 testID="EarnEnterAmount/TokenAmountInput"
+                hasError={!!tokenAmount && !isAmountLessThanBalance}
               />
               <Touchable
                 borderRadius={TOKEN_SELECTOR_BORDER_RADIUS}
@@ -456,6 +457,7 @@ function EarnEnterAmount({ route }: Props) {
                 placeholder={`${localCurrencySymbol}${new BigNumber(0).toFormat(2)}`}
                 testID="EarnEnterAmount/LocalAmountInput"
                 editable={!!transactionToken.priceUsd}
+                hasError={!!tokenAmount && !isAmountLessThanBalance}
               />
             </View>
           </View>

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -431,6 +431,7 @@ export default function GoldBuyEnterAmount({ route }: Props) {
                 autoFocus
                 placeholder={new BigNumber(0).toFormat(2)}
                 testID="GoldBuyEnterAmount/TokenAmountInput"
+                hasError={!!insufficientBalance}
               />
               {selectedToken && (
                 <Touchable

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -296,6 +296,7 @@ export default function GoldSellEnterAmount(_props: Props) {
                 autoFocus
                 placeholder={new BigNumber(0).toFormat(XAUT0_DECIMALS)}
                 testID="GoldSellEnterAmount/GoldAmountInput"
+                hasError={!!insufficientBalance}
               />
               <View style={styles.goldBadge}>
                 <GoldIconSelector size={20} />

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -244,6 +244,7 @@ export default function EnterAmount({
             amountType={amountType}
             toggleAmountType={handleToggleAmountType}
             onOpenTokenPicker={tokenSelectionDisabled ? undefined : onOpenTokenPicker}
+            hasError={!!showLowerAmountError}
           />
 
           {!!maxFeeAmount && !!amount && (
@@ -373,6 +374,9 @@ const styles = StyleSheet.create({
     flex: 1,
     marginRight: Spacing.Smallest8,
   },
+  amountInputError: {
+    color: Colors.error,
+  },
   feeContainer: {
     marginVertical: Spacing.Regular16,
     padding: Spacing.Regular16,
@@ -419,6 +423,7 @@ export function AmountInput({
   placeholder = '0',
   testID = 'AmountInput',
   editable = true,
+  hasError = false,
 }: {
   inputValue: string
   onInputChange(value: string): void
@@ -428,6 +433,11 @@ export function AmountInput({
   placeholder?: string
   testID?: string
   editable?: boolean
+  // When true, colors the typed amount red so the user gets predictive
+  // feedback as they cross a validation threshold (over-balance, over-cap,
+  // etc.). The inline InLineNotification below the input still explains
+  // what went wrong; this prop is the fast visual signal.
+  hasError?: boolean
 }) {
   // the startPosition and inputRef variables exist to ensure TextInput
   // displays the start of the value for long values on Android
@@ -459,7 +469,11 @@ export function AmountInput({
         // unset lineHeight to allow ellipsis on long inputs on iOS. For
         // android, ellipses doesn't work and unsetting line height causes
         // height changes when amount is entered
-        inputStyle={[inputStyle, Platform.select({ ios: { lineHeight: undefined } })]}
+        inputStyle={[
+          inputStyle,
+          Platform.select({ ios: { lineHeight: undefined } }),
+          hasError && styles.amountInputError,
+        ]}
         testID={testID}
         onBlur={() => {
           handleSetStartPosition(0)

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -338,7 +338,6 @@ export function SwapScreen({ route }: Props) {
     inputSwapAmount,
     selectingField,
     selectingNoUsdPriceToken,
-    confirmingSwap,
     switchedToNetworkId,
     startedSwapId,
     selectedPercentage,
@@ -437,8 +436,11 @@ export function SwapScreen({ route }: Props) {
     fromTokenBalance.gt(0) &&
     parsedSwapAmount[Field.FROM].gte(fromTokenBalance)
 
-  const fromSwapAmountError =
-    !isVirtualDolares && confirmingSwap && parsedSwapAmount[Field.FROM].gt(fromTokenBalance)
+  // Predictive: red-highlight the amount the moment it exceeds the wallet
+  // balance, without waiting for the user to press "Swap". Virtual Dolares
+  // rows compare against the aggregate, handled by the SwapScreen validator
+  // path elsewhere, so we skip this check for it.
+  const fromSwapAmountError = !isVirtualDolares && parsedSwapAmount[Field.FROM].gt(fromTokenBalance)
 
   // Compare against quoteToToken because for virtual "Dolares" the quote
   // settles into the concrete fallback (USDT) while toToken stays virtual


### PR DESCRIPTION
## What

Unify how the wallet tells the user "you're exceeding your balance". The check now fires while the user is still typing, colours the amount itself red so the problem is impossible to miss, and preserves the existing inline warning that explains what happened.

## Screens touched

- **Send** (`src/send/EnterAmount.tsx`): TokenEnterAmount now receives `hasError={!!showLowerAmountError}`. Already predictive in the CTA-disable path, now visually as well.
- **Earn / Neeru / Allbridge** (`src/earn/EarnEnterAmount.tsx`): both the token input and the local amount input wire `hasError={!!tokenAmount && !isAmountLessThanBalance}`, so Neeru deposits and Allbridge / Aave deposits go red the moment the amount exceeds the wallet balance.
- **Gold Buy** (`src/gold/GoldBuyEnterAmount.tsx`): `hasError={!!insufficientBalance}`.
- **Gold Sell** (`src/gold/GoldSellEnterAmount.tsx`): `hasError={!!insufficientBalance}`.
- **Swap** (`src/swap/SwapScreen.tsx`): drop the `confirmingSwap` guard on `fromSwapAmountError`. Previously the FROM amount only turned red after the user pressed "Swap", which contradicted every other screen. Now it fires while the user types.

## Shared components

- `src/components/TokenEnterAmount.tsx`: new `hasError?: boolean` prop paints the primary amount text in `Colors.error`.
- `src/send/EnterAmount.tsx` (the shared `AmountInput`): same new `hasError?: boolean` prop with an `amountInputError` style, so send / earn / gold all get the same treatment through a single component.

## Verification

- `yarn build:ts` clean.
- `yarn lint src/` clean.
- `yarn jest src/{send,earn,gold,swap}` runs 47 suites / 475 tests green.

## Related

Companion to the store submission of 1.118.6 — this ships in the next release. Not required for the store cut that already happened; it goes out in the next version.