### PR TITLE
chore: rewrite self-referential rename annotations before history scrub

### DIFF
--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -2124,8 +2124,7 @@ export const migrations = {
   },
   252: (state: any) => {
     // Neeru zero-exposure refactor renames the persisted position shape
-    // (principal -> amount, tranche -> category, trancheLabel -> categoryLabel,
-    // maturityTs -> endTs, dailyRateRay -> rateValue). Rather than rewriting
+    // (five fields renamed to opaque wire names). Rather than rewriting
     // every persisted entry, clear the cached positions on upgrade: the earn
     // screen refetches from the backend on mount, so the visible impact is a
     // single fetch cycle and no data loss.

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3788,8 +3788,7 @@ export const v251SchemaWithWriFeeAdapterBootstrap = {
 }
 
 // Neeru zero-exposure refactor. The persisted position shape is renamed
-// (principal -> amount, tranche -> category, trancheLabel -> categoryLabel,
-// maturityTs -> endTs, dailyRateRay -> rateValue). Migration 252 clears
+// (five fields renamed to opaque wire names). Migration 252 clears
 // state.neeru.positions and state.neeru.optimisticPositions so old-shape
 // entries do not survive the upgrade; the earn screen refetches on mount.
 export const v252Schema = {


### PR DESCRIPTION
Preparation for the history scrub in a follow-up. The two comments in `src/redux/migrations.ts` and `test/schemas.ts` spelled out the pre-cutover field names (`trancheLabel`, `maturityTs`, `dailyRateRay`) as documentation of what the migration replaces. That block survived the zero-exposure sweep because grep was scoped to `src/earn/neeru/`. Rewriting the annotations to 'five fields renamed to opaque wire names' before running `git filter-repo --replace-text` keeps HEAD identical after the scrub and avoids garbled comments like 'categoryLabel -> categoryLabel' as collateral. No behavior change, docs only.

## Test plan
- [x] `yarn build:ts` clean