### PR TITLE
chore(comments): drop tracked-source references to the bilateral consumer spec path

### DIFF
--- a/src/earn/neeru/errorMapping.ts
+++ b/src/earn/neeru/errorMapping.ts
@@ -1,6 +1,6 @@
 // Stable enumeration of the wallet-facing trigger error codes emitted by the
-// backend post-2026-07-11 categoria cutover. Source of truth:
-// tasks/specs/wallet-consumer-spec.md section 8 (hooks-api triggerShortcut).
+// backend post-2026-07-11 categoria cutover. Source of truth: backend
+// consumer spec section 8 (hooks-api triggerShortcut, bilateral doc).
 const NEERU_ERROR_KEYS: Record<string, string> = {
   INVALID_CATEGORY: 'neeruVaults.errors.invalidTranche',
   INVALID_AMOUNT: 'neeruVaults.errors.invalidAmount',

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -63,7 +63,7 @@ function getHooksApiFunctionUrl(
 // Server-side envelope surfaced by the earn positions endpoint when one of
 // the wired apps (allbridge / neeru-vaults) fails to load and the other
 // still returned; the missing slice must be treated as unknown rather than
-// as an empty result. See tasks/specs/wallet-consumer-spec.md section 8.
+// as an empty result (backend consumer spec section 8, bilateral doc).
 interface HooksApiMeta {
   partialFailure?: {
     neeru?: boolean


### PR DESCRIPTION
Two code comments left over from #266 pointed at `tasks/specs/wallet-consumer-spec.md` as if the doc lived in this repo. It does not — the bilateral spec lives in the backend clone, and this repo should not carry a copy. Rephrased both comments to reference the spec by title only.

## Test plan
- [x] `yarn build:ts` clean