### PR TITLE
fix(earn): Neeru explainer covers the 7-day grace window

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2950,19 +2950,19 @@
       "close": "Close",
       "flexible": {
         "title": "Flexible deposit",
-        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated every day and is paid out on each withdrawal. Ideal if you want to keep the money available.\n\nNo maturity and no renewal: the deposit stays active until you decide to withdraw."
+        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated day by day and paid out on each withdrawal. Ideal if you want the money to stay available.\n\nNo maturity, no renewal: the deposit stays active until you decide to withdraw."
       },
       "thirtyDays": {
         "title": "30-day deposit",
-        "body": "Your Pesos are locked for 30 days. At maturity you withdraw principal + interest at no cost. Interest builds up day by day.\n\nAutomatic renewal: if you do not withdraw at maturity, the deposit renews for another 30 days with the interest added to the capital, so it keeps earning.\n\nIf you need to withdraw before maturity, a 20% fee applies only to the interest earned. Your capital is never touched."
+        "body": "Your Pesos are locked for 30 days. Interest builds up day by day during the term.\n\nOnce the 30 days are up, you have a 7-day window to withdraw principal + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 30 days. The interest earned is added to the capital so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your capital is never touched."
       },
       "sixtyDays": {
         "title": "60-day deposit",
-        "body": "Your Pesos are locked for 60 days. At maturity you withdraw principal + interest at no cost. Usually pays more than Flexible and 30 days. Interest builds up day by day.\n\nAutomatic renewal: if you do not withdraw at maturity, the deposit renews for another 60 days with the interest added to the capital, so it keeps earning.\n\nIf you need to withdraw before maturity, a 20% fee applies only to the interest earned. Your capital is never touched."
+        "body": "Your Pesos are locked for 60 days. Interest builds up day by day during the term. Usually pays more than Flexible and 30 days.\n\nOnce the 60 days are up, you have a 7-day window to withdraw principal + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 60 days. The interest earned is added to the capital so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your capital is never touched."
       },
       "ninetyDays": {
         "title": "90-day deposit",
-        "body": "Your Pesos are locked for 90 days. At maturity you withdraw principal + interest at no cost. Usually the best rate. Interest builds up day by day.\n\nAutomatic renewal: if you do not withdraw at maturity, the deposit renews for another 90 days with the interest added to the capital, so it keeps earning.\n\nIf you need to withdraw before maturity, a 20% fee applies only to the interest earned. Your capital is never touched."
+        "body": "Your Pesos are locked for 90 days. Interest builds up day by day during the term. Usually the best rate.\n\nOnce the 90 days are up, you have a 7-day window to withdraw principal + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 90 days. The interest earned is added to the capital so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your capital is never touched."
       }
     },
     "detail": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2957,19 +2957,19 @@
       "close": "Cerrar",
       "flexible": {
         "title": "Depósito Flexible",
-        "body": "Deposita y retira tus Pesos cuando quieras, sin plazo mínimo ni comisiones. Los intereses se generan cada día y se abonan al retirar. Ideal si necesitas tener el dinero disponible.\n\nNo tiene vencimiento ni renovación: el depósito queda activo hasta que decidas retirarlo."
+        "body": "Depositas y retiras tus Pesos cuando quieras, sin plazo mínimo ni comisiones. Los intereses se generan día a día y se abonan al retirar. Ideal si necesitas tener el dinero disponible.\n\nNo tiene vencimiento ni renovación: el depósito queda activo hasta que decidas retirarlo."
       },
       "thirtyDays": {
         "title": "Depósito a 30 días",
-        "body": "Tus Pesos quedan guardados 30 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Los intereses se van acumulando día a día.\n\nRenovación automática: si al vencer no retiras, el depósito se renueva por otros 30 días con los intereses sumados al capital, para que sigan generando rendimiento.\n\nSi necesitas retirar antes del vencimiento, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
+        "body": "Tus Pesos quedan guardados 30 días. Los intereses se acumulan día a día durante el plazo.\n\nAl cumplirse los 30 días tienes una ventana de 7 días para retirar el capital + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 30 días. Los intereses generados se suman al capital para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
       },
       "sixtyDays": {
         "title": "Depósito a 60 días",
-        "body": "Tus Pesos quedan guardados 60 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele rendir más que Flexible y 30 días. Los intereses se van acumulando día a día.\n\nRenovación automática: si al vencer no retiras, el depósito se renueva por otros 60 días con los intereses sumados al capital, para que sigan generando rendimiento.\n\nSi necesitas retirar antes del vencimiento, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
+        "body": "Tus Pesos quedan guardados 60 días. Los intereses se acumulan día a día durante el plazo. Suele rendir más que Flexible y 30 días.\n\nAl cumplirse los 60 días tienes una ventana de 7 días para retirar el capital + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 60 días. Los intereses generados se suman al capital para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
       },
       "ninetyDays": {
         "title": "Depósito a 90 días",
-        "body": "Tus Pesos quedan guardados 90 días. Al terminar el plazo, retiras el capital + los intereses ganados sin costo. Suele ser la opción con mejor rendimiento. Los intereses se van acumulando día a día.\n\nRenovación automática: si al vencer no retiras, el depósito se renueva por otros 90 días con los intereses sumados al capital, para que sigan generando rendimiento.\n\nSi necesitas retirar antes del vencimiento, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
+        "body": "Tus Pesos quedan guardados 90 días. Los intereses se acumulan día a día durante el plazo. Suele ser la opción con mejor rendimiento.\n\nAl cumplirse los 90 días tienes una ventana de 7 días para retirar el capital + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 90 días. Los intereses generados se suman al capital para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
       }
     },
     "detail": {


### PR DESCRIPTION
Corrects the Neeru tranche explainer copy after reading the contract source at `FondoCOPmMVP.sol`.

## What changed

Previous copy (PR #256): 'if you do not withdraw at maturity, the deposit renews for another N days'. That collapsed two distinct on-chain states into one.

Real behaviour:

1. **Interest builds up day by day during the term.**
2. **At maturity, interest STOPS accruing** (line 570-572 in the contract: 'Fixed tranches stop accruing at maturity — bounded obligations').
3. **A 7-day grace window opens.** During those 7 days the owner can withdraw principal + earned interest at full value with no fee. Interest does not grow during this window.
4. **Only after the grace expires** can `RENEWER_ROLE` renew the position (`RENEWAL_GRACE_WINDOW = 7 days`, line 173; `revert GraceWindowActive()` if triggered earlier, line 647). Renewal capitalizes the frozen interest into the new principal (`p.principal += accrued`, line 651) and sets `startTs = p.maturityTs` so the new cycle starts retroactively at the old maturity.
5. Early close before the term ends still triggers the 20% fee on interest (unchanged).

Copy for 30/60/90-day tranches now surfaces the 7-day window explicitly. Flexible copy is untouched — no maturity, no grace, no renewal.

## Verification

- `yarn build:ts` clean.
- `yarn jest src/earn/PoolCard` 7 tests green.
- `yarn lint src/earn/PoolCard.tsx` clean.