### PR TITLE
fix(earn): Neeru explainer covers auto-renewal + smaller ? badge

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2950,19 +2950,19 @@
       "close": "Close",
       "flexible": {
         "title": "Flexible deposit",
-        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated every day and is paid out on each withdrawal. Ideal if you want to keep the money available."
+        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated every day and is paid out on each withdrawal. Ideal if you want to keep the money available.\n\nNo maturity and no renewal: the deposit stays active until you decide to withdraw."
       },
       "thirtyDays": {
         "title": "30-day deposit",
-        "body": "Your Pesos are locked for 30 days. At maturity you withdraw principal + interest at no cost.\n\nIf you need to withdraw earlier, a 20% fee applies only to the interest earned. Your capital is never touched. Interest builds up day by day."
+        "body": "Your Pesos are locked for 30 days. At maturity you withdraw principal + interest at no cost. Interest builds up day by day.\n\nAutomatic renewal: if you do not withdraw at maturity, the deposit renews for another 30 days with the interest added to the capital, so it keeps earning.\n\nIf you need to withdraw before maturity, a 20% fee applies only to the interest earned. Your capital is never touched."
       },
       "sixtyDays": {
         "title": "60-day deposit",
-        "body": "Your Pesos are locked for 60 days. At maturity you withdraw principal + interest at no cost. Usually pays more than Flexible and 30 days.\n\nIf you need to withdraw earlier, a 20% fee applies only to the interest earned. Your capital is never touched. Interest builds up day by day."
+        "body": "Your Pesos are locked for 60 days. At maturity you withdraw principal + interest at no cost. Usually pays more than Flexible and 30 days. Interest builds up day by day.\n\nAutomatic renewal: if you do not withdraw at maturity, the deposit renews for another 60 days with the interest added to the capital, so it keeps earning.\n\nIf you need to withdraw before maturity, a 20% fee applies only to the interest earned. Your capital is never touched."
       },
       "ninetyDays": {
         "title": "90-day deposit",
-        "body": "Your Pesos are locked for 90 days. At maturity you withdraw principal + interest at no cost. Usually the best rate.\n\nIf you need to withdraw earlier, a 20% fee applies only to the interest earned. Your capital is never touched. Interest builds up day by day."
+        "body": "Your Pesos are locked for 90 days. At maturity you withdraw principal + interest at no cost. Usually the best rate. Interest builds up day by day.\n\nAutomatic renewal: if you do not withdraw at maturity, the deposit renews for another 90 days with the interest added to the capital, so it keeps earning.\n\nIf you need to withdraw before maturity, a 20% fee applies only to the interest earned. Your capital is never touched."
       }
     },
     "detail": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2957,19 +2957,19 @@
       "close": "Cerrar",
       "flexible": {
         "title": "Depósito Flexible",
-        "body": "Deposita y retira tus Pesos cuando quieras, sin plazo mínimo ni comisiones. Los intereses se generan cada día y se abonan cada vez que retiras. Ideal si necesitas tener el dinero disponible."
+        "body": "Deposita y retira tus Pesos cuando quieras, sin plazo mínimo ni comisiones. Los intereses se generan cada día y se abonan al retirar. Ideal si necesitas tener el dinero disponible.\n\nNo tiene vencimiento ni renovación: el depósito queda activo hasta que decidas retirarlo."
       },
       "thirtyDays": {
         "title": "Depósito a 30 días",
-        "body": "Tus Pesos quedan guardados 30 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo.\n\nSi los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca. Los intereses se van acumulando día a día."
+        "body": "Tus Pesos quedan guardados 30 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Los intereses se van acumulando día a día.\n\nRenovación automática: si al vencer no retiras, el depósito se renueva por otros 30 días con los intereses sumados al capital, para que sigan generando rendimiento.\n\nSi necesitas retirar antes del vencimiento, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
       },
       "sixtyDays": {
         "title": "Depósito a 60 días",
-        "body": "Tus Pesos quedan guardados 60 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele rendir más que Flexible y 30 días.\n\nSi los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca. Los intereses se van acumulando día a día."
+        "body": "Tus Pesos quedan guardados 60 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele rendir más que Flexible y 30 días. Los intereses se van acumulando día a día.\n\nRenovación automática: si al vencer no retiras, el depósito se renueva por otros 60 días con los intereses sumados al capital, para que sigan generando rendimiento.\n\nSi necesitas retirar antes del vencimiento, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
       },
       "ninetyDays": {
         "title": "Depósito a 90 días",
-        "body": "Tus Pesos quedan guardados 90 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele ser la opción con mejor rendimiento.\n\nSi los necesitas antes, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca. Los intereses se van acumulando día a día."
+        "body": "Tus Pesos quedan guardados 90 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele ser la opción con mejor rendimiento. Los intereses se van acumulando día a día.\n\nRenovación automática: si al vencer no retiras, el depósito se renueva por otros 90 días con los intereses sumados al capital, para que sigan generando rendimiento.\n\nSi necesitas retirar antes del vencimiento, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
       }
     },
     "detail": {

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, Pressable, StyleSheet, Text, View } from 'react-native'
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
@@ -268,7 +268,13 @@ export default function PoolCard({
               testID={`PoolCard/${positionId}/ExplainerSheet`}
             >
               <Text style={styles.explainerTitle}>{neeruExplainer.title}</Text>
-              <Text style={styles.explainerBody}>{neeruExplainer.body}</Text>
+              <ScrollView
+                style={styles.explainerScroll}
+                contentContainerStyle={styles.explainerScrollContent}
+                showsVerticalScrollIndicator={false}
+              >
+                <Text style={styles.explainerBody}>{neeruExplainer.body}</Text>
+              </ScrollView>
               <Touchable
                 onPress={() => setExplainerOpen(false)}
                 style={styles.explainerClose}
@@ -356,18 +362,18 @@ const styles = StyleSheet.create({
     gap: Spacing.Tiny4,
   },
   explainerBadge: {
-    width: 18,
-    height: 18,
-    borderRadius: 9,
+    width: 14,
+    height: 14,
+    borderRadius: 7,
     backgroundColor: Colors.gray2,
     alignItems: 'center',
     justifyContent: 'center',
   },
   explainerBadgeText: {
-    ...typeScale.bodyXSmall,
-    color: Colors.black,
+    ...typeScale.bodyXXSmall,
+    color: Colors.gray4,
     fontWeight: '600',
-    lineHeight: 18,
+    lineHeight: 14,
   },
   explainerBackdrop: {
     flex: 1,
@@ -380,6 +386,13 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: Spacing.Regular16,
     gap: Spacing.Small12,
+    maxHeight: '80%',
+  },
+  explainerScroll: {
+    flexGrow: 0,
+  },
+  explainerScrollContent: {
+    paddingVertical: Spacing.Smallest8,
   },
   explainerTitle: {
     ...typeScale.labelSemiBoldSmall,


### PR DESCRIPTION
## Two follow-ups on the previous Neeru explainer

### Auto-renewal on 30 / 60 / 90 day tranches

Per [neeru-vaults-backend-spec.md#L32](tasks/plans/neeru-vaults-backend-spec.md) ("Renewal-by-user flow for Neeru — operator-side via `RENEWER_ROLE`") and the on-chain event set (`PositionRenewed`, `close_kind = 'renewed'`), non-flexible positions that are not withdrawn at maturity get renewed by the Neeru operator for another cycle of the same tranche, with the accrued interest capitalized into the new position's principal.

That is a material fact the user needs to know before choosing a tranche. New paragraph on each fixed-term explainer:

> Renovación automática: si al vencer no retiras, el depósito se renueva por otros N días con los intereses sumados al capital, para que sigan generando rendimiento.

Flexible gets the opposite paragraph clarifying: no maturity, no renewal, position stays active until manual withdrawal.

Since the body now spans three paragraphs, the modal card wraps the body in a `ScrollView` capped at `maxHeight: 80%` so the button stays in view on smaller devices.

### Smaller `?` badge

Shrunk from `18x18` (radius 9) at `bodyXSmall` to `14x14` (radius 7) at `bodyXXSmall`. Now reads as a subtle info hint next to the subtitle rather than a competing element, matching "un poco grande" feedback. `Colors.gray4` on the text also reduces contrast so the tranche label stays dominant.

## Verification

- `yarn build:ts` clean.
- `yarn lint src/earn/PoolCard.tsx` clean.
- `yarn jest src/earn/PoolCard` 7 tests green.
- Rebuilt + reinstalled `MobileStack-mainnetdev` on sim.