### PR TITLE
feat(positions): honor hooks-api partialFailure + drop legacy neeru codes + smoke playbook

### DIFF
--- a/scripts/pre-release-backend-smoke.sh
+++ b/scripts/pre-release-backend-smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Pre-release smoke against the TuCop backend. Runs the six checks from the
+# wallet-consumer-spec verification playbook and halts on any regression.
+#
+# Usage: ./scripts/pre-release-backend-smoke.sh
+#        ADDR=<any-neeru-holder> ./scripts/pre-release-backend-smoke.sh
+#
+# The default address is a public spike wallet that always has Neeru history
+# on mainnet. Override ADDR if that changes.
+set -euo pipefail
+
+BASE=${BASE:-https://tucop-backend-production.up.railway.app}
+ADDR=${ADDR:-0x81dcf9160237d0ef0d4db27cfb2ea9743547f882}
+
+STEP=0
+fail() {
+  echo
+  echo "SMOKE FAILED: $1" >&2
+  exit 1
+}
+
+next() {
+  STEP=$((STEP + 1))
+  echo
+  echo "[$STEP/6] $1"
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing dependency: $1"
+}
+
+require curl
+require jq
+
+next "health probes"
+curl -sf "$BASE/health" | jq -e '.ok == true' >/dev/null || fail "/health did not return ok"
+curl -sf "$BASE/ready" | jq -e '.ok == true' >/dev/null || fail "/ready did not return ok"
+curl -sf "$BASE/health/relay" | jq -e '.ok == true' >/dev/null || fail "/health/relay is failing (relay may need refunding)"
+
+next "neeru catalogue (4 categories, no partialFailure)"
+CATALOG=$(curl -sf "$BASE/hooks-api/getEarnPositions?networkIds=celo-mainnet&supportedAppIds=neeru-vaults&address=$ADDR")
+COUNT=$(echo "$CATALOG" | jq '.data | length')
+PF=$(echo "$CATALOG" | jq '.meta.partialFailure // null')
+[[ "$COUNT" == "4" ]] || fail "expected 4 neeru categories, got $COUNT"
+[[ "$PF" == "null" ]] || fail "unexpected partialFailure: $PF"
+
+next "shortcut list (withdraw-amount-only present, withdraw-principal-only absent)"
+SHORTCUTS=$(curl -sf "$BASE/hooks-api/v2/getShortcuts")
+echo "$SHORTCUTS" | jq -e '.data | any(.appId == "neeru-vaults" and .id == "withdraw-amount-only")' >/dev/null \
+  || fail "withdraw-amount-only shortcut missing"
+echo "$SHORTCUTS" | jq -e '.data | any(.id == "withdraw-principal-only") | not' >/dev/null \
+  || fail "legacy withdraw-principal-only shortcut is still emitted"
+
+next "asset URLs (new path 200, old path 404)"
+NEW_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/assets/neeru/category-0.png")
+OLD_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/assets/neeru/tranche-0.png")
+[[ "$NEW_STATUS" == "200" ]] || fail "new asset URL returned $NEW_STATUS"
+[[ "$OLD_STATUS" == "404" ]] || fail "old asset URL returned $OLD_STATUS (expected 404 post-cutover)"
+
+next "neeru positions detail (shape check)"
+DETAIL=$(curl -sf "$BASE/api/earn/neeru/positions?address=$ADDR")
+echo "$DETAIL" | jq -e '.data.positions | type == "array"' >/dev/null \
+  || fail "detail endpoint did not return a positions array"
+
+next "feed indexer health (lag under 100 blocks)"
+FEED_HEALTH=$(curl -sf "$BASE/api/transactions/indexer/health")
+LAG=$(echo "$FEED_HEALTH" | jq '.lagBlocks')
+[[ "$LAG" =~ ^-?[0-9]+$ ]] || fail "lagBlocks not numeric: $LAG"
+if [[ "$LAG" -gt 100 ]]; then
+  fail "indexer lag $LAG blocks exceeds 100-block threshold"
+fi
+
+echo
+echo "OK  all 6 smoke checks passed against $BASE"

--- a/src/earn/neeru/__tests__/errorMapping.test.ts
+++ b/src/earn/neeru/__tests__/errorMapping.test.ts
@@ -11,13 +11,17 @@ describe('mapNeeruErrorToI18nKey', () => {
   it('returns unknown for unrecognized', () => {
     expect(mapNeeruErrorToI18nKey('SOME_NEW_CODE')).toBe('neeruVaults.errors.unknown')
   })
-  it('maps INVALID_CATEGORY (new wire) to the same i18n key as INVALID_TRANCHE', () => {
+  it('maps INVALID_CATEGORY to the invalidTranche i18n key', () => {
     expect(mapNeeruErrorToI18nKey('INVALID_CATEGORY')).toBe('neeruVaults.errors.invalidTranche')
   })
-  it('maps CATEGORY_CAP_EXCEEDED (new wire) to the same i18n key as TRANCHE_CAP_EXCEEDED', () => {
+  it('maps CATEGORY_CAP_EXCEEDED to the trancheCapExceeded i18n key', () => {
     expect(mapNeeruErrorToI18nKey('CATEGORY_CAP_EXCEEDED')).toBe(
       'neeruVaults.errors.trancheCapExceeded'
     )
+  })
+  it('does not map the pre-cutover TRANCHE_* codes anymore', () => {
+    expect(mapNeeruErrorToI18nKey('INVALID_TRANCHE')).toBe('neeruVaults.errors.unknown')
+    expect(mapNeeruErrorToI18nKey('TRANCHE_CAP_EXCEEDED')).toBe('neeruVaults.errors.unknown')
   })
 })
 

--- a/src/earn/neeru/errorMapping.ts
+++ b/src/earn/neeru/errorMapping.ts
@@ -1,15 +1,12 @@
-// Backend renamed TRANCHE-* codes to CATEGORY-* in the categoria UX cutover.
-// Both are mapped to the same i18n keys so cached error responses from prior
-// backend versions still surface a translated message; new codes are what
-// current backend emits.
+// Stable enumeration of the wallet-facing trigger error codes emitted by the
+// backend post-2026-07-11 categoria cutover. Source of truth:
+// tasks/specs/wallet-consumer-spec.md section 8 (hooks-api triggerShortcut).
 const NEERU_ERROR_KEYS: Record<string, string> = {
-  INVALID_TRANCHE: 'neeruVaults.errors.invalidTranche',
   INVALID_CATEGORY: 'neeruVaults.errors.invalidTranche',
   INVALID_AMOUNT: 'neeruVaults.errors.invalidAmount',
   AMOUNT_BELOW_MIN: 'neeruVaults.errors.amountBelowMin',
   DEPOSITS_PAUSED: 'neeruVaults.errors.depositsPaused',
   GLOBAL_CAP_EXCEEDED: 'neeruVaults.errors.globalCapExceeded',
-  TRANCHE_CAP_EXCEEDED: 'neeruVaults.errors.trancheCapExceeded',
   CATEGORY_CAP_EXCEEDED: 'neeruVaults.errors.trancheCapExceeded',
   RATE_NOT_SET: 'neeruVaults.errors.rateNotSet',
   POSITION_NOT_FOUND: 'neeruVaults.errors.positionStale',

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -34,6 +34,7 @@ import {
   triggerShortcutSuccess,
 } from 'src/positions/slice'
 import { Position, Shortcut } from 'src/positions/types'
+import { RootState } from 'src/redux/store'
 import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
@@ -59,11 +60,22 @@ function getHooksApiFunctionUrl(
   return url
 }
 
+// Server-side envelope surfaced by the earn positions endpoint when one of
+// the wired apps (allbridge / neeru-vaults) fails to load and the other
+// still returned; the missing slice must be treated as unknown rather than
+// as an empty result. See tasks/specs/wallet-consumer-spec.md section 8.
+interface HooksApiMeta {
+  partialFailure?: {
+    neeru?: boolean
+    allbridge?: boolean
+  }
+}
+
 async function fetchHooks<T>(
   url: string,
   options: RequestInit | null = null,
   duration: number = HOOKS_FETCH_TIMEOUT
-) {
+): Promise<{ data: T; meta?: HooksApiMeta }> {
   const response = await fetchWithTimeout(url, options, duration)
   if (!response.ok) {
     throw new Error(`Unable to fetch ${url}: ${response.status} ${response.statusText}`)
@@ -71,7 +83,7 @@ async function fetchHooks<T>(
   const json = await response.json()
 
   Logger.debug('response fetch hooks', json.data)
-  return json.data as T
+  return { data: json.data as T, meta: json.meta as HooksApiMeta | undefined }
 }
 
 async function fetchPositions({
@@ -106,10 +118,20 @@ async function fetchPositions({
 
   const options: RequestInit = { headers: { 'Accept-Language': language } }
 
-  const [walletPositions, earnPositions] = await Promise.all([
+  const [walletResponse, earnResponse] = await Promise.all([
     fetchHooks<Position[]>(getPositionsUrl.toString(), options),
     fetchHooks<Position[]>(getEarnPositionsUrl.toString(), options),
   ])
+
+  const walletPositions = walletResponse.data
+  const earnPositions = earnResponse.data
+  const partialFailure = earnResponse.meta?.partialFailure
+
+  if (partialFailure && (partialFailure.neeru || partialFailure.allbridge)) {
+    Logger.warn(TAG, 'getEarnPositions returned partialFailure; earn slice may be incomplete', {
+      partialFailure,
+    })
+  }
 
   Logger.debug('WALLET', walletPositions)
 
@@ -129,6 +151,7 @@ async function fetchPositions({
   return {
     positions,
     earnPositionIds: earnPositions.map((position) => position.positionId),
+    partialFailure,
   }
 }
 
@@ -139,7 +162,8 @@ async function fetchShortcuts(hooksApiUrl: string, walletAddress: string) {
   url.searchParams.set('address', walletAddress)
   networkIds.forEach((networkId) => url.searchParams.append('networkIds', networkId))
 
-  return await fetchHooks<Shortcut[]>(url.toString())
+  const { data } = await fetchHooks<Shortcut[]>(url.toString())
+  return data
 }
 
 export function* fetchShortcutsSaga() {
@@ -187,7 +211,7 @@ export function* fetchPositionsSaga() {
     const hooksApiUrl = yield* select(hooksApiUrlSelector)
     const language = (yield* select(currentLanguageSelector)) || 'en'
     const shortLanguage = language.split('-')[0]
-    const { positions, earnPositionIds } = yield* call(fetchPositions, {
+    const { positions, earnPositionIds, partialFailure } = yield* call(fetchPositions, {
       hooksApiUrl,
       walletAddress: address,
       language: shortLanguage,
@@ -197,7 +221,41 @@ export function* fetchPositionsSaga() {
     Logger.debug(TAG, 'walletAddress>>>', hooksApiUrl)
     Logger.debug(TAG, 'positions>>>', positions)
 
-    yield* put(fetchPositionsSuccess({ positions, earnPositionIds, fetchedAt: Date.now() }))
+    // When the earn endpoint reports partialFailure the missing slice is
+    // "unknown, not empty" per the backend spec. Merging with the prior
+    // cache keeps any positions from the missing slice visible until the
+    // next successful fetch; without this the Earn tab would render empty
+    // cards for the affected app (repro: 2026-07-11 selector-bug window).
+    let effectivePositions = positions
+    let effectiveEarnPositionIds = earnPositionIds
+    if (partialFailure && (partialFailure.neeru || partialFailure.allbridge)) {
+      const previousPositions = yield* select((state: RootState) => state.positions.positions)
+      const previousEarnPositionIds = yield* select(
+        (state: RootState) => state.positions.earnPositionIds
+      )
+      const affectedAppIds = new Set<string>()
+      if (partialFailure.neeru) affectedAppIds.add('neeru-vaults')
+      if (partialFailure.allbridge) affectedAppIds.add('allbridge')
+      const preserved = previousPositions.filter((p) => affectedAppIds.has(p.appId))
+      const seen = new Set(positions.map((p) => p.positionId))
+      const merged = [...positions, ...preserved.filter((p) => !seen.has(p.positionId))]
+      const preservedIds = preserved.map((p) => p.positionId)
+      effectivePositions = merged
+      effectiveEarnPositionIds = Array.from(
+        new Set([
+          ...earnPositionIds,
+          ...previousEarnPositionIds.filter((id) => preservedIds.includes(id)),
+        ])
+      )
+    }
+
+    yield* put(
+      fetchPositionsSuccess({
+        positions: effectivePositions,
+        earnPositionIds: effectiveEarnPositionIds,
+        fetchedAt: Date.now(),
+      })
+    )
   } catch (err) {
     const error = ensureError(err)
     yield* put(fetchPositionsFailure(error))


### PR DESCRIPTION
## Summary

Backend delivered a `wallet-consumer-spec.md` bilateral doc on 2026-07-12 (SHA256 `2a4969...`). Reviewing our code against it surfaced three gaps; this PR closes all three.

Gaps found and fixed:

1. **`meta.partialFailure` was silently dropped.** `fetchHooks` only returned `json.data`; the `meta` envelope from `getEarnPositions` was ignored. If backend's Neeru or Allbridge read failed while the other still returned, the wallet saw an incomplete `data: [...]` with no signal, wiped the positions cache with it, and rendered empty cards on the earn tab. This is the exact scenario that ran for 27h during the 2026-07-11 selector-bug incident (only invisible because the Statsig gate suppressed exposure).

2. **Legacy `INVALID_TRANCHE` / `TRANCHE_CAP_EXCEEDED` still in `errorMapping.ts`.** Backend confirmed post-cutover they never emit these anymore; the spec's section 8 enumerates the eleven codes still surfaced, and our map now matches one-to-one.

3. **No pre-release verification playbook.** Spec section 9 lists six curl checks that should catch backend regressions before we ship a wallet release. Not integrated on our side.

## Changes

- `src/positions/saga.ts`
  - New `HooksApiMeta` type + `fetchHooks<T>` returns `{ data, meta? }` and both callers (`fetchPositions`, `fetchShortcuts`) updated to destructure.
  - `fetchPositions` extracts `earnResponse.meta.partialFailure` and forwards it up.
  - `fetchPositionsSaga` on partial failure preserves any prior positions from the affected app id (`neeru-vaults` / `allbridge`) and merges them with the successful slice; `earnPositionIds` union-merged so the affected ids are not dropped either.

- `src/earn/neeru/errorMapping.ts` — legacy `INVALID_TRANCHE`, `TRANCHE_CAP_EXCEEDED` removed. Kept mapping is now the exact spec set.

- `src/earn/neeru/__tests__/errorMapping.test.ts` — assertion added that the legacy codes fall through to the unknown i18n key.

- `scripts/pre-release-backend-smoke.sh` — executable form of the spec's verification playbook. `set -euo pipefail`, `jq` for structural assertions, halts on any regression. Six checks: health probes / neeru catalogue count + `partialFailure` absent / shortcut list contains the new id and omits the legacy one / assets 200 vs 404 / neeru positions detail shape / feed indexer lag under 100 blocks. Dry-run against live backend passes 6/6.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn jest src/earn/neeru src/positions` -> 110 tests pass
- [x] `yarn lint` clean
- [x] `./scripts/pre-release-backend-smoke.sh` -> 6/6 pass against production
- [ ] Manual smoke on the Statsig-gated Neeru surface once merged