### PR TITLE
fix(positions): include response body in triggerShortcut error

### DIFF
--- a/src/earn/hooks.test.tsx
+++ b/src/earn/hooks.test.tsx
@@ -299,7 +299,7 @@ describe('usePrepareEnterAmountTransactionsCallback', () => {
     })
 
     await expect(result.current.refreshPreparedTransactions(mockRefreshArgs)).rejects.toEqual(
-      new Error('Unable to trigger shortcut: 500 Internal Server Error')
+      new Error('Unable to trigger shortcut: 500 Internal Server Error {}')
     )
     jest.useFakeTimers()
   })

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -285,7 +285,15 @@ export async function triggerShortcutRequest(hooksApiUrl: string, bodyJson: any)
     30_000
   )
   if (!response.ok) {
-    throw new Error(`Unable to trigger shortcut: ${response.status} ${response.statusText}`)
+    let body = ''
+    try {
+      body = await response.text()
+    } catch {
+      // ignore body read failure
+    }
+    throw new Error(
+      `Unable to trigger shortcut: ${response.status} ${response.statusText} ${body}`.trim()
+    )
   }
   const { data } = await response.json()
   return data


### PR DESCRIPTION
## Summary

- Follow-up to #259. The user reported the Neeru deposit UI showed a generic error even after the estimation fix; sim logs revealed the backend was returning HTTP 400 with a specific code (e.g. \`AMOUNT_BELOW_MIN\`) that the wallet was throwing away.
- \`triggerShortcutRequest\` only included \`status\` + \`statusText\` in the thrown message. On iOS \`statusText\` is often empty, so the extractor got \`Unable to trigger shortcut: 400\` and never saw the code.
- Fix: read the response body on failure and append it to the thrown message. \`extractNeeruErrorCode\` string-matches known codes, so it picks the code up now and \`EarnEnterAmount\` maps to the specific i18n key (e.g. \`neeruVaults.errors.amountBelowMin\`).

## Test plan

- [x] \`yarn build:ts\`
- [x] \`yarn lint src/positions/saga.ts\`
- [x] \`yarn jest src/positions/saga\` (18/18)
- [ ] Sim relaunch + Neeru deposit reproduces the failure: modal now shows the specific reason instead of "algo salio mal".