### PR TITLE
feat(earn): headline pool rate in E.A. and group cards by provider

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2745,6 +2745,13 @@
       "network": "Network",
       "fees": "Fees"
     },
+    "section": {
+      "neeru": "Neeru",
+      "allbridge": "Allbridge",
+      "aave": "Aave",
+      "marranitos": "Marranitos",
+      "others": "Others"
+    },
     "home": {
       "title": "Earn",
       "learnMore": "<0>Learn more</0> about yield pools.",
@@ -2775,6 +2782,8 @@
       "addToPool": "Add to Pool",
       "apy": "{{apy}}% APY",
       "percentage": "{{percentage}}%",
+      "percentageEa": "{{percentage}}% APY",
+      "mvEquivalent": "Approx {{percentage}}% monthly",
       "poweredBy": "Powered by {{providerName}}",
       "deposited": "Supplied",
       "depositAndEarnings": "Deposit & Earnings",

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -2726,6 +2726,13 @@
       "network": "Network",
       "fees": "Fees"
     },
+    "section": {
+      "neeru": "Neeru",
+      "allbridge": "Allbridge",
+      "aave": "Aave",
+      "marranitos": "Marranitos",
+      "others": "Others"
+    },
     "home": {
       "title": "Earn",
       "learnMore": "<0>Learn more</0> about yield pools.",
@@ -2756,6 +2763,8 @@
       "addToPool": "Add to Pool",
       "apy": "{{apy}}% APY",
       "percentage": "{{percentage}}%",
+      "percentageEa": "{{percentage}}% APY",
+      "mvEquivalent": "Approx {{percentage}}% monthly",
       "poweredBy": "Powered by {{providerName}}",
       "deposited": "Supplied",
       "depositAndEarnings": "Deposit & Earnings"

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2752,6 +2752,13 @@
       "network": "Red",
       "fees": "Tarifas"
     },
+    "section": {
+      "neeru": "Neeru",
+      "allbridge": "Allbridge",
+      "aave": "Aave",
+      "marranitos": "Marranitos",
+      "others": "Otros"
+    },
     "home": {
       "title": "Tu dinero crece",
       "learnMore": "<0>Más información</0> sobre las pools de rendimiento.",
@@ -2782,6 +2789,8 @@
       "addToPool": "Depositar",
       "apy": "{{apy}}% de APY",
       "percentage": "{{percentage}}%",
+      "percentageEa": "{{percentage}}% E.A.",
+      "mvEquivalent": "Equivale a {{percentage}}% M.V.",
       "poweredBy": "Con tecnología de {{providerName}}",
       "deposited": "Suministrado",
       "depositAndEarnings": "Depósitos y ganancias",

--- a/src/earn/EarnHome.tsx
+++ b/src/earn/EarnHome.tsx
@@ -51,6 +51,67 @@ const HEADER_OPACITY_ANIMATION_DISTANCE = 20
 
 export const MARRANITOS_POSITION_TYPE = 'marranitos'
 export const MY_MARRANITOS_POSITION_TYPE = 'misMarranitos'
+export const SECTION_HEADER_TYPE = 'sectionHeader'
+
+// Fixed section order for the "haz crecer tu dinero" list. Keeps the layout
+// predictable regardless of how the backend orders pools day-to-day. Providers
+// not in this list fall through to the trailing "otros" bucket.
+const SECTION_ORDER: Array<{ id: string; titleKey: string; match: (item: any) => boolean }> = [
+  {
+    id: 'neeru',
+    titleKey: 'earnFlow.section.neeru',
+    match: (item) => item?.appId === 'neeru-vaults',
+  },
+  {
+    id: 'allbridge',
+    titleKey: 'earnFlow.section.allbridge',
+    match: (item) => item?.appId === 'allbridge',
+  },
+  {
+    id: 'aave',
+    titleKey: 'earnFlow.section.aave',
+    match: (item) => item?.appId === 'aave',
+  },
+  {
+    id: 'marranitos',
+    titleKey: 'earnFlow.section.marranitos',
+    match: (item) =>
+      item?.positionType === MARRANITOS_POSITION_TYPE ||
+      item?.positionType === MY_MARRANITOS_POSITION_TYPE,
+  },
+]
+
+// Interleaves section header pseudo-items between grouped pools so the flat
+// list rendering in PoolList can lay them out with headers without a full
+// SectionList refactor. Items not matching any known section go into an
+// "others" bucket rendered last.
+function groupPoolsIntoSections(pools: any[]) {
+  if (pools.length === 0) return []
+  const buckets: Record<string, any[]> = {}
+  const others: any[] = []
+  for (const section of SECTION_ORDER) buckets[section.id] = []
+  for (const pool of pools) {
+    const section = SECTION_ORDER.find((s) => s.match(pool))
+    if (section) buckets[section.id].push(pool)
+    else others.push(pool)
+  }
+  const out: any[] = []
+  for (const section of SECTION_ORDER) {
+    const items = buckets[section.id]
+    if (items.length === 0) continue
+    out.push({ positionType: SECTION_HEADER_TYPE, id: section.id, titleKey: section.titleKey })
+    out.push(...items)
+  }
+  if (others.length > 0) {
+    out.push({
+      positionType: SECTION_HEADER_TYPE,
+      id: 'others',
+      titleKey: 'earnFlow.section.others',
+    })
+    out.push(...others)
+  }
+  return out
+}
 
 type Props = NativeStackScreenProps<StackParamList, Screens.EarnHome>
 
@@ -292,7 +353,7 @@ export default function EarnHome({ navigation, route }: Props) {
     }
   }, [walletAddress])
 
-  const allPools = useMemo(() => {
+  const flatPools = useMemo(() => {
     const marranitos =
       activeTab === EarnTabType.AllPools ? marranitos_pools.filter((pool) => pool.isActive) : stakes
     return [
@@ -305,8 +366,14 @@ export default function EarnHome({ navigation, route }: Props) {
     ]
   }, [displayPools, tokenList, marranitos_pools, activeTab])
 
+  // Interleaved with section-header pseudo-items so the flat list rendering
+  // in PoolList can group pools by provider (Neeru, Allbridge, ...). Empty
+  // states below use `flatPools` because header items would falsely inflate
+  // the length even when zero real pools are available.
+  const allPools = useMemo(() => groupPoolsIntoSections(flatPools), [flatPools])
+
   const zeroPoolsinMyPoolsTab =
-    !errorLoadingPools && allPools.length === 0 && activeTab === EarnTabType.MyPools
+    !errorLoadingPools && flatPools.length === 0 && activeTab === EarnTabType.MyPools
 
   const loadStakes = async () => {
     if (!walletAddress) return
@@ -351,8 +418,8 @@ export default function EarnHome({ navigation, route }: Props) {
             <EarnTabBar activeTab={activeTab} onChange={handleChangeActiveView} />
           </View>
         </Animated.View>
-        {((allPools.length === 0 && activeTab === EarnTabType.AllPools) ||
-          (allPools.length === 0 && errorLoadingPools)) && (
+        {((flatPools.length === 0 && activeTab === EarnTabType.AllPools) ||
+          (flatPools.length === 0 && errorLoadingPools)) && (
           <View style={styles.textContainer}>
             <AttentionIcon size={48} color={Colors.black} />
             <Text style={styles.errorTitle}>{t('earnFlow.home.errorTitle')}</Text>
@@ -366,7 +433,7 @@ export default function EarnHome({ navigation, route }: Props) {
             <Text style={styles.description}>{t('earnFlow.home.noPoolsDescription')}</Text>
           </View>
         )}
-        {!!allPools.length &&
+        {!!flatPools.length &&
           !errorLoadingPools &&
           !zeroPoolsinMyPoolsTab &&
           (activeTab === EarnTabType.AllPools || activeTab === EarnTabType.MyPools) && (

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -22,6 +22,7 @@ import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
 import { NeeruTrancheId, trancheIdFromPositionId } from 'src/earn/neeru/constants'
+import { effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
 
 const NEERU_CARD_SUBTITLE_KEY_BY_TRANCHE: Record<NeeruTrancheId, string> = {
   0: 'neeruVaults.cardSubtitle.flexible',
@@ -90,7 +91,19 @@ export default function PoolCard({
     return `${localCurrencySymbol}${tvlInFiat ? formatValueToDisplay(tvlInFiat) : '--'}`
   }, [localCurrencySymbol, tvlInFiat])
 
-  const totalYieldRate = getTotalYieldRate(pool).toFixed(2)
+  const rawYieldRate = getTotalYieldRate(pool).toNumber()
+  const totalYieldRate = rawYieldRate.toFixed(2)
+  // Neeru quotes a monthly effective rate (M.V.). The headline on the card
+  // needs to be the annual effective rate (E.A.) so the number is directly
+  // comparable to bank promos and other DeFi surfaces the user browses. Keep
+  // the monthly rate visible as a smaller subtitle so no context is lost.
+  const isNeeruPool = pool.appId === 'neeru-vaults'
+  const neeruRates = useMemo(() => {
+    if (!isNeeruPool) return null
+    const mv = rawYieldRate
+    const ea = effectiveAnnualPercentFromMonthly(mv)
+    return { mv: mv.toFixed(2), ea: ea.toFixed(2) }
+  }, [isNeeruPool, rawYieldRate])
 
   // Card title is always the user-friendly token display name per the wallet manual
   // (cCOP -> Pesos, USDT/USDC/USDm -> Dolares, etc).
@@ -148,11 +161,22 @@ export default function PoolCard({
           <View style={styles.keyValueContainer}>
             <View style={styles.keyValueRow}>
               <Text style={styles.keyText}>{t('earnFlow.poolCard.yieldRate')}</Text>
-              <Text style={styles.valueTextBold}>
-                {t('earnFlow.poolCard.percentage', {
-                  percentage: totalYieldRate,
-                })}
-              </Text>
+              {neeruRates ? (
+                <View style={styles.rateStackContainer} testID="PoolCard/NeeruRateStack">
+                  <Text style={styles.valueTextBold}>
+                    {t('earnFlow.poolCard.percentageEa', { percentage: neeruRates.ea })}
+                  </Text>
+                  <Text style={styles.rateEquivalent}>
+                    {t('earnFlow.poolCard.mvEquivalent', { percentage: neeruRates.mv })}
+                  </Text>
+                </View>
+              ) : (
+                <Text style={styles.valueTextBold}>
+                  {t('earnFlow.poolCard.percentage', {
+                    percentage: totalYieldRate,
+                  })}
+                </Text>
+              )}
             </View>
             <View style={styles.keyValueRow}>
               <Text style={styles.keyText}>{t('earnFlow.poolCard.tvl')}</Text>
@@ -236,5 +260,12 @@ const styles = StyleSheet.create({
     gap: Spacing.Smallest8,
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  rateStackContainer: {
+    alignItems: 'flex-end',
+  },
+  rateEquivalent: {
+    ...typeScale.bodyXSmall,
+    color: Colors.gray3,
   },
 })

--- a/src/earn/PoolList.tsx
+++ b/src/earn/PoolList.tsx
@@ -15,7 +15,11 @@ import { NotificationVariant } from 'src/components/InLineNotification'
 import { showToast } from 'src/components/showToast'
 import Animated from 'react-native-reanimated'
 import { useSelector } from 'react-redux'
-import { MARRANITOS_POSITION_TYPE, MY_MARRANITOS_POSITION_TYPE } from 'src/earn/EarnHome'
+import {
+  MARRANITOS_POSITION_TYPE,
+  MY_MARRANITOS_POSITION_TYPE,
+  SECTION_HEADER_TYPE,
+} from 'src/earn/EarnHome'
 import MarranitosContract, { STAKING_ADDRESS } from 'src/earn/marranitos/MarranitosContract'
 import MarranitosPoolCard from 'src/earn/marranitos/MarranitosPoolCard'
 import { RenderStakeItem } from 'src/earn/marranitos/RenderStakeItem'
@@ -153,7 +157,11 @@ export default function PoolList({
     <AnimatedFlatList
       data={displayPools}
       renderItem={({ item }) =>
-        item.positionType == MARRANITOS_POSITION_TYPE ? (
+        item.positionType == SECTION_HEADER_TYPE ? (
+          <Text style={styles.sectionHeader} testID={`PoolList/SectionHeader/${item.id}`}>
+            {t(item.titleKey)}
+          </Text>
+        ) : item.positionType == MARRANITOS_POSITION_TYPE ? (
           <MarranitosPoolCard
             pool={item}
             testID={`PoolCard/${item.positionId}`}
@@ -171,7 +179,9 @@ export default function PoolList({
           <PoolCard pool={item} testID={`PoolCard/${item.positionId}`} />
         )
       }
-      keyExtractor={(item) => item.positionId}
+      keyExtractor={(item) =>
+        item.positionType === SECTION_HEADER_TYPE ? `section-${item.id}` : item.positionId
+      }
       onScroll={handleScroll}
       // Workaround iOS setting an incorrect automatic inset at the top
       scrollIndicatorInsets={{ top: 0.01 }}
@@ -217,5 +227,11 @@ const styles = StyleSheet.create({
     ...typeScale.bodySmall,
     fontWeight: '600',
     textDecorationLine: 'underline',
+  },
+  sectionHeader: {
+    ...typeScale.labelSemiBoldMedium,
+    color: Colors.black,
+    marginTop: Spacing.Small12,
+    marginBottom: Spacing.Smallest8,
   },
 })

--- a/src/earn/neeru/rateConversion.ts
+++ b/src/earn/neeru/rateConversion.ts
@@ -9,6 +9,18 @@ export function monthlyPercentFromDailyRateRay(dailyRateRay: string): number {
   return Number(monthly.toFixed(6))
 }
 
+// Colombian financial-rate convention: Neeru quotes a monthly effective rate
+// (M.V. = mensual vencido). The user-facing headline in the wallet should be
+// the annual effective rate (E.A. = efectivo anual) so the number compares
+// against every other yield surface (bank promos, other DeFi cards). Exact
+// conversion: E.A. = ((1 + M.V./100)^12 - 1) * 100.
+export function effectiveAnnualPercentFromMonthly(monthlyPercent: number): number {
+  if (monthlyPercent <= 0) return 0
+  const monthlyRate = new BigNumber(monthlyPercent).dividedBy(100)
+  const annual = monthlyRate.plus(1).pow(12).minus(1).multipliedBy(100)
+  return Number(annual.toFixed(6))
+}
+
 export function computePayout({
   principal,
   accruedInterest,


### PR DESCRIPTION
## Two Neeru/Allbridge UX gaps on the Earn tab

### 1) Pool card rate: show E.A. big + M.V. small (Neeru)

Neeru quotes its yield as a monthly effective rate (M.V. = mensual vencido). The card used to render that number without any qualifier, so users read it as annual and dramatically underestimated the return. A `1.5% M.V.` reads like a bank checking account when it is actually `~19.6% E.A.`.

The headline is now the annual effective rate (E.A. = efectivo anual):

```
E.A. = ((1 + M.V. / 100) ^ 12 - 1) * 100
```

The monthly rate stays on the card as a smaller subtitle so the user sees where the annual number comes from.

- Add `effectiveAnnualPercentFromMonthly` in [src/earn/neeru/rateConversion.ts](src/earn/neeru/rateConversion.ts).
- Update [src/earn/PoolCard.tsx](src/earn/PoolCard.tsx) to render `X.XX% E.A.` big + `Equivale a Y.YY% M.V.` small for Neeru pools.
- Non-Neeru pools (Allbridge, Aave) keep the existing `X.XX%` since those providers already report annual rates.
- New i18n keys `earnFlow.poolCard.percentageEa` and `earnFlow.poolCard.mvEquivalent` in es-419, en-US, base.

### 2) Section grouping in the pool list

The list was one flat FlatList mixing Neeru, Allbridge, Marranitos in whatever order the backend returned them. Cards now sit under a bold provider header, in the fixed order: **Neeru → Allbridge → Aave → Marranitos → Otros**.

- Add `groupPoolsIntoSections` in [src/earn/EarnHome.tsx](src/earn/EarnHome.tsx) that interleaves section-header pseudo-items between grouped pools.
- Update [src/earn/PoolList.tsx](src/earn/PoolList.tsx) to render a `Text` header when the item's `positionType === SECTION_HEADER_TYPE`.
- Empty-state and MyPools zero-state checks switched to `flatPools` so header pseudo-items do not inflate the length.
- New i18n keys `earnFlow.section.{neeru,allbridge,aave,marranitos,others}` in es-419, en-US, base.

## Result

Neeru card rate stops confusing users about compounding, and every provider gets a clean visual header the user can scan.

## Verification

- `yarn build:ts` clean.
- `yarn lint src/earn` clean.
- `yarn jest src/earn` 29 suites / 242 tests green.