### PR TITLE
fix(earn/neeru): follow backend categoria cutover on the read path

### DIFF
--- a/src/earn/neeru/__tests__/api.test.ts
+++ b/src/earn/neeru/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { FetchMock } from 'jest-fetch-mock'
-import { fetchNeeruPositions } from 'src/earn/neeru/api'
+import { adaptNeeruPosition, fetchNeeruPositions } from 'src/earn/neeru/api'
 import { _resetForTests } from 'src/lib/circuitBreaker/circuitBreaker'
 
 const mockFetch = fetch as FetchMock
@@ -41,6 +41,126 @@ describe('fetchNeeruPositions', () => {
     expect(result.address).toBe('0x' + 'a'.repeat(40))
     expect(result.positions).toEqual([])
     expect(result.lastSyncedBlock).toBe(70750000)
+  })
+
+  it('adapts positions with new wire names (amount/category/categoryLabel)', async () => {
+    const newWirePosition = {
+      positionId: '0xfondo:category-2',
+      category: 2,
+      categoryLabel: 'sixtyDays',
+      amount: '1000',
+      accruedInterest: '5',
+      dailyRateRay: '1000000000000000000000000000',
+      monthlyRatePercentage: 0.5,
+      startTs: 1700000000,
+      maturityTs: 1705184000,
+      depositBlock: 70000000,
+      depositTxHash: '0xabc',
+      renewedFromPositionId: null,
+      currentPayoutIfClosed: {
+        amount: '1000',
+        interest: '5',
+        penaltyBps: 0,
+        interestAfterPenalty: '5',
+        total: '1005',
+        isEarly: false,
+      },
+    }
+    mockFetch.mockResponseOnce(
+      JSON.stringify({
+        data: { ...mockFixture.data, positions: [newWirePosition] },
+      }),
+      { status: 200 }
+    )
+
+    const result = await runWithTimers(() =>
+      fetchNeeruPositions({
+        baseUrl: 'https://example.test',
+        walletAddress: '0x' + 'a'.repeat(40),
+      })
+    )
+    expect(result.positions).toHaveLength(1)
+    expect(result.positions[0].tranche).toBe(2)
+    expect(result.positions[0].trancheLabel).toBe('sixtyDays')
+    expect(result.positions[0].principal).toBe('1000')
+    expect(result.positions[0].currentPayoutIfClosed.principal).toBe('1000')
+  })
+
+  it('adapts positions with legacy wire names (principal/tranche/trancheLabel)', async () => {
+    // Kept because backend recommended dual-read during rollout; if a cached
+    // response predates the wire rename this branch keeps the position usable.
+    const oldWirePosition = {
+      positionId: '0xfondo:tranche-3',
+      tranche: 3,
+      trancheLabel: 'ninetyDays',
+      principal: '500',
+      accruedInterest: '2',
+      dailyRateRay: '1000000000000000000000000000',
+      monthlyRatePercentage: 0.75,
+      startTs: 1700000000,
+      maturityTs: 1707776000,
+      depositBlock: 70000001,
+      depositTxHash: '0xdef',
+      renewedFromPositionId: null,
+      currentPayoutIfClosed: {
+        principal: '500',
+        interest: '2',
+        penaltyBps: 0,
+        interestAfterPenalty: '2',
+        total: '502',
+        isEarly: false,
+      },
+    }
+    mockFetch.mockResponseOnce(
+      JSON.stringify({
+        data: { ...mockFixture.data, positions: [oldWirePosition] },
+      }),
+      { status: 200 }
+    )
+
+    const result = await runWithTimers(() =>
+      fetchNeeruPositions({
+        baseUrl: 'https://example.test',
+        walletAddress: '0x' + 'a'.repeat(40),
+      })
+    )
+    expect(result.positions).toHaveLength(1)
+    expect(result.positions[0].tranche).toBe(3)
+    expect(result.positions[0].trancheLabel).toBe('ninetyDays')
+    expect(result.positions[0].principal).toBe('500')
+  })
+
+  it('adaptNeeruPosition prefers new wire names when both are present', () => {
+    const adapted = adaptNeeruPosition({
+      positionId: '0xfondo:category-1',
+      tranche: 3,
+      category: 1,
+      trancheLabel: 'old',
+      categoryLabel: 'new',
+      principal: '999',
+      amount: '111',
+      accruedInterest: '0',
+      dailyRateRay: '1000000000000000000000000000',
+      monthlyRatePercentage: 0.3,
+      startTs: 0,
+      maturityTs: 0,
+      depositBlock: 0,
+      depositTxHash: '0x0',
+      renewedFromPositionId: null,
+      currentPayoutIfClosed: {
+        amount: '111',
+        principal: '999',
+        interest: '0',
+        penaltyBps: 0,
+        interestAfterPenalty: '0',
+        total: '111',
+        isEarly: false,
+      },
+    })
+    expect(adapted.tranche).toBe(1)
+    expect(adapted.trancheLabel).toBe('new')
+    expect(adapted.principal).toBe('111')
+    expect(adapted.currentPayoutIfClosed.principal).toBe('111')
   })
 
   it('throws on non-2xx', async () => {

--- a/src/earn/neeru/__tests__/constants.test.ts
+++ b/src/earn/neeru/__tests__/constants.test.ts
@@ -14,4 +14,14 @@ describe('trancheIdFromPositionId', () => {
       trancheIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-9')
     ).toBeNull()
   })
+  it('extracts tranche id from a positionId using the new :category- suffix', () => {
+    expect(
+      trancheIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-2')
+    ).toBe(2)
+  })
+  it('returns null for out-of-range category', () => {
+    expect(
+      trancheIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-9')
+    ).toBeNull()
+  })
 })

--- a/src/earn/neeru/__tests__/errorMapping.test.ts
+++ b/src/earn/neeru/__tests__/errorMapping.test.ts
@@ -11,6 +11,14 @@ describe('mapNeeruErrorToI18nKey', () => {
   it('returns unknown for unrecognized', () => {
     expect(mapNeeruErrorToI18nKey('SOME_NEW_CODE')).toBe('neeruVaults.errors.unknown')
   })
+  it('maps INVALID_CATEGORY (new wire) to the same i18n key as INVALID_TRANCHE', () => {
+    expect(mapNeeruErrorToI18nKey('INVALID_CATEGORY')).toBe('neeruVaults.errors.invalidTranche')
+  })
+  it('maps CATEGORY_CAP_EXCEEDED (new wire) to the same i18n key as TRANCHE_CAP_EXCEEDED', () => {
+    expect(mapNeeruErrorToI18nKey('CATEGORY_CAP_EXCEEDED')).toBe(
+      'neeruVaults.errors.trancheCapExceeded'
+    )
+  })
 })
 
 describe('extractNeeruErrorCode', () => {

--- a/src/earn/neeru/api.ts
+++ b/src/earn/neeru/api.ts
@@ -1,7 +1,111 @@
-import { NeeruPositionsResponse } from 'src/earn/neeru/types'
+import BigNumber from 'bignumber.js'
+import { NeeruTrancheId } from 'src/earn/neeru/constants'
+import {
+  NeeruIndividualPosition,
+  NeeruPositionPayout,
+  NeeruPositionsResponse,
+} from 'src/earn/neeru/types'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 
 const NEERU_FETCH_TIMEOUT_MS = 15_000
+
+// The backend Neeru feed was renamed on the wire (principal -> amount,
+// tranche -> category, trancheLabel -> categoryLabel) as part of the
+// "categoria" UX cutover. The wallet's internal model keeps the old field
+// names because on-chain event args (Deposit.principal, Deposit.tranche)
+// are structural and cannot be renamed, and mirroring the immutable layer
+// keeps the wallet-side surface consistent across the whole earn stack.
+// Everything the backend produces flows through this adapter; nothing
+// downstream needs to know about the wire rename.
+interface RawPayout {
+  amount?: string
+  principal?: string
+  interest: string
+  penaltyBps: number
+  interestAfterPenalty: string
+  total: string
+  isEarly: boolean
+}
+
+interface RawPosition {
+  positionId: string
+  category?: NeeruTrancheId
+  tranche?: NeeruTrancheId
+  categoryLabel?: string
+  trancheLabel?: string
+  amount?: string
+  principal?: string
+  accruedInterest: string
+  dailyRateRay: string
+  monthlyRatePercentage: number
+  startTs: number
+  maturityTs: number
+  depositBlock: number
+  depositTxHash: string
+  renewedFromPositionId: string | null
+  currentPayoutIfClosed: RawPayout
+  optimistic?: boolean
+  staleOptimistic?: boolean
+}
+
+interface RawResponse {
+  address: string
+  positions: RawPosition[]
+  lastSyncedBlock: number
+  lastSyncedAt: string
+}
+
+function pickFirst(
+  ...values: Array<string | number | NeeruTrancheId | undefined>
+): string | number | undefined {
+  for (const v of values) {
+    if (v !== undefined && v !== null) return v as string | number
+  }
+  return undefined
+}
+
+function adaptPayout(raw: RawPayout): NeeruPositionPayout {
+  const principal = pickFirst(raw.amount, raw.principal)
+  if (principal === undefined) {
+    throw new Error('Neeru payout missing amount/principal')
+  }
+  return {
+    principal: new BigNumber(principal).toFixed(),
+    interest: raw.interest,
+    penaltyBps: raw.penaltyBps,
+    interestAfterPenalty: raw.interestAfterPenalty,
+    total: raw.total,
+    isEarly: raw.isEarly,
+  }
+}
+
+export function adaptNeeruPosition(raw: RawPosition): NeeruIndividualPosition {
+  const tranche = pickFirst(raw.category, raw.tranche) as NeeruTrancheId | undefined
+  const trancheLabel = pickFirst(raw.categoryLabel, raw.trancheLabel)
+  const principal = pickFirst(raw.amount, raw.principal)
+  if (tranche === undefined || trancheLabel === undefined || principal === undefined) {
+    throw new Error(
+      `Neeru position missing required fields (positionId=${raw.positionId}, tranche=${tranche}, label=${trancheLabel}, principal=${principal})`
+    )
+  }
+  return {
+    positionId: raw.positionId,
+    tranche,
+    trancheLabel: String(trancheLabel),
+    principal: new BigNumber(principal).toFixed(),
+    accruedInterest: raw.accruedInterest,
+    dailyRateRay: raw.dailyRateRay,
+    monthlyRatePercentage: raw.monthlyRatePercentage,
+    startTs: raw.startTs,
+    maturityTs: raw.maturityTs,
+    depositBlock: raw.depositBlock,
+    depositTxHash: raw.depositTxHash,
+    renewedFromPositionId: raw.renewedFromPositionId,
+    currentPayoutIfClosed: adaptPayout(raw.currentPayoutIfClosed),
+    ...(raw.optimistic !== undefined && { optimistic: raw.optimistic }),
+    ...(raw.staleOptimistic !== undefined && { staleOptimistic: raw.staleOptimistic }),
+  }
+}
 
 export async function fetchNeeruPositions({
   baseUrl,
@@ -17,5 +121,11 @@ export async function fetchNeeruPositions({
     throw new Error(`fetchNeeruPositions failed: ${response.status} ${response.statusText}`)
   }
   const body = await response.json()
-  return body.data as NeeruPositionsResponse
+  const raw = body.data as RawResponse
+  return {
+    address: raw.address,
+    positions: raw.positions.map(adaptNeeruPosition),
+    lastSyncedBlock: raw.lastSyncedBlock,
+    lastSyncedAt: raw.lastSyncedAt,
+  }
 }

--- a/src/earn/neeru/constants.ts
+++ b/src/earn/neeru/constants.ts
@@ -18,8 +18,12 @@ export const NEERU_TRANCHE_LABEL_KEYS: Record<NeeruTrancheId, string> = {
   3: 'neeruVaults.tranches.ninetyDays',
 }
 
+// Backend renamed the positionId suffix from `:tranche-<N>` to `:category-<N>`
+// as part of the categoria UX cutover. Accept both so persisted state from
+// prior wallet versions still parses cleanly during the transition; the new
+// form is what backend emits going forward.
 export const trancheIdFromPositionId = (positionId: string): NeeruTrancheId | null => {
-  const match = positionId.match(/:tranche-(\d)$/)
+  const match = positionId.match(/:(?:tranche|category)-(\d)$/)
   if (!match) return null
   const id = Number(match[1])
   if (id < 0 || id > 3) return null

--- a/src/earn/neeru/errorMapping.ts
+++ b/src/earn/neeru/errorMapping.ts
@@ -1,10 +1,16 @@
+// Backend renamed TRANCHE-* codes to CATEGORY-* in the categoria UX cutover.
+// Both are mapped to the same i18n keys so cached error responses from prior
+// backend versions still surface a translated message; new codes are what
+// current backend emits.
 const NEERU_ERROR_KEYS: Record<string, string> = {
   INVALID_TRANCHE: 'neeruVaults.errors.invalidTranche',
+  INVALID_CATEGORY: 'neeruVaults.errors.invalidTranche',
   INVALID_AMOUNT: 'neeruVaults.errors.invalidAmount',
   AMOUNT_BELOW_MIN: 'neeruVaults.errors.amountBelowMin',
   DEPOSITS_PAUSED: 'neeruVaults.errors.depositsPaused',
   GLOBAL_CAP_EXCEEDED: 'neeruVaults.errors.globalCapExceeded',
   TRANCHE_CAP_EXCEEDED: 'neeruVaults.errors.trancheCapExceeded',
+  CATEGORY_CAP_EXCEEDED: 'neeruVaults.errors.trancheCapExceeded',
   RATE_NOT_SET: 'neeruVaults.errors.rateNotSet',
   POSITION_NOT_FOUND: 'neeruVaults.errors.positionStale',
   POSITION_NOT_OWNED: 'neeruVaults.errors.positionStale',

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -187,7 +187,7 @@ export function* emergencyCloseNeeruPositionSaga(action: ReturnType<typeof emerg
         address: walletAddress,
         appId: 'neeru-vaults',
         networkId: NetworkId['celo-mainnet'],
-        shortcutId: 'withdraw-principal-only',
+        shortcutId: 'withdraw-amount-only',
         positionId,
       }
     )


### PR DESCRIPTION
## Summary

Backend PRs #125/#127/#128/#129 shipped a hard cutover of the Neeru wire naming (see [wallet-coordination-neeru-cutover doc](https://github.com/TuCopFinance/TuCOPWallet-Backend/blob/main/docs/wallet-coordination-neeru-cutover.md)). Verified live today: old icon URL 404s, `getShortcuts` only returns `withdraw-amount-only`, so there is no dual-write window on the backend side. The wallet reads the feed on every open of the Earn/Neeru surface, so it needs to migrate the boundary this release.

## What changes

| Layer | Wire (backend) | Internal (wallet) |
| --- | --- | --- |
| Field | `amount` | `principal` (kept - aligns with on-chain `Deposit.principal`) |
| Field | `category` | `tranche` (kept - aligns with on-chain `Deposit.tranche`) |
| Field | `categoryLabel` | `trancheLabel` (kept) |
| Shortcut id | `withdraw-amount-only` | request updated |
| Error codes | `INVALID_CATEGORY`, `CATEGORY_CAP_EXCEEDED` | mapped to existing i18n keys |
| PositionId suffix | `:category-<N>` | regex accepts both `:tranche-` and `:category-` |
| Icon URL | `.../assets/neeru/category-{N}.png` | wallet does not build these, backend serves them |
| ABI (unchanged) | `principal: uint256`, `tranche: uint8` | on-chain, structural |

Internal model stays on the old field names so the wallet-side surface (types, UI, selectors, tests) remains coherent with the on-chain event args, which the backend explicitly kept as `principal`/`tranche`. Everything from the wire flows through `adaptNeeruPosition` and `adaptPayout` in `api.ts`.

## Files

- `src/earn/neeru/api.ts` - wire-to-internal adapter, prefers new names with a fallback to old for cached responses.
- `src/earn/neeru/constants.ts` - regex accepts both position-id suffixes.
- `src/earn/neeru/errorMapping.ts` - adds `INVALID_CATEGORY` and `CATEGORY_CAP_EXCEEDED`.
- `src/earn/neeru/saga.ts` - emergency close now sends `withdraw-amount-only`.
- Tests added: adapter over new-wire, adapter fallback to legacy-wire, prefer-new-when-both, positionId regex for both suffixes, new error codes.

## Test plan

- [x] `yarn jest src/earn/neeru` - 82 tests pass
- [x] `yarn build:ts` clean
- [x] `yarn lint` clean
- [ ] Manual smoke on Statsig-gated Neeru surface with a delegated wallet once merged (rollout is behind `show_neeru_vaults`, no user impact if not verified pre-merge)