### PR TITLE
fix(earn): Neeru explainer uses in-app Modal with smaller typography

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2947,21 +2947,22 @@
       "ninetyDays": "90-day deposit"
     },
     "explainer": {
+      "close": "Close",
       "flexible": {
         "title": "Flexible deposit",
-        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no penalties. Interest accrues daily at the E.A. rate shown on the card. Ideal if you want full flexibility."
+        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated every day and is paid out on each withdrawal. Ideal if you want to keep the money available."
       },
       "thirtyDays": {
         "title": "30-day deposit",
-        "body": "Your capital is locked for 30 days. At maturity you withdraw principal + interest at no cost.\n\nIf you need to withdraw earlier, a 20% fee is charged ON THE INTEREST EARNED only (never on your capital). Interest accrues daily."
+        "body": "Your Pesos are locked for 30 days. At maturity you withdraw principal + interest at no cost.\n\nIf you need to withdraw earlier, a 20% fee applies only to the interest earned. Your capital is never touched. Interest builds up day by day."
       },
       "sixtyDays": {
         "title": "60-day deposit",
-        "body": "Your capital is locked for 60 days. At maturity you withdraw principal + interest at no cost. Usually pays a higher rate than Flexible and 30 days.\n\nIf you need to withdraw earlier, a 20% fee is charged ON THE INTEREST EARNED only (never on your capital). Interest accrues daily."
+        "body": "Your Pesos are locked for 60 days. At maturity you withdraw principal + interest at no cost. Usually pays more than Flexible and 30 days.\n\nIf you need to withdraw earlier, a 20% fee applies only to the interest earned. Your capital is never touched. Interest builds up day by day."
       },
       "ninetyDays": {
         "title": "90-day deposit",
-        "body": "Your capital is locked for 90 days. At maturity you withdraw principal + interest at no cost. Usually the highest rate.\n\nIf you need to withdraw earlier, a 20% fee is charged ON THE INTEREST EARNED only (never on your capital). Interest accrues daily."
+        "body": "Your Pesos are locked for 90 days. At maturity you withdraw principal + interest at no cost. Usually the best rate.\n\nIf you need to withdraw earlier, a 20% fee applies only to the interest earned. Your capital is never touched. Interest builds up day by day."
       }
     },
     "detail": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2954,21 +2954,22 @@
       "ninetyDays": "Deposito a 90 dias"
     },
     "explainer": {
+      "close": "Cerrar",
       "flexible": {
         "title": "Depósito Flexible",
-        "body": "Depositá y retirá tus Pesos cuando quieras, sin plazo mínimo ni penalizaciones. Los intereses se acumulan a diario a la tasa E.A. que ves en la card. Ideal si querés flexibilidad total."
+        "body": "Deposita y retira tus Pesos cuando quieras, sin plazo mínimo ni comisiones. Los intereses se generan cada día y se abonan cada vez que retiras. Ideal si necesitas tener el dinero disponible."
       },
       "thirtyDays": {
         "title": "Depósito a 30 días",
-        "body": "Tu capital queda bloqueado por 30 días. Al vencer, retirás capital + intereses sin ningún cargo.\n\nSi necesitás retirar antes, se aplica una comisión del 20% SOBRE LOS INTERESES ganados (nunca sobre tu capital). Los intereses se acumulan a diario."
+        "body": "Tus Pesos quedan guardados 30 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo.\n\nSi los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca. Los intereses se van acumulando día a día."
       },
       "sixtyDays": {
         "title": "Depósito a 60 días",
-        "body": "Tu capital queda bloqueado por 60 días. Al vencer, retirás capital + intereses sin ningún cargo. Suele pagar mejor tasa que Flexible y 30 días.\n\nSi necesitás retirar antes, se aplica una comisión del 20% SOBRE LOS INTERESES ganados (nunca sobre tu capital). Los intereses se acumulan a diario."
+        "body": "Tus Pesos quedan guardados 60 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele rendir más que Flexible y 30 días.\n\nSi los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca. Los intereses se van acumulando día a día."
       },
       "ninetyDays": {
         "title": "Depósito a 90 días",
-        "body": "Tu capital queda bloqueado por 90 días. Al vencer, retirás capital + intereses sin ningún cargo. Es la opción que suele pagar la mejor tasa.\n\nSi necesitás retirar antes, se aplica una comisión del 20% SOBRE LOS INTERESES ganados (nunca sobre tu capital). Los intereses se acumulan a diario."
+        "body": "Tus Pesos quedan guardados 90 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele ser la opción con mejor rendimiento.\n\nSi los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca. Los intereses se van acumulando día a día."
       }
     },
     "detail": {

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert, StyleSheet, Text, View } from 'react-native'
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
@@ -149,6 +149,7 @@ export default function PoolCard({
     return { title: t(keys.title), body: t(keys.body) }
   }, [pool, t])
 
+  const [isExplainerOpen, setExplainerOpen] = useState(false)
   const onPressExplainer = (event: any) => {
     event.stopPropagation?.()
     if (!neeruExplainer) return
@@ -159,7 +160,7 @@ export default function PoolCard({
       poolAmount: balance,
       providerId: appId,
     })
-    Alert.alert(neeruExplainer.title, neeruExplainer.body, [{ text: t('ok') ?? 'OK' }])
+    setExplainerOpen(true)
   }
 
   const onPress = () => {
@@ -253,6 +254,32 @@ export default function PoolCard({
           </Text>
         </View>
       </Touchable>
+      {neeruExplainer && (
+        <Modal
+          visible={isExplainerOpen}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setExplainerOpen(false)}
+        >
+          <Pressable style={styles.explainerBackdrop} onPress={() => setExplainerOpen(false)}>
+            <Pressable
+              style={styles.explainerCard}
+              onPress={(e) => e.stopPropagation()}
+              testID={`PoolCard/${positionId}/ExplainerSheet`}
+            >
+              <Text style={styles.explainerTitle}>{neeruExplainer.title}</Text>
+              <Text style={styles.explainerBody}>{neeruExplainer.body}</Text>
+              <Touchable
+                onPress={() => setExplainerOpen(false)}
+                style={styles.explainerClose}
+                testID={`PoolCard/${positionId}/ExplainerClose`}
+              >
+                <Text style={styles.explainerCloseText}>{t('neeruVaults.explainer.close')}</Text>
+              </Touchable>
+            </Pressable>
+          </Pressable>
+        </Modal>
+      )}
     </Shadow>
   )
 }
@@ -341,5 +368,35 @@ const styles = StyleSheet.create({
     color: Colors.black,
     fontWeight: '600',
     lineHeight: 18,
+  },
+  explainerBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.Regular16,
+  },
+  explainerCard: {
+    backgroundColor: Colors.white,
+    borderRadius: 12,
+    padding: Spacing.Regular16,
+    gap: Spacing.Small12,
+  },
+  explainerTitle: {
+    ...typeScale.labelSemiBoldSmall,
+    color: Colors.black,
+  },
+  explainerBody: {
+    ...typeScale.bodyXSmall,
+    color: Colors.gray4,
+  },
+  explainerClose: {
+    alignSelf: 'flex-end',
+    paddingHorizontal: Spacing.Small12,
+    paddingVertical: Spacing.Smallest8,
+    marginTop: Spacing.Smallest8,
+  },
+  explainerCloseText: {
+    ...typeScale.labelSemiBoldSmall,
+    color: Colors.primary,
   },
 })


### PR DESCRIPTION
## Change

Replace the native `Alert.alert()` explainer with a self-contained `Modal` so we control typography and rewrite the copy for a Colombian audience.

### Modal + typography

- `Modal` renders a card at `typeScale.bodyXSmall` (12px, letter-spacing 0.12) for the body and `typeScale.labelSemiBoldSmall` for the title. Dark backdrop dismisses on tap; a "Cerrar" button on the card also dismisses.
- Local `isExplainerOpen` state per card so each tranche's modal is independent. Backdrop swallows taps so the outer card `Touchable` does not fire behind the modal.
- New style tokens (`explainerBackdrop`, `explainerCard`, `explainerTitle`, `explainerBody`, `explainerClose`, `explainerCloseText`) pull sizing straight from `src/styles`.
- New i18n key `neeruVaults.explainer.close` (`Cerrar` in es-419, `Close` in base). The generic `dismiss` key (`Ignorar`) read like the user was dismissing a warning, wrong tone for an info sheet.

### Copy rewrite for Colombia

- Tuteo neutro (`Depositas` / `retiras` / `necesitas`) instead of the previously mixed rioplatense forms (`depositá` / `retirá` / `necesitás`). Colombian users read the second-person singular without the vos accent.
- Dropped the phrase "Los intereses se acumulan a diario a la tasa E.A. que ves en la card". The E.A. on the card is the annual effective rate; interest technically compounds from a daily rate under the hood. Mentioning "tasa E.A." here confused users about whether the daily accrual matches the card headline. New copy says the interest "se generan cada día" / "se van acumulando día a día", factually true and does not overload the E.A. label.
- New phrasing "Si los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca." emphasizes the capital-safety story users kept asking about, and drops the emphatic uppercase for a more Colombian-neutral tone.
- Flexible: "sin comisiones" instead of "sin penalizaciones" — Colombian banking language uses "comisión" for a fee, "penalización" reads legalistic.
- 30/60/90: "Tus Pesos quedan guardados" instead of "Tu capital queda bloqueado" — friendlier and matches the app's peso-first language.

## Verification

- `yarn build:ts` clean.
- `yarn lint src/earn/PoolCard.tsx` clean.
- `yarn jest src/earn` 3 suites / 37 tests green.
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim.

## Follow-ups

- If the Modal shape gets adopted by other cards, migrate it out to `src/components/InfoModal.tsx` so send/swap/gold explainers can reuse it.