### PR TITLE
chore(earn/neeru): drop remaining partner-contract vocabulary from tracked source

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,3 +82,17 @@ jobs:
           # Force color output in the terminal with chalk
           # See https://github.com/chalk/supports-color/issues/106
           FORCE_COLOR: 2
+
+  backend-smoke:
+    name: Backend smoke (pre-release)
+    runs-on: ubuntu-latest
+    # Release-quality gate: runs the wallet-consumer-spec verification
+    # playbook against production before we cut a release. Six curl checks
+    # (health, neeru catalogue, shortcut list, asset URLs, positions detail,
+    # feed indexer lag). Skipped on Development PRs so a transient backend
+    # blip does not block day-to-day work.
+    if: github.event_name != 'pull_request' || github.base_ref == 'main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run pre-release backend smoke
+        run: bash scripts/pre-release-backend-smoke.sh

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2934,7 +2934,7 @@
     }
   },
   "neeruVaults": {
-    "tranches": {
+    "categories": {
       "flexible": "Flexible",
       "thirtyDays": "30 days",
       "sixtyDays": "60 days",
@@ -2950,28 +2950,28 @@
       "close": "Close",
       "flexible": {
         "title": "Flexible deposit",
-        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated day by day and paid out on each withdrawal. Ideal if you want the money to stay available.\n\nNo maturity, no renewal: the deposit stays active until you decide to withdraw."
+        "body": "Deposit and withdraw your Pesos anytime, with no lock-up and no fees. Interest is generated day by day and paid out on each withdrawal. Ideal if you want the money to stay available.\n\nNo end date, no renewal: the deposit stays active until you decide to withdraw."
       },
       "thirtyDays": {
         "title": "30-day deposit",
-        "body": "Your Pesos are locked for 30 days. Interest builds up day by day during the term.\n\nOnce the 30 days are up, you have a 7-day window to withdraw principal + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 30 days. The interest earned is added to the capital so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your capital is never touched."
+        "body": "Your Pesos are locked for 30 days. Interest builds up day by day during the term.\n\nOnce the 30 days are up, you have a 7-day window to withdraw your deposit + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 30 days. The interest earned is added to the balance so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your deposit is never touched."
       },
       "sixtyDays": {
         "title": "60-day deposit",
-        "body": "Your Pesos are locked for 60 days. Interest builds up day by day during the term. Usually pays more than Flexible and 30 days.\n\nOnce the 60 days are up, you have a 7-day window to withdraw principal + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 60 days. The interest earned is added to the capital so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your capital is never touched."
+        "body": "Your Pesos are locked for 60 days. Interest builds up day by day during the term. Usually pays more than Flexible and 30 days.\n\nOnce the 60 days are up, you have a 7-day window to withdraw your deposit + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 60 days. The interest earned is added to the balance so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your deposit is never touched."
       },
       "ninetyDays": {
         "title": "90-day deposit",
-        "body": "Your Pesos are locked for 90 days. Interest builds up day by day during the term. Usually the best rate.\n\nOnce the 90 days are up, you have a 7-day window to withdraw principal + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 90 days. The interest earned is added to the capital so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your capital is never touched."
+        "body": "Your Pesos are locked for 90 days. Interest builds up day by day during the term. Usually the best rate.\n\nOnce the 90 days are up, you have a 7-day window to withdraw your deposit + earned interest at no cost. Interest does not grow during that window.\n\nIf you do not withdraw within those 7 days, the deposit automatically renews for another 90 days. The interest earned is added to the balance so it keeps earning.\n\nIf you need to withdraw before the term ends, a 20% fee applies only to the interest earned. Your deposit is never touched."
       }
     },
     "detail": {
-      "header": "Your {{trancheLabel}} positions",
-      "aggregateBalance": "Total in {{trancheLabel}}: {{amount}} Pesos",
+      "header": "Your {{categoryLabel}} positions",
+      "aggregateBalance": "Total in {{categoryLabel}}: {{amount}} Pesos",
       "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% monthly",
       "depositCta": "Deposit",
       "noPositions": "You don't have positions in this option yet",
-      "descriptionByTranche": {
+      "descriptionByCategory": {
         "flexible": "Withdraw anytime with no minimum lock",
         "thirtyDays": "Lock your Pesos for 30 days at a higher rate",
         "sixtyDays": "Lock your Pesos for 60 days at a higher rate",
@@ -2979,9 +2979,9 @@
       }
     },
     "positionRow": {
-      "principal": "Principal: {{amount}} Pesos",
+      "amount": "Deposited: {{amount}} Pesos",
       "interest": "Earned: {{amount}} Pesos",
-      "maturity": "Available {{date}}",
+      "availableAt": "Available {{date}}",
       "flexible": "No minimum time",
       "depositedAt": "Deposited on {{date}}",
       "manageCta": "Manage",
@@ -2993,34 +2993,34 @@
     "closeSheet": {
       "title": "Withdraw your deposit",
       "currentPayout": "You will receive",
-      "principalLabel": "Principal",
+      "amountLabel": "Deposited",
       "interestLabel": "Interest earned",
       "penaltyLabel": "Early withdrawal fee ({{percentage}}%)",
       "totalLabel": "Total",
-      "earlyWarning": "You are withdrawing before {{date}}. The fee applies only to the interest, never to your principal.",
+      "earlyWarning": "You are withdrawing before {{date}}. The fee applies only to the interest, never to your deposit.",
       "confirmCta": "Confirm withdrawal",
-      "principalOnlyCta": "Exit with principal only",
-      "principalOnlyHelp": "If the normal withdrawal fails, you can recover your principal without interest."
+      "amountOnlyCta": "Withdraw deposit only",
+      "amountOnlyHelp": "If the normal withdrawal fails, you can recover your deposit without interest."
     },
     "emergencyCloseSheet": {
       "title": "Emergency withdrawal",
       "subtitle": "The fund cannot pay interest right now",
-      "explanation": "You can recover your principal of {{principal}} Pesos now, but you will forfeit the {{interest}} Pesos of interest you earned. This is irreversible.",
+      "explanation": "You can recover your deposit of {{amount}} Pesos now, but you will forfeit the {{interest}} Pesos of interest you earned. This is irreversible.",
       "alternative": "If you can wait, the fund usually recovers within a few hours.",
       "primaryCta": "Wait and try again later",
-      "secondaryCta": "Withdraw principal only",
+      "secondaryCta": "Withdraw deposit only",
       "confirmAgain": "Tap again to confirm"
     },
     "errors": {
       "fetchPositionsFailed": "We couldn't load your positions. Pull down to retry.",
       "closeFailed": "We couldn't process the withdrawal. Try again.",
       "unknown": "Something went wrong. Try again.",
-      "invalidTranche": "Invalid tranche selected.",
+      "invalidCategory": "Invalid category.",
       "invalidAmount": "Invalid amount.",
       "amountBelowMin": "Minimum deposit: {{minAmount}} Pesos.",
       "depositsPaused": "Deposits are temporarily paused.",
       "globalCapExceeded": "The fund is full. Try later.",
-      "trancheCapExceeded": "This option is full. Try another or come back later.",
+      "categoryCapExceeded": "This option is full. Try another or come back later.",
       "rateNotSet": "This option is not available right now.",
       "positionStale": "Refresh your positions and try again.",
       "positionAlreadyClosed": "This position is already closed.",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2941,7 +2941,7 @@
     }
   },
   "neeruVaults": {
-    "tranches": {
+    "categories": {
       "flexible": "Flexible",
       "thirtyDays": "30 dias",
       "sixtyDays": "60 dias",
@@ -2961,24 +2961,24 @@
       },
       "thirtyDays": {
         "title": "Depósito a 30 días",
-        "body": "Tus Pesos quedan guardados 30 días. Los intereses se acumulan día a día durante el plazo.\n\nAl cumplirse los 30 días tienes una ventana de 7 días para retirar el capital + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 30 días. Los intereses generados se suman al capital para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
+        "body": "Tus Pesos quedan guardados 30 días. Los intereses se acumulan día a día durante el plazo.\n\nAl cumplirse los 30 días tienes una ventana de 7 días para retirar el depósito + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 30 días. Los intereses generados se suman al saldo para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu depósito nunca se toca."
       },
       "sixtyDays": {
         "title": "Depósito a 60 días",
-        "body": "Tus Pesos quedan guardados 60 días. Los intereses se acumulan día a día durante el plazo. Suele rendir más que Flexible y 30 días.\n\nAl cumplirse los 60 días tienes una ventana de 7 días para retirar el capital + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 60 días. Los intereses generados se suman al capital para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
+        "body": "Tus Pesos quedan guardados 60 días. Los intereses se acumulan día a día durante el plazo. Suele rendir más que Flexible y 30 días.\n\nAl cumplirse los 60 días tienes una ventana de 7 días para retirar el depósito + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 60 días. Los intereses generados se suman al saldo para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu depósito nunca se toca."
       },
       "ninetyDays": {
         "title": "Depósito a 90 días",
-        "body": "Tus Pesos quedan guardados 90 días. Los intereses se acumulan día a día durante el plazo. Suele ser la opción con mejor rendimiento.\n\nAl cumplirse los 90 días tienes una ventana de 7 días para retirar el capital + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 90 días. Los intereses generados se suman al capital para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu capital nunca se toca."
+        "body": "Tus Pesos quedan guardados 90 días. Los intereses se acumulan día a día durante el plazo. Suele ser la opción con mejor rendimiento.\n\nAl cumplirse los 90 días tienes una ventana de 7 días para retirar el depósito + los intereses ganados sin ningún cobro. En esta ventana el interés no sigue creciendo.\n\nSi en esos 7 días no retiras, el depósito se renueva automáticamente por otros 90 días. Los intereses generados se suman al saldo para seguir rindiendo.\n\nSi necesitas retirar antes de cumplir el plazo, se cobra el 20% únicamente sobre los intereses generados. Tu depósito nunca se toca."
       }
     },
     "detail": {
-      "header": "Tus depositos {{trancheLabel}}",
-      "aggregateBalance": "Total en {{trancheLabel}}: {{amount}} Pesos",
+      "header": "Tus depositos {{categoryLabel}}",
+      "aggregateBalance": "Total en {{categoryLabel}}: {{amount}} Pesos",
       "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% mensual",
       "depositCta": "Depositar",
       "noPositions": "Todavia no tienes depositos en esta opcion",
-      "descriptionByTranche": {
+      "descriptionByCategory": {
         "flexible": "Retira en cualquier momento, sin tiempo minimo",
         "thirtyDays": "Bloquea tus Pesos 30 dias a una tasa mas alta",
         "sixtyDays": "Bloquea tus Pesos 60 dias a una tasa mas alta",
@@ -2986,9 +2986,9 @@
       }
     },
     "positionRow": {
-      "principal": "Capital: {{amount}} Pesos",
+      "amount": "Depositado: {{amount}} Pesos",
       "interest": "Ganado: {{amount}} Pesos",
-      "maturity": "Disponible el {{date}}",
+      "availableAt": "Disponible el {{date}}",
       "flexible": "Sin tiempo minimo",
       "depositedAt": "Depositado el {{date}}",
       "manageCta": "Gestionar",
@@ -3000,34 +3000,34 @@
     "closeSheet": {
       "title": "Retira tu deposito",
       "currentPayout": "Recibiras",
-      "principalLabel": "Capital",
+      "amountLabel": "Depositado",
       "interestLabel": "Intereses ganados",
       "penaltyLabel": "Comision por retiro temprano ({{percentage}}%)",
       "totalLabel": "Total",
-      "earlyWarning": "Estas retirando antes del {{date}}. La comision se aplica solo al interes, nunca al capital.",
+      "earlyWarning": "Estas retirando antes del {{date}}. La comision se aplica solo al interes, nunca al deposito.",
       "confirmCta": "Confirmar retiro",
-      "principalOnlyCta": "Salir solo con mi capital",
-      "principalOnlyHelp": "Si el retiro normal falla, puedes recuperar tu capital sin intereses."
+      "amountOnlyCta": "Retirar solo el deposito",
+      "amountOnlyHelp": "Si el retiro normal falla, puedes recuperar tu deposito sin intereses."
     },
     "emergencyCloseSheet": {
       "title": "Retiro de emergencia",
       "subtitle": "El fondo no puede pagar intereses en este momento",
-      "explanation": "Puedes recuperar tu capital de {{principal}} Pesos ahora, pero perderas los {{interest}} Pesos de interes que generaste. Esta accion no se puede revertir.",
+      "explanation": "Puedes recuperar tu deposito de {{amount}} Pesos ahora, pero perderas los {{interest}} Pesos de interes que generaste. Esta accion no se puede revertir.",
       "alternative": "Si puedes esperar, el fondo se recupera generalmente en unas horas.",
       "primaryCta": "Esperar e intentar despues",
-      "secondaryCta": "Retirar solo el capital",
+      "secondaryCta": "Retirar solo el deposito",
       "confirmAgain": "Toca de nuevo para confirmar"
     },
     "errors": {
       "fetchPositionsFailed": "No pudimos cargar tus depositos. Desliza hacia abajo para reintentar.",
       "closeFailed": "No pudimos procesar el retiro. Intenta de nuevo.",
       "unknown": "Algo salio mal. Intenta de nuevo.",
-      "invalidTranche": "Opcion invalida.",
+      "invalidCategory": "Categoria invalida.",
       "invalidAmount": "Monto invalido.",
       "amountBelowMin": "El monto es menor al mínimo permitido para este depósito.",
       "depositsPaused": "Los depositos estan temporalmente pausados.",
       "globalCapExceeded": "El fondo esta lleno. Intenta mas tarde.",
-      "trancheCapExceeded": "Esta opcion esta llena. Prueba otra o intenta mas tarde.",
+      "categoryCapExceeded": "Esta opcion esta llena. Prueba otra o intenta mas tarde.",
       "rateNotSet": "Esta opcion no esta disponible en este momento.",
       "positionStale": "Actualiza tus depositos y reintenta.",
       "positionAlreadyClosed": "Este deposito ya fue cerrado.",

--- a/src/earn/EarnHome.test.tsx
+++ b/src/earn/EarnHome.test.tsx
@@ -127,7 +127,7 @@ describe('EarnHome', () => {
   describe('Neeru Vaults gate', () => {
     const neeruPool = {
       ...mockEarnPositions[0],
-      positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-1',
+      positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-1',
       address: '0x988af5977201a0e988f2c75ea952532f6beb5082',
       networkId: NetworkId['celo-mainnet'],
       appId: 'neeru-vaults',

--- a/src/earn/PoolCard.test.tsx
+++ b/src/earn/PoolCard.test.tsx
@@ -50,11 +50,11 @@ describe('PoolCard', () => {
   })
 
   describe('card title display', () => {
-    it('renders Neeru pool title as the token display name with tranche subtitle below', () => {
+    it('renders Neeru pool title as the token display name with category subtitle below', () => {
       const neeruPool = {
         ...mockEarnPositions[0],
         appId: 'neeru-vaults',
-        positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-1',
+        positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-1',
       }
       const { getByText, queryByText } = render(
         <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
@@ -63,7 +63,7 @@ describe('PoolCard', () => {
       )
       // Title is the token display name (USDC -> Dólares from getTokenDisplayName)
       expect(getByText('Dólares')).toBeTruthy()
-      // Subtitle is the tranche-specific i18n key (mock returns key)
+      // Subtitle is the category-specific i18n key (mock returns key)
       expect(getByText('neeruVaults.cardSubtitle.thirtyDays')).toBeTruthy()
       // Raw token symbols never shown
       expect(queryByText('USDC')).toBeNull()

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -128,7 +128,7 @@ export default function PoolCard({
     [tokensInfo]
   )
 
-  // For Neeru pools, append a per-tranche subtitle so the 4 cards are distinguishable.
+  // For Neeru pools, append a per-category subtitle so the 4 cards are distinguishable.
   const cardSubtitle = useMemo(() => {
     if (pool.appId !== 'neeru-vaults') return null
     const categoryId = categoryIdFromPositionId(pool.positionId)
@@ -137,7 +137,7 @@ export default function PoolCard({
     return t(key)
   }, [pool, t])
 
-  // Per-tranche explainer sheet. The `?` next to the subtitle fires this so
+  // Per-category explainer sheet. The `?` next to the subtitle fires this so
   // the user can read how the specific option (Flexible / 30 / 60 / 90 days)
   // behaves without leaving the Earn tab. Uses native Alert for zero-infra
   // cost; a designed BottomSheet is a follow-up if we want richer content.

--- a/src/earn/neeru/NeeruCloseSheet.tsx
+++ b/src/earn/neeru/NeeruCloseSheet.tsx
@@ -16,10 +16,10 @@ import { Spacing } from 'src/styles/styles'
 interface Props {
   position: NeeruIndividualPosition
   onClose: () => void
-  onPrincipalOnlyRequested?: (position: NeeruIndividualPosition) => void
+  onAmountOnlyRequested?: (position: NeeruIndividualPosition) => void
 }
 
-export default function NeeruCloseSheet({ position, onClose, onPrincipalOnlyRequested }: Props) {
+export default function NeeruCloseSheet({ position, onClose, onAmountOnlyRequested }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const closeStatus = useSelector(neeruCloseStatusSelector)
@@ -38,7 +38,7 @@ export default function NeeruCloseSheet({ position, onClose, onPrincipalOnlyRequ
     >
       <View style={styles.body}>
         <Text style={styles.subtitle}>{t('neeruVaults.closeSheet.currentPayout')}</Text>
-        <Row label={t('neeruVaults.closeSheet.principalLabel')} value={`${payout.amount} Pesos`} />
+        <Row label={t('neeruVaults.closeSheet.amountLabel')} value={`${payout.amount} Pesos`} />
         <Row label={t('neeruVaults.closeSheet.interestLabel')} value={`${payout.interest} Pesos`} />
         {payout.isEarly && (
           <Row
@@ -65,20 +65,18 @@ export default function NeeruCloseSheet({ position, onClose, onPrincipalOnlyRequ
           onPress={() => dispatch(closePositionStart({ positionId: position.positionId }))}
           style={styles.cta}
         />
-        {onPrincipalOnlyRequested && (
+        {onAmountOnlyRequested && (
           <>
             <Button
-              testID="NeeruCloseSheet.PrincipalOnly"
+              testID="NeeruCloseSheet.AmountOnly"
               size={BtnSizes.FULL}
               type={BtnTypes.SECONDARY}
-              text={t('neeruVaults.closeSheet.principalOnlyCta')}
+              text={t('neeruVaults.closeSheet.amountOnlyCta')}
               disabled={closeStatus === 'loading'}
-              onPress={() => onPrincipalOnlyRequested(position)}
+              onPress={() => onAmountOnlyRequested(position)}
               style={styles.secondaryCta}
             />
-            <Text style={styles.principalOnlyHelp}>
-              {t('neeruVaults.closeSheet.principalOnlyHelp')}
-            </Text>
+            <Text style={styles.amountOnlyHelp}>{t('neeruVaults.closeSheet.amountOnlyHelp')}</Text>
           </>
         )}
       </View>
@@ -126,7 +124,7 @@ const styles = StyleSheet.create({
   },
   cta: { marginTop: Spacing.Regular16 },
   secondaryCta: { marginTop: Spacing.Smallest8 },
-  principalOnlyHelp: {
+  amountOnlyHelp: {
     ...typeScale.bodySmall,
     color: Colors.gray3,
     marginTop: Spacing.Smallest8,

--- a/src/earn/neeru/NeeruEmergencyCloseSheet.tsx
+++ b/src/earn/neeru/NeeruEmergencyCloseSheet.tsx
@@ -32,7 +32,7 @@ export default function NeeruEmergencyCloseSheet({ position, onConfirm, onCancel
         <Text style={styles.subtitle}>{t('neeruVaults.emergencyCloseSheet.subtitle')}</Text>
         <Text style={styles.bodyText}>
           {t('neeruVaults.emergencyCloseSheet.explanation', {
-            principal: position.amount,
+            amount: position.amount,
             interest: position.accruedInterest,
           })}
         </Text>

--- a/src/earn/neeru/NeeruPositionRow.tsx
+++ b/src/earn/neeru/NeeruPositionRow.tsx
@@ -31,7 +31,7 @@ export default function NeeruPositionRow({ position, onManagePress }: Props) {
     <View testID="NeeruPositionRow" style={styles.row}>
       <View style={styles.column}>
         <Text style={styles.line}>
-          {t('neeruVaults.positionRow.principal', { amount: position.amount })}
+          {t('neeruVaults.positionRow.amount', { amount: position.amount })}
         </Text>
         <Text style={styles.line}>
           {t('neeruVaults.positionRow.interest', { amount: position.accruedInterest })}
@@ -39,7 +39,7 @@ export default function NeeruPositionRow({ position, onManagePress }: Props) {
         <Text style={styles.subline}>
           {isFlexible
             ? t('neeruVaults.positionRow.flexible')
-            : t('neeruVaults.positionRow.maturity', { date: endDate })}
+            : t('neeruVaults.positionRow.availableAt', { date: endDate })}
         </Text>
         {isOptimistic && !isStale && (
           <View testID="NeeruPositionRow.ProcessingBadge" style={styles.badge}>

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -34,10 +34,10 @@ import { Spacing } from 'src/styles/styles'
 type Props = NativeStackScreenProps<StackParamList, Screens.NeeruVaultDetail>
 
 const DESCRIPTION_KEY_BY_CATEGORY: Record<NeeruCategoryId, string> = {
-  0: 'neeruVaults.detail.descriptionByTranche.flexible',
-  1: 'neeruVaults.detail.descriptionByTranche.thirtyDays',
-  2: 'neeruVaults.detail.descriptionByTranche.sixtyDays',
-  3: 'neeruVaults.detail.descriptionByTranche.ninetyDays',
+  0: 'neeruVaults.detail.descriptionByCategory.flexible',
+  1: 'neeruVaults.detail.descriptionByCategory.thirtyDays',
+  2: 'neeruVaults.detail.descriptionByCategory.sixtyDays',
+  3: 'neeruVaults.detail.descriptionByCategory.ninetyDays',
 }
 
 export default function NeeruVaultDetailScreen({ route }: Props) {
@@ -78,7 +78,7 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
   }
 
   const positions = byCategory[categoryId]
-  const trancheLabel = t(NEERU_CATEGORY_LABEL_KEYS[categoryId])
+  const categoryLabel = t(NEERU_CATEGORY_LABEL_KEYS[categoryId])
   const description = t(DESCRIPTION_KEY_BY_CATEGORY[categoryId])
   const total = positions
     .reduce((acc, p) => acc.plus(p.currentPayoutIfClosed.total), new BigNumber(0))
@@ -95,10 +95,10 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
           />
         }
       >
-        <Text style={styles.header}>{t('neeruVaults.detail.header', { trancheLabel })}</Text>
+        <Text style={styles.header}>{t('neeruVaults.detail.header', { categoryLabel })}</Text>
         <Text style={styles.description}>{description}</Text>
         <Text style={styles.total}>
-          {t('neeruVaults.detail.aggregateBalance', { trancheLabel, amount: total })}
+          {t('neeruVaults.detail.aggregateBalance', { categoryLabel, amount: total })}
         </Text>
 
         {positions.length === 0 ? (
@@ -128,7 +128,7 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
         <NeeruCloseSheet
           position={selectedPosition}
           onClose={() => setSelectedPosition(null)}
-          onPrincipalOnlyRequested={(pos) => {
+          onAmountOnlyRequested={(pos) => {
             setSelectedPosition(null)
             setEmergencyTarget(pos)
           }}

--- a/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
@@ -37,7 +37,7 @@ describe('NeeruCloseSheet', () => {
         <NeeruCloseSheet position={pos} onClose={jest.fn()} />
       </Provider>
     )
-    // Translation mock returns keys, so we assert on the principal/interest VALUES
+    // Translation mock returns keys, so we assert on the amount/interest VALUES
     expect(getByText(/10000/)).toBeTruthy()
     expect(getByText(/82.5/)).toBeTruthy()
     expect(getByText(/10066/)).toBeTruthy()
@@ -55,29 +55,29 @@ describe('NeeruCloseSheet', () => {
     expect(spy).toHaveBeenCalledWith(closePositionStart({ positionId: '1234' }))
   })
 
-  it('hides the principal-only option when no callback is provided', () => {
+  it('hides the amount-only option when no callback is provided', () => {
     const store = createMockStore({ neeru: initialNeeruState } as any)
     const { queryByTestId } = render(
       <Provider store={store}>
         <NeeruCloseSheet position={pos} onClose={jest.fn()} />
       </Provider>
     )
-    expect(queryByTestId('NeeruCloseSheet.PrincipalOnly')).toBeNull()
+    expect(queryByTestId('NeeruCloseSheet.AmountOnly')).toBeNull()
   })
 
-  it('exposes principal-only option that invokes the callback with the position', () => {
+  it('exposes amount-only option that invokes the callback with the position', () => {
     const store = createMockStore({ neeru: initialNeeruState } as any)
-    const onPrincipalOnlyRequested = jest.fn()
+    const onAmountOnlyRequested = jest.fn()
     const { getByTestId } = render(
       <Provider store={store}>
         <NeeruCloseSheet
           position={pos}
           onClose={jest.fn()}
-          onPrincipalOnlyRequested={onPrincipalOnlyRequested}
+          onAmountOnlyRequested={onAmountOnlyRequested}
         />
       </Provider>
     )
-    fireEvent.press(getByTestId('NeeruCloseSheet.PrincipalOnly'))
-    expect(onPrincipalOnlyRequested).toHaveBeenCalledWith(pos)
+    fireEvent.press(getByTestId('NeeruCloseSheet.AmountOnly'))
+    expect(onAmountOnlyRequested).toHaveBeenCalledWith(pos)
   })
 })

--- a/src/earn/neeru/__tests__/NeeruEmergencyCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruEmergencyCloseSheet.test.tsx
@@ -27,7 +27,7 @@ const pos: NeeruIndividualPosition = {
 }
 
 describe('NeeruEmergencyCloseSheet', () => {
-  it('renders principal and interest in the explanation', () => {
+  it('renders amount and interest in the explanation', () => {
     const { getByText } = render(
       <NeeruEmergencyCloseSheet position={pos} onConfirm={jest.fn()} onCancel={jest.fn()} />
     )

--- a/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
@@ -45,7 +45,7 @@ const renderRow = (position: NeeruIndividualPosition, onManagePress = jest.fn())
 describe('NeeruPositionRow', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  it('renders principal and interest for backend positions', () => {
+  it('renders amount and interest for backend positions', () => {
     const { getByText } = renderRow(pos)
     expect(getByText(/10000/)).toBeTruthy()
     expect(getByText(/82.5/)).toBeTruthy()

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -16,7 +16,7 @@ jest.mock('src/navigator/NavigationService', () => ({ navigate: jest.fn() }))
 const pool = {
   ...mockEarnPositions[0],
   appId: 'neeru-vaults',
-  positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-1',
+  positionId: 'celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-1',
   address: '0x988af5977201a0e988f2c75ea952532f6beb5082',
   networkId: NetworkId['celo-mainnet'],
 }
@@ -123,7 +123,7 @@ describe('NeeruVaultDetailScreen', () => {
     expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
   })
 
-  it('opens NeeruEmergencyCloseSheet proactively when principal-only option is tapped', () => {
+  it('opens NeeruEmergencyCloseSheet proactively when amount-only option is tapped', () => {
     const store = createMockStore({
       neeru: {
         ...initialNeeruState,
@@ -138,7 +138,7 @@ describe('NeeruVaultDetailScreen', () => {
     )
     fireEvent.press(getByTestId('NeeruPositionRow.Manage.321'))
     expect(getByTestId('NeeruCloseSheet')).toBeTruthy()
-    fireEvent.press(getByTestId('NeeruCloseSheet.PrincipalOnly'))
+    fireEvent.press(getByTestId('NeeruCloseSheet.AmountOnly'))
     expect(queryByTestId('NeeruCloseSheet')).toBeNull()
     expect(getByTestId('NeeruEmergencyCloseSheet')).toBeTruthy()
   })

--- a/src/earn/neeru/__tests__/constants.test.ts
+++ b/src/earn/neeru/__tests__/constants.test.ts
@@ -1,27 +1,22 @@
 import { categoryIdFromPositionId } from 'src/earn/neeru/constants'
 
 describe('categoryIdFromPositionId', () => {
-  it('extracts tranche id from a valid Neeru positionId', () => {
-    expect(
-      categoryIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-2')
-    ).toBe(2)
-  })
-  it('returns null for non-Neeru positionId', () => {
-    expect(categoryIdFromPositionId('celo-mainnet:0xabc:allbridge-pool-1')).toBeNull()
-  })
-  it('returns null for out-of-range tranche', () => {
-    expect(
-      categoryIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:tranche-9')
-    ).toBeNull()
-  })
-  it('extracts tranche id from a positionId using the new :category- suffix', () => {
+  it('extracts category id from a valid positionId', () => {
     expect(
       categoryIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-2')
     ).toBe(2)
   })
-  it('returns null for out-of-range category', () => {
+  it('returns null for a non-earn positionId', () => {
+    expect(categoryIdFromPositionId('celo-mainnet:0xabc:allbridge-pool-1')).toBeNull()
+  })
+  it('returns null for an out-of-range category', () => {
     expect(
       categoryIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:category-9')
+    ).toBeNull()
+  })
+  it('returns null for an unknown suffix', () => {
+    expect(
+      categoryIdFromPositionId('celo-mainnet:0x988af5977201a0e988f2c75ea952532f6beb5082:legacy-2')
     ).toBeNull()
   })
 })

--- a/src/earn/neeru/__tests__/errorMapping.test.ts
+++ b/src/earn/neeru/__tests__/errorMapping.test.ts
@@ -11,12 +11,12 @@ describe('mapNeeruErrorToI18nKey', () => {
   it('returns unknown for unrecognized', () => {
     expect(mapNeeruErrorToI18nKey('SOME_NEW_CODE')).toBe('neeruVaults.errors.unknown')
   })
-  it('maps INVALID_CATEGORY to the invalidTranche i18n key', () => {
-    expect(mapNeeruErrorToI18nKey('INVALID_CATEGORY')).toBe('neeruVaults.errors.invalidTranche')
+  it('maps INVALID_CATEGORY to the invalidCategory i18n key', () => {
+    expect(mapNeeruErrorToI18nKey('INVALID_CATEGORY')).toBe('neeruVaults.errors.invalidCategory')
   })
-  it('maps CATEGORY_CAP_EXCEEDED to the trancheCapExceeded i18n key', () => {
+  it('maps CATEGORY_CAP_EXCEEDED to the categoryCapExceeded i18n key', () => {
     expect(mapNeeruErrorToI18nKey('CATEGORY_CAP_EXCEEDED')).toBe(
-      'neeruVaults.errors.trancheCapExceeded'
+      'neeruVaults.errors.categoryCapExceeded'
     )
   })
   it('does not map the pre-cutover TRANCHE_* codes anymore', () => {

--- a/src/earn/neeru/constants.ts
+++ b/src/earn/neeru/constants.ts
@@ -32,17 +32,14 @@ export type NeeruCategoryId = 0 | 1 | 2 | 3
 export const NEERU_CATEGORY_IDS: NeeruCategoryId[] = [3, 2, 1, 0]
 
 export const NEERU_CATEGORY_LABEL_KEYS: Record<NeeruCategoryId, string> = {
-  0: 'neeruVaults.tranches.flexible',
-  1: 'neeruVaults.tranches.thirtyDays',
-  2: 'neeruVaults.tranches.sixtyDays',
-  3: 'neeruVaults.tranches.ninetyDays',
+  0: 'neeruVaults.categories.flexible',
+  1: 'neeruVaults.categories.thirtyDays',
+  2: 'neeruVaults.categories.sixtyDays',
+  3: 'neeruVaults.categories.ninetyDays',
 }
 
-// Backend positionId suffix was renamed from `:tranche-<N>` to `:category-<N>`
-// in the 2026-07 wire cutover. Accept both so persisted state from prior
-// wallet versions still parses cleanly during the transition.
 export const categoryIdFromPositionId = (positionId: string): NeeruCategoryId | null => {
-  const match = positionId.match(/:(?:tranche|category)-(\d)$/)
+  const match = positionId.match(/:category-(\d)$/)
   if (!match) return null
   const id = Number(match[1])
   if (id < 0 || id > 3) return null

--- a/src/earn/neeru/errorMapping.ts
+++ b/src/earn/neeru/errorMapping.ts
@@ -2,12 +2,12 @@
 // backend post-2026-07-11 categoria cutover. Source of truth: backend
 // consumer spec section 8 (hooks-api triggerShortcut, bilateral doc).
 const NEERU_ERROR_KEYS: Record<string, string> = {
-  INVALID_CATEGORY: 'neeruVaults.errors.invalidTranche',
+  INVALID_CATEGORY: 'neeruVaults.errors.invalidCategory',
   INVALID_AMOUNT: 'neeruVaults.errors.invalidAmount',
   AMOUNT_BELOW_MIN: 'neeruVaults.errors.amountBelowMin',
   DEPOSITS_PAUSED: 'neeruVaults.errors.depositsPaused',
   GLOBAL_CAP_EXCEEDED: 'neeruVaults.errors.globalCapExceeded',
-  CATEGORY_CAP_EXCEEDED: 'neeruVaults.errors.trancheCapExceeded',
+  CATEGORY_CAP_EXCEEDED: 'neeruVaults.errors.categoryCapExceeded',
   RATE_NOT_SET: 'neeruVaults.errors.rateNotSet',
   POSITION_NOT_FOUND: 'neeruVaults.errors.positionStale',
   POSITION_NOT_OWNED: 'neeruVaults.errors.positionStale',


### PR DESCRIPTION
## Summary

Backend sweep of HEAD `7df2db2` found residual `tranche` / `principal` / `maturity` vocabulary that survived the #265 zero-exposure refactor across i18n keys, i18n values, CSS class names, prop names, testIDs and test descriptions. This PR closes the remaining surface end-to-end.

Backend's two grep assertions (from the wallet-consumer-spec verification block) both return zero on this HEAD:

```
grep -rEn 'tranche|principal|maturity' src/earn/neeru/ locales/base/translation.json locales/es-419/translation.json | grep -v 'positionId.match'
# 0 hits

grep -rn 'invalidTranche|trancheCapExceeded' src/
# 0 hits
```

## What changes

### i18n keys (both locales)

- `neeruVaults.tranches.*` -> `neeruVaults.categories.*`
- `neeruVaults.detail.descriptionByTranche.*` -> `descriptionByCategory.*`
- `neeruVaults.positionRow.principal` -> `.amount`
- `neeruVaults.positionRow.maturity` -> `.availableAt`
- `neeruVaults.closeSheet.principalLabel` -> `.amountLabel`
- `neeruVaults.closeSheet.principalOnlyCta` -> `.amountOnlyCta`
- `neeruVaults.closeSheet.principalOnlyHelp` -> `.amountOnlyHelp`
- `neeruVaults.errors.invalidTranche` -> `errors.invalidCategory`
- `neeruVaults.errors.trancheCapExceeded` -> `errors.categoryCapExceeded`

Interpolation vars: `{{trancheLabel}}` -> `{{categoryLabel}}`, `{{principal}}` -> `{{amount}}` (renamed in translation values and every `t()` call site).

### i18n values (user-facing copy)

- `Principal: {{amount}} Pesos` -> `Deposited: {{amount}} Pesos` (es-419: `Depositado`)
- `Principal` label -> `Deposited` (es-419: `Depositado`)
- `Exit with principal only` -> `Withdraw deposit only` (es-419: `Retirar solo el deposito`)
- `Invalid tranche selected.` -> `Invalid category.` (es-419: `Categoria invalida.`)
- Explainer bodies: `principal + earned interest` -> `deposit + earned interest`, `Your capital is never touched.` -> `Your deposit is never touched.`, `nunca al capital` -> `nunca al deposito`, etc.
- Emergency explanation, secondaryCta, warning line — all updated to say `deposit` instead of `principal` / `capital`.

### Code

- `src/earn/neeru/constants.ts`: `categoryIdFromPositionId` regex drops the legacy `:tranche-` fallback branch; only `:category-` matches now. Backend no longer emits the pre-cutover suffix, and the earn slice refetches on mount so persisted positionIds from before 1.118.7 get replaced on the next successful backend read.
- `src/earn/neeru/errorMapping.ts`: values point to `invalidCategory` / `categoryCapExceeded` (were still pointing at the old tranche i18n keys).
- `src/earn/neeru/NeeruCloseSheet.tsx`: `PrincipalOnly` prop / testID / CSS class renamed to `AmountOnly`. `onPrincipalOnlyRequested` -> `onAmountOnlyRequested`.
- `src/earn/neeru/NeeruEmergencyCloseSheet.tsx`: `t()` call passes `amount:` instead of `principal:` for the interpolation slot.
- `src/earn/neeru/NeeruPositionRow.tsx`: two `t()` key strings updated.
- `src/earn/neeru/NeeruVaultDetailScreen.tsx`: `DESCRIPTION_KEY_BY_CATEGORY` points at `descriptionByCategory`; local var `trancheLabel` renamed to `categoryLabel`; callback renamed.
- Tests: describe/it strings and testID references updated; the constants test that used a `:tranche-` positionId is replaced with a generic `:legacy-` suffix.

### Release automation

- `.github/workflows/check.yml` gains a `backend-smoke` job that runs `scripts/pre-release-backend-smoke.sh`. Guarded by the same `PR to main OR manual OR schedule` condition as `vulnerability` and `knip-regression` — day-to-day Development PRs are not gated on backend uptime, but any release cut to `main` will fail if the six spec checks regress.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn jest src/earn/neeru` -> 80 tests pass
- [x] `yarn lint` clean
- [x] `./scripts/pre-release-backend-smoke.sh` -> 6/6 pass against production
- [x] Backend's two grep assertions -> 0 hits each on HEAD