### PR TITLE
fix(earn): show 'Pesos' not 'cCOP' + Neeru tranche explainer '?'

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2946,6 +2946,24 @@
       "sixtyDays": "60-day deposit",
       "ninetyDays": "90-day deposit"
     },
+    "explainer": {
+      "flexible": {
+        "title": "Flexible deposit",
+        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no penalties. Interest accrues daily at the E.A. rate shown on the card. Ideal if you want full flexibility."
+      },
+      "thirtyDays": {
+        "title": "30-day deposit",
+        "body": "Your capital is locked for 30 days. At maturity you withdraw principal + interest at no cost.\n\nIf you need to withdraw earlier, a 20% fee is charged ON THE INTEREST EARNED only (never on your capital). Interest accrues daily."
+      },
+      "sixtyDays": {
+        "title": "60-day deposit",
+        "body": "Your capital is locked for 60 days. At maturity you withdraw principal + interest at no cost. Usually pays a higher rate than Flexible and 30 days.\n\nIf you need to withdraw earlier, a 20% fee is charged ON THE INTEREST EARNED only (never on your capital). Interest accrues daily."
+      },
+      "ninetyDays": {
+        "title": "90-day deposit",
+        "body": "Your capital is locked for 90 days. At maturity you withdraw principal + interest at no cost. Usually the highest rate.\n\nIf you need to withdraw earlier, a 20% fee is charged ON THE INTEREST EARNED only (never on your capital). Interest accrues daily."
+      }
+    },
     "detail": {
       "header": "Your {{trancheLabel}} positions",
       "aggregateBalance": "Total in {{trancheLabel}}: {{amount}} Pesos",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2953,6 +2953,24 @@
       "sixtyDays": "Deposito a 60 dias",
       "ninetyDays": "Deposito a 90 dias"
     },
+    "explainer": {
+      "flexible": {
+        "title": "Depósito Flexible",
+        "body": "Depositá y retirá tus Pesos cuando quieras, sin plazo mínimo ni penalizaciones. Los intereses se acumulan a diario a la tasa E.A. que ves en la card. Ideal si querés flexibilidad total."
+      },
+      "thirtyDays": {
+        "title": "Depósito a 30 días",
+        "body": "Tu capital queda bloqueado por 30 días. Al vencer, retirás capital + intereses sin ningún cargo.\n\nSi necesitás retirar antes, se aplica una comisión del 20% SOBRE LOS INTERESES ganados (nunca sobre tu capital). Los intereses se acumulan a diario."
+      },
+      "sixtyDays": {
+        "title": "Depósito a 60 días",
+        "body": "Tu capital queda bloqueado por 60 días. Al vencer, retirás capital + intereses sin ningún cargo. Suele pagar mejor tasa que Flexible y 30 días.\n\nSi necesitás retirar antes, se aplica una comisión del 20% SOBRE LOS INTERESES ganados (nunca sobre tu capital). Los intereses se acumulan a diario."
+      },
+      "ninetyDays": {
+        "title": "Depósito a 90 días",
+        "body": "Tu capital queda bloqueado por 90 días. Al vencer, retirás capital + intereses sin ningún cargo. Es la opción que suele pagar la mejor tasa.\n\nSi necesitás retirar antes, se aplica una comisión del 20% SOBRE LOS INTERESES ganados (nunca sobre tu capital). Los intereses se acumulan a diario."
+      }
+    },
     "detail": {
       "header": "Tus depositos {{trancheLabel}}",
       "aggregateBalance": "Total en {{trancheLabel}}: {{amount}} Pesos",

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -47,7 +47,7 @@ import {
   useTotalTokenBalance,
 } from 'src/tokens/hooks'
 import { tokenFetchErrorSelector } from 'src/tokens/selectors'
-import { getSupportedNetworkIdsForTokenBalances } from 'src/tokens/utils'
+import { getSupportedNetworkIdsForTokenBalances, getTokenDisplayName } from 'src/tokens/utils'
 
 function TokenBalance({
   style = styles.balance,
@@ -110,7 +110,7 @@ function TokenBalance({
           {!hideBalance && (
             <Text style={styles.tokenBalance}>
               {formatValueToDisplay(tokenBalance)}{' '}
-              {tokensWithUsdValue[0].symbol === 'cCOP' ? 'COPm' : tokensWithUsdValue[0].symbol}
+              {getTokenDisplayName(tokensWithUsdValue[0].symbol)}
             </Text>
           )}
         </View>

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -182,7 +182,7 @@ describe('EarnEnterAmount', () => {
       )
 
       expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeTruthy()
-      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('USDC')
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('Dólares')
       expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeDisabled()
       expect(queryByTestId('downArrowIcon')).toBeFalsy()
     })
@@ -422,7 +422,7 @@ describe('EarnEnterAmount', () => {
       )
 
       expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeTruthy()
-      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('USDC')
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('Dólares')
       expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeDisabled()
       expect(queryByTestId('downArrowIcon')).toBeFalsy()
     })

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -45,6 +45,7 @@ import { useLocalToTokenAmount, useTokenInfo, useTokenToLocalAmount } from 'src/
 import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector, swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
+import { getTokenDisplayName } from 'src/tokens/utils'
 import { getInputDecimalsForToken } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
@@ -443,7 +444,7 @@ function EarnEnterAmount({ route }: Props) {
               >
                 <>
                   <TokenIcon token={inputToken} size={IconSize.SMALL} />
-                  <Text style={styles.tokenName}>{inputToken.symbol}</Text>
+                  <Text style={styles.tokenName}>{getTokenDisplayName(inputToken.symbol)}</Text>
                   {dropdownEnabled && <DownArrowIcon color={Colors.gray5} />}
                 </>
               </Touchable>
@@ -488,14 +489,18 @@ function EarnEnterAmount({ route }: Props) {
           <InLineNotification
             variant={NotificationVariant.Warning}
             title={t('earnFlow.enterAmount.notEnoughBalanceForGasWarning.title', {
-              feeTokenSymbol: prepareTransactionsResult.feeCurrencies[0].symbol,
+              feeTokenSymbol: getTokenDisplayName(
+                prepareTransactionsResult.feeCurrencies[0].symbol
+              ),
             })}
             description={t('earnFlow.enterAmount.notEnoughBalanceForGasWarning.description', {
-              feeTokenSymbol: prepareTransactionsResult.feeCurrencies[0].symbol,
+              feeTokenSymbol: getTokenDisplayName(
+                prepareTransactionsResult.feeCurrencies[0].symbol
+              ),
               network: NETWORK_NAMES[prepareTransactionsResult.feeCurrencies[0].networkId],
             })}
             ctaLabel={t('earnFlow.enterAmount.notEnoughBalanceForGasWarning.noGasCta', {
-              feeTokenSymbol: feeCurrencies[0].symbol,
+              feeTokenSymbol: getTokenDisplayName(feeCurrencies[0].symbol),
               network: NETWORK_NAMES[prepareTransactionsResult.feeCurrencies[0].networkId],
             })}
             onPressCta={() => {
@@ -520,10 +525,10 @@ function EarnEnterAmount({ route }: Props) {
           <InLineNotification
             variant={NotificationVariant.Warning}
             title={t('sendEnterAmountScreen.insufficientBalanceWarning.title', {
-              tokenSymbol: inputToken.symbol,
+              tokenSymbol: getTokenDisplayName(inputToken.symbol),
             })}
             description={t('sendEnterAmountScreen.insufficientBalanceWarning.description', {
-              tokenSymbol: inputToken.symbol,
+              tokenSymbol: getTokenDisplayName(inputToken.symbol),
             })}
             style={styles.warning}
             testID="EarnEnterAmount/NotEnoughBalanceWarning"

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { Alert, StyleSheet, Text, View } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
@@ -23,6 +23,22 @@ import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
 import { NeeruTrancheId, trancheIdFromPositionId } from 'src/earn/neeru/constants'
 import { effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
+
+const NEERU_EXPLAINER_KEY_BY_TRANCHE: Record<NeeruTrancheId, { title: string; body: string }> = {
+  0: { title: 'neeruVaults.explainer.flexible.title', body: 'neeruVaults.explainer.flexible.body' },
+  1: {
+    title: 'neeruVaults.explainer.thirtyDays.title',
+    body: 'neeruVaults.explainer.thirtyDays.body',
+  },
+  2: {
+    title: 'neeruVaults.explainer.sixtyDays.title',
+    body: 'neeruVaults.explainer.sixtyDays.body',
+  },
+  3: {
+    title: 'neeruVaults.explainer.ninetyDays.title',
+    body: 'neeruVaults.explainer.ninetyDays.body',
+  },
+}
 
 const NEERU_CARD_SUBTITLE_KEY_BY_TRANCHE: Record<NeeruTrancheId, string> = {
   0: 'neeruVaults.cardSubtitle.flexible',
@@ -121,6 +137,31 @@ export default function PoolCard({
     return t(key)
   }, [pool, t])
 
+  // Per-tranche explainer sheet. The `?` next to the subtitle fires this so
+  // the user can read how the specific option (Flexible / 30 / 60 / 90 days)
+  // behaves without leaving the Earn tab. Uses native Alert for zero-infra
+  // cost; a designed BottomSheet is a follow-up if we want richer content.
+  const neeruExplainer = useMemo(() => {
+    if (pool.appId !== 'neeru-vaults') return null
+    const trancheId = trancheIdFromPositionId(pool.positionId)
+    if (trancheId === null) return null
+    const keys = NEERU_EXPLAINER_KEY_BY_TRANCHE[trancheId]
+    return { title: t(keys.title), body: t(keys.body) }
+  }, [pool, t])
+
+  const onPressExplainer = (event: any) => {
+    event.stopPropagation?.()
+    if (!neeruExplainer) return
+    AppAnalytics.track(EarnEvents.earn_pool_card_press, {
+      poolId: positionId,
+      depositTokenId,
+      networkId,
+      poolAmount: balance,
+      providerId: appId,
+    })
+    Alert.alert(neeruExplainer.title, neeruExplainer.body, [{ text: t('ok') ?? 'OK' }])
+  }
+
   const onPress = () => {
     AppAnalytics.track(EarnEvents.earn_pool_card_press, {
       poolId: positionId,
@@ -155,7 +196,21 @@ export default function PoolCard({
             ))}
             <View style={styles.titleTextContainer}>
               <Text style={styles.titleTokens}>{cardTitle}</Text>
-              {cardSubtitle ? <Text style={styles.cardSubtitle}>{cardSubtitle}</Text> : null}
+              {cardSubtitle ? (
+                <View style={styles.subtitleRow}>
+                  <Text style={styles.cardSubtitle}>{cardSubtitle}</Text>
+                  {neeruExplainer && (
+                    <Touchable
+                      onPress={onPressExplainer}
+                      hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+                      style={styles.explainerBadge}
+                      testID={`PoolCard/${positionId}/ExplainerButton`}
+                    >
+                      <Text style={styles.explainerBadgeText}>?</Text>
+                    </Touchable>
+                  )}
+                </View>
+              ) : null}
             </View>
           </View>
           <View style={styles.keyValueContainer}>
@@ -267,5 +322,24 @@ const styles = StyleSheet.create({
   rateEquivalent: {
     ...typeScale.bodyXSmall,
     color: Colors.gray3,
+  },
+  subtitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.Tiny4,
+  },
+  explainerBadge: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: Colors.gray2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  explainerBadgeText: {
+    ...typeScale.bodyXSmall,
+    color: Colors.black,
+    fontWeight: '600',
+    lineHeight: 18,
   },
 })


### PR DESCRIPTION
## Two Neeru UX gaps

### 1) Deposit screen showed `cCOP` everywhere

The Neeru deposit flow rendered `inputToken.symbol` directly on the token pill and on both the insufficient-balance and not-enough-gas warnings. On Celo mainnet the COPm contract exposes the legacy on-chain symbol `cCOP`, which the app must translate to `Pesos` per the wallet manual ([.claude/rules/tokens.md](.claude/rules/tokens.md)).

Before:
- Token pill: `cCOP`
- Gas warning: "Necesitas más cCOP para continuar. Agrega cCOP en Celo"

After: routed those three sites through `getTokenDisplayName(symbol)`, which already maps `COPm/cCOP` -> `Pesos`, `USDT/USDC/USDm/cUSD/USD₮` -> `Dólares`, and `cEUR/EURm` -> `Euros`. Same fix applied to `src/components/TokenBalance.tsx` where the primary balance row was still substituting `cCOP` -> `COPm` instead of `Pesos`.

### 2) `?` explainer per Neeru tranche card

Added a small `?` badge next to the tranche subtitle on each Neeru card (Flexible, 30 días, 60 días, 90 días). Tapping the badge fires a native Alert with a tranche-specific description:

- **Flexible**: no lock-up, withdraw anytime, no penalty.
- **30 / 60 / 90 días**: capital locked until maturity; if withdrawn early, 20% fee applies only to accrued interest (never to capital).

Content sourced from [tasks/plans/neeru-vaults-backend-spec.md](tasks/plans/neeru-vaults-backend-spec.md): `penaltyBps = 2000` on non-flexible tranches, tranche=0 exempt from the penalty logic per line 432 of the spec. Copy lives at `neeruVaults.explainer.{flexible,thirtyDays,sixtyDays,ninetyDays}.{title,body}` in es-419 and base locales. The badge uses `event.stopPropagation` so tapping it doesn't accidentally navigate to the tranche detail.

## Verification

- `yarn build:ts` clean.
- `yarn lint src/earn` clean.
- `yarn jest src/earn` 29 suites / 240+ tests green (updated one legacy assertion that hard-coded "USDC" on the token-pill to now check for "Dólares", matching the new display convention).
- Rebuilt + reinstalled `MobileStack-mainnetdev` on the sim.