### PR TITLE
fix(earn): surface specific Neeru backend error in prepare-tx notification

### DIFF
--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3024,7 +3024,7 @@
       "unknown": "Algo salio mal. Intenta de nuevo.",
       "invalidTranche": "Opcion invalida.",
       "invalidAmount": "Monto invalido.",
-      "amountBelowMin": "Deposito minimo: {{minAmount}} Pesos.",
+      "amountBelowMin": "El monto es menor al mínimo permitido para este depósito.",
       "depositsPaused": "Los depositos estan temporalmente pausados.",
       "globalCapExceeded": "El fondo esta lleno. Intenta mas tarde.",
       "trancheCapExceeded": "Esta opcion esta llena. Prueba otra o intenta mas tarde.",

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -46,6 +46,7 @@ import { reorderForBugE } from 'src/tokens/feeCurrencyPicker'
 import { feeCurrenciesSelector, swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
+import { extractNeeruErrorCode, mapNeeruErrorToI18nKey } from 'src/earn/neeru/errorMapping'
 import { getInputDecimalsForToken } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
@@ -538,7 +539,16 @@ function EarnEnterAmount({ route }: Props) {
           <InLineNotification
             variant={NotificationVariant.Error}
             title={t('sendEnterAmountScreen.prepareTransactionError.title')}
-            description={t('sendEnterAmountScreen.prepareTransactionError.description')}
+            description={
+              // Surface the specific Neeru backend error (GLOBAL_CAP_EXCEEDED,
+              // TRANCHE_CAP_EXCEEDED, DEPOSITS_PAUSED, AMOUNT_BELOW_MIN, ...)
+              // as a Colombian-Spanish description whenever the failing pool is
+              // Neeru. Falls back to the generic prepare-transaction copy for
+              // Allbridge / Aave / any provider without a code map.
+              pool.appId === 'neeru-vaults'
+                ? t(mapNeeruErrorToI18nKey(extractNeeruErrorCode(prepareTransactionError)))
+                : t('sendEnterAmountScreen.prepareTransactionError.description')
+            }
             style={styles.warning}
             testID="EarnEnterAmount/PrepareTransactionError"
           />


### PR DESCRIPTION
## Live bug
Live-version (1.118.6) users with sizeable COPm balances are hitting the generic `Algo salió mal - No fue posible preparar una transacción para este token` toast on the Neeru deposit screen. The wallet caught the hooks-api error into `prepareTransactionError` but always rendered `sendEnterAmountScreen.prepareTransactionError.description`, hiding the real reason.

## Root cause of the confusion (not the on-chain failure itself)
The Neeru backend ([TuCOPWallet-Backend/src/hooks-api/neeru/trigger.ts](../TuCOPWallet-Backend/src/hooks-api/neeru/trigger.ts)) throws structured codes for every preflight failure:

- `DEPOSITS_PAUSED` (governance-paused deposits)
- `GLOBAL_CAP_EXCEEDED` (contract-wide TVL cap hit)
- `TRANCHE_CAP_EXCEEDED` (per-tranche cap hit — the likely bucket for whales hitting a nearly-full tranche)
- `RATE_NOT_SET` (governance has not activated the tranche rate)
- `AMOUNT_BELOW_MIN` (below `minDeposit`)
- `INVALID_TRANCHE` / `INVALID_AMOUNT` (defensive client-side)

## Fix
- [`src/earn/neeru/errorMapping.ts`](src/earn/neeru/errorMapping.ts) already contained the mapping + extractor — but it was only referenced from tests. Wire it into the `prepareTransactionError` render path in [`src/earn/EarnEnterAmount.tsx`](src/earn/EarnEnterAmount.tsx#L537) so the InLineNotification description shows e.g. **"Esta opción está llena. Prueba otra o intenta más tarde."** instead of a generic 'algo salió mal'.
- Fix `neeruVaults.errors.amountBelowMin` — the previous copy interpolated `{{minAmount}}`, which the error mapper never provides. Now reads **"El monto es menor al mínimo permitido para este depósito."** so nothing renders as raw `{{minAmount}}`.

Non-Neeru pools (Allbridge, Aave) keep the existing generic copy — no error-code contract there, and the generic message is still accurate.

## Verification
- `yarn build:ts` clean
- `yarn lint src/earn/EarnEnterAmount.tsx` clean
- `yarn jest src/earn` 13 suites / 99 tests green

## What we still don't know
This PR turns 'algo salió mal' into a meaningful message but does not fix the underlying reject if it turns out to be a genuine `TRANCHE_CAP_EXCEEDED`. If the on-chain caps are the real issue, next step is either bumping the caps via Neeru governance or a wallet-side pre-check that hides the affected tranche card before the user attempts a deposit.