### PR TITLE
fix(earn): let Neeru error override the gas-shortage banner

### DIFF
--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -285,6 +285,7 @@ function EarnEnterAmount({ route }: Props) {
 
   const isAmountLessThanBalance = tokenAmount && tokenAmount.lte(balanceInInputToken)
   const showNotEnoughBalanceForGasWarning =
+    !prepareTransactionError &&
     isAmountLessThanBalance &&
     prepareTransactionsResult &&
     prepareTransactionsResult.type === 'not-enough-balance-for-gas'


### PR DESCRIPTION
## Summary

- Follow-up to #260. Live repro on the sim showed a wallet with sufficient balance still saw \`Necesitas mas Pesos para continuar\` (gas shortage) when the backend was actually rejecting the trigger with \`AMOUNT_BELOW_MIN\`.
- The gas-shortage banner short-circuits on a stale or race-derived \`prepareTransactionsResult.type === 'not-enough-balance-for-gas'\` even when \`prepareTransactionError\` is set with the specific code.
- Fix: skip the gas-shortage banner whenever \`prepareTransactionError\` is truthy, so the Neeru-specific error notification wins.

## Test plan

- [x] \`yarn build:ts\`
- [x] \`yarn lint src/earn/EarnEnterAmount.tsx\`
- [x] \`yarn jest src/earn/EarnEnterAmount\` (24/24)
- [ ] Sim: 10k COP deposit intent on wallet with ~11k COP balance now shows the specific Neeru message instead of the gas-shortage warning.