### PR TITLE
fix(viem): fall back to gas hint when batched tx follows approve

### DIFF
--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -264,7 +264,23 @@ export async function tryEstimateTransactions(
     feeCurrencyAddress
   )
 
-  for (const baseTx of baseTransactions) {
+  // ERC-20 `approve(address,uint256)` selector.
+  const APPROVE_SELECTOR = '0x095ea7b3'
+  // Fallback gas for non-ERC20-transfer txs that follow an approve in the same
+  // batch. Multi-tx flows (approve -> deposit / withdraw / etc.) fail
+  // `eth_estimateGas` on the second tx because the simulator runs against
+  // LATEST state where the approve has not yet executed, and the callee's
+  // `transferFrom` reverts with `insufficient allowance`. We already fall
+  // back for plain ERC-20 transfers (line 209), but complex integrations
+  // (Neeru deposit, Allbridge deposit, etc.) hit the same class of revert.
+  // Use a conservative-but-realistic default so those flows are priced and
+  // not silently classified as `not-enough-balance-for-gas`. On-chain the
+  // wallet still respects any smaller gas the RPC would have set for the
+  // actual submission, so this is not an over-charge risk.
+  const POST_APPROVE_FALLBACK_GAS = BigInt(300_000)
+
+  for (let i = 0; i < baseTransactions.length; i++) {
+    const baseTx = baseTransactions[i]
     if (baseTx.gas) {
       // We have an estimate of gas already and don't want to recalculate it
       // e.g. if this is a swap transaction that depends on an approval transaction that hasn't been submitted yet, so simulation would fail
@@ -294,6 +310,40 @@ export async function tryEstimateTransactions(
         baseFeePerGas,
       })
       if (!tx) {
+        // Post-approve fallback: if a prior tx in this batch was an ERC-20
+        // approve, the revert is almost certainly the LATEST-state allowance
+        // gap, not a real "no funds" condition. Use the fallback gas so the
+        // whole batch prices instead of silently returning null (which would
+        // present as `not-enough-balance-for-gas` to the user).
+        const prevTxs = baseTransactions.slice(0, i)
+        const anyPrevApprove = prevTxs.some((prev) =>
+          prev.data?.toLowerCase().startsWith(APPROVE_SELECTOR)
+        )
+        if (anyPrevApprove) {
+          const fallbackGas =
+            POST_APPROVE_FALLBACK_GAS + BigInt(feeCurrency.isNative ? 0 : STATIC_GAS_PADDING)
+          Logger.warn(
+            TAG,
+            `Post-approve fallback gas for feeCurrency ${feeCurrency.symbol} at batch index ${i}`,
+            {
+              fallbackGas: fallbackGas.toString(),
+              feeCurrency: feeCurrencyAddress,
+              from: baseTx.from,
+              to: baseTx.to,
+              txData: baseTx.data?.toString().substring(0, 100),
+            }
+          )
+          transactions.push({
+            ...baseTx,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+            ...(feeCurrencyAddress && { feeCurrency: feeCurrencyAddress }),
+            gas: fallbackGas,
+            _estimatedGasUse: fallbackGas,
+            _baseFeePerGas: baseFeePerGas,
+          })
+          continue
+        }
         return null
       }
       transactions.push(tx)


### PR DESCRIPTION
## Summary

- Live users with sufficient balance (>100k COP) were seeing "Necesitas mas Pesos para continuar" on Neeru deposits because the wallet misinterpreted a simulation failure as insufficient balance for gas.
- Root cause: `tryEstimateTransactions` runs `eth_estimateGas` on each tx independently against LATEST chain state. When a Neeru deposit follows an approve in the same batch, the deposit simulation reverts (allowance still 0), the estimation returns null, every fee currency ends up failing, and the wallet ends up on the not-enough-balance-for-gas path.
- Fix: when a tx has no gas hint AND simulation fails AND any earlier tx in the batch starts with the ERC20 approve selector `0x095ea7b3`, fall back to a 300k gas hint (plus static padding for non-native fee currency) instead of returning null.
- This restores the batched-tx flow that Neeru relies on (approve + deposit) without weakening the revert-guard for other cases.

## Test plan

- [x] `yarn build:ts`
- [x] `yarn lint src/viem/prepareTransactions.ts`
- [x] `yarn jest src/viem/prepareTransactions` (56/56)
- [ ] Sanity check on simulator: Neeru deposit with fresh allowance from a wallet with ~11k COP (`0x81dcf9160237d0ef0d4db27cfb2ea9743547f882`) succeeds through the amount screen.