### PR TITLE
fix(feed): render failed state on Earn + Swap items and buffer CIP-64 shortcut gas

### DIFF
--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -251,7 +251,12 @@ const preparedTransactions: SerializableTransactionRequest[] = [
     data: '0x0',
     feeCurrency: mockCusdAddress as `0x${string}`,
     from: '0x0000000000000000000000000000000000007E57',
-    gas: '1850000',
+    // Swap tx base gas = 1_800_000. On CIP-64 (non-native fee currency) the
+    // wallet adds STATIC_GAS_PADDING (50_000) + SHORTCUT_NON_NATIVE_BUFFER_BPS
+    // (25% of 1_800_000 = 450_000) = 2_300_000 total. The buffer landed with
+    // the fix for the 2026-07-14 Neeru OOG so shortcut-supplied gas retains
+    // real headroom over CIP-64 overhead + real-world variance.
+    gas: '2300000',
     // The swap (second) tx has no fresh estimateGas call in this fixture so
     // _estimatedGasUse stays undefined, matching the actual saga output.
     _estimatedGasUse: undefined,
@@ -1294,15 +1299,19 @@ describe('SwapScreen', () => {
       // Per Bug E fix: pickFeeCurrency promotes cUSD ahead of CELO whenever
       // the user has any cUSD balance. The fixture token mock has cUSD
       // priceUsd = 1 and uses 18 decimals (same as CELO), so the gas math is:
-      //   gas: 21000 (approval) + 1850000 (swap, CIP-64 adds 50k overhead) = 1871000
-      //   maxGasFee:        1871000 * 12 Gwei = 0.022452 cUSD
-      //   estimatedGasFee:  (12600 calibrated approval + 1850000 swap) * 8 Gwei = 0.0149008 cUSD
+      //   swap base gas:   1_800_000
+      //   CIP-64 overhead: STATIC_GAS_PADDING (50_000) + 25% shortcut buffer
+      //                    (450_000) = 500_000  -> total swap gas 2_300_000
+      //   gas:             21_000 (approval) + 2_300_000 (swap) = 2_321_000
+      //   maxGasFee:       2_321_000 * 12 Gwei = 0.027852 cUSD
+      //   estimatedGasFee: (12_600 calibrated approval + 2_300_000 swap) * 8 Gwei
+      //                                                              = 0.0185008 cUSD
       //   ...USD = same numeric value since cUSD priceUsd = 1.
-      gas: 1871000,
-      maxGasFee: 0.022452,
-      maxGasFeeUsd: 0.022452,
-      estimatedGasFee: 0.0149008,
-      estimatedGasFeeUsd: 0.0149008,
+      gas: 2321000,
+      maxGasFee: 0.027852,
+      maxGasFeeUsd: 0.027852,
+      estimatedGasFee: 0.0185008,
+      estimatedGasFeeUsd: 0.0185008,
       appFeePercentageIncludedInPrice: undefined,
       feeCurrency: mockCusdAddress,
       feeCurrencySymbol: 'cUSD',

--- a/src/transactions/feed/EarnFeedItem.test.tsx
+++ b/src/transactions/feed/EarnFeedItem.test.tsx
@@ -8,7 +8,7 @@ import { Screens } from 'src/navigator/Screens'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import EarnFeedItem from 'src/transactions/feed/EarnFeedItem'
-import { NetworkId, TokenTransactionTypeV2 } from 'src/transactions/types'
+import { NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
 import {
   mockAaveArbUsdcAddress,
@@ -182,6 +182,18 @@ describe.each([
       expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_feed_item_select, {
         origin: type,
       })
+    })
+
+    it('Should render failed subtitle when transaction reverted', () => {
+      const failedTx = { ...transaction, status: TransactionStatus.Failed }
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <EarnFeedItem transaction={failedTx} />
+        </Provider>
+      )
+
+      expect(getByTestId('EarnFeedItem/subtitle')).toHaveTextContent('feedItemFailedTransaction')
+      expect(getByTestId('EarnFeedItem/subtitle')).not.toHaveTextContent(expectedSubTitle)
     })
   }
 )

--- a/src/transactions/feed/EarnFeedItem.tsx
+++ b/src/transactions/feed/EarnFeedItem.tsx
@@ -20,6 +20,7 @@ import {
   EarnSwapDeposit,
   EarnWithdraw,
   TokenTransactionTypeV2,
+  TransactionStatus,
 } from 'src/transactions/types'
 import { formatFeedTime } from 'src/utils/time'
 
@@ -72,6 +73,11 @@ export default function EarnFeedItem({ transaction }: Props) {
     transaction.type !== TokenTransactionTypeV2.EarnDeposit &&
     transaction.type !== TokenTransactionTypeV2.EarnSwapDeposit
 
+  const isFailed = transaction.status === TransactionStatus.Failed
+  if (isFailed) {
+    subtitle = t('feedItemFailedTransaction')
+  }
+
   return (
     <Touchable
       testID={`EarnFeedItem/${transaction.transactionHash}`}
@@ -97,7 +103,10 @@ export default function EarnFeedItem({ transaction }: Props) {
               tokenId={tokenId}
               showLocalAmount={true}
               showExplicitPositiveSign={true}
-              style={[styles.amount, isPositive && { color: Colors.accent }]}
+              style={[
+                styles.amount,
+                isFailed ? { color: Colors.gray3 } : isPositive && { color: Colors.accent },
+              ]}
               testID={'EarnFeedItem/amount'}
             />
           </View>

--- a/src/transactions/feed/SwapFeedItem.test.tsx
+++ b/src/transactions/feed/SwapFeedItem.test.tsx
@@ -137,6 +137,39 @@ describe('SwapFeedItem', () => {
     expect(getByTestId('SwapFeedItem/outgoingAmount')).toHaveTextContent('-2.87 cUSD')
   })
 
+  it('renders failed subtitle and grays the incoming amount when the swap reverted', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <SwapFeedItem transaction={{ ...swapTransaction, status: TransactionStatus.Failed }} />
+      </Provider>
+    )
+
+    expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent('feedItemFailedTransaction')
+    expect(getByTestId('SwapFeedItem/subtitle')).not.toHaveTextContent('feedItemSwapPath')
+    // Incoming amount still rendered so users can see what would have arrived, but styling
+    // switches to gray so it does not read as a real inbound movement.
+    expect(getByTestId('SwapFeedItem/incomingAmount')).toHaveTextContent('+2.93 cEUR')
+  })
+
+  it('renders failed subtitle for a reverted cross-chain swap regardless of route text', () => {
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          tokens: { tokenBalances: mockTokenBalances },
+        })}
+      >
+        <SwapFeedItem
+          transaction={{ ...crossChainSwapTransaction, status: TransactionStatus.Failed }}
+        />
+      </Provider>
+    )
+
+    expect(getByTestId('SwapFeedItem/subtitle')).toHaveTextContent('feedItemFailedTransaction')
+    expect(getByTestId('SwapFeedItem/subtitle')).not.toHaveTextContent(
+      'transactionFeed.crossChainSwapTransactionLabel'
+    )
+  })
+
   it('renders correctly for pending cross-chain swap with no inAmount value', async () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={createMockStore()}>

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -14,7 +14,7 @@ import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { useTokenInfo } from 'src/tokens/hooks'
 import TransactionFeedItemImage from 'src/transactions/feed/TransactionFeedItemImage'
-import { TokenExchange, TokenTransactionTypeV2 } from 'src/transactions/types'
+import { TokenExchange, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import { formatFeedTime } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -36,6 +36,7 @@ function SwapFeedItem({ transaction }: Props) {
   }
 
   const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction
+  const isFailed = transaction.status === TransactionStatus.Failed
   // EIP-7702 atomic batches from the TuCop indexer feed (and from the
   // fetch-Blockscout classifier for the same batches) populate
   // fromTokenAmounts with every leg of the batch. When every leg is a
@@ -155,7 +156,7 @@ function SwapFeedItem({ transaction }: Props) {
                 showSymbol={true}
                 showExplicitPositiveSign={true}
                 hideSign={false}
-                style={styles.amount}
+                style={[styles.amount, isFailed && { color: colors.gray3 }]}
                 testID={'SwapFeedItem/incomingAmount'}
               />
             )}
@@ -172,22 +173,24 @@ function SwapFeedItem({ transaction }: Props) {
               adjustsFontSizeToFit={true}
               minimumFontScale={0.8}
             >
-              {isCrossChainSwap
-                ? t('transactionFeed.crossChainSwapTransactionLabel')
-                : isMultiDollarSwap
-                  ? t('feedItemSwapPath', {
-                      token1: t('assets.dollars'),
-                      token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
-                    })
-                  : isMultiLegSwap
-                    ? t('feedItemSwapPathMulti', {
-                        count: fromLegCount,
+              {isFailed
+                ? t('feedItemFailedTransaction')
+                : isCrossChainSwap
+                  ? t('transactionFeed.crossChainSwapTransactionLabel')
+                  : isMultiDollarSwap
+                    ? t('feedItemSwapPath', {
+                        token1: t('assets.dollars'),
                         token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
                       })
-                    : t('feedItemSwapPath', {
-                        token1: getTokenName(outgoingTokenInfo, transaction.outAmount.tokenId),
-                        token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
-                      })}
+                    : isMultiLegSwap
+                      ? t('feedItemSwapPathMulti', {
+                          count: fromLegCount,
+                          token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
+                        })
+                      : t('feedItemSwapPath', {
+                          token1: getTokenName(outgoingTokenInfo, transaction.outAmount.tokenId),
+                          token2: getTokenName(incomingTokenInfo, transaction.inAmount.tokenId),
+                        })}
             </Text>
             {isMultiDollarSwap && multiDollarOutgoingTotal ? (
               <Text style={styles.tokenAmount} testID={'SwapFeedItem/outgoingAmount'}>

--- a/src/viem/prepareTransactions.test.ts
+++ b/src/viem/prepareTransactions.test.ts
@@ -385,17 +385,17 @@ describe('prepareTransactions module', () => {
             to: '0xto' as Address,
             data: '0xdata',
 
-            gas: BigInt(15_000), // 50k will be added for fee currency 1 since it is non-native
+            gas: BigInt(15_000), // 50k padding + 25% shortcut buffer (3_750) added for non-native fee currency 1
           },
         ],
         origin: 'earn-withdraw',
       })
       expect(result).toStrictEqual({
         type: 'need-decrease-spend-amount-for-gas',
-        maxGasFeeInDecimal: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
-        estimatedGasFeeInDecimal: new BigNumber('65'), // 15k + 50k non-native gas token buffer / 1000 feeCurrency1 decimals
+        maxGasFeeInDecimal: new BigNumber('69.4375'), // (15k + 50k padding + 3_750 shortcut buffer) * 1.01 / 1000 feeCurrency1 decimals
+        estimatedGasFeeInDecimal: new BigNumber('68.75'), // (15k + 50k padding + 3_750 shortcut buffer) / 1000 feeCurrency1 decimals
         feeCurrency: mockFeeCurrencies[1],
-        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasFee
+        decreasedSpendAmount: new BigNumber(0.5625), // 70.0 balance minus maxGasFee
       })
       expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
       expect(AppAnalytics.track).toHaveBeenCalledWith(
@@ -468,17 +468,17 @@ describe('prepareTransactions module', () => {
             to: '0xto' as Address,
             data: '0xdata',
 
-            gas: BigInt(15_000), // 50k will be added for fee currency 1 since it is non-native
+            gas: BigInt(15_000), // 50k padding + 25% shortcut buffer (3_750) added for non-native fee currency 1
           },
         ],
         origin: 'wallet-connect',
       })
       expect(result).toStrictEqual({
         type: 'need-decrease-spend-amount-for-gas',
-        maxGasFeeInDecimal: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
-        estimatedGasFeeInDecimal: new BigNumber('65'), // 15k + 50k non-native gas token buffer / 1000 feeCurrency1 decimals
+        maxGasFeeInDecimal: new BigNumber('69.4375'), // (15k + 50k padding + 3_750 shortcut buffer) * 1.01 / 1000 feeCurrency1 decimals
+        estimatedGasFeeInDecimal: new BigNumber('68.75'), // (15k + 50k padding + 3_750 shortcut buffer) / 1000 feeCurrency1 decimals
         feeCurrency: mockFeeCurrencies[1],
-        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasFee
+        decreasedSpendAmount: new BigNumber(0.5625), // 70.0 balance minus maxGasFee
       })
       expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
       expect(AppAnalytics.track).toHaveBeenCalledWith(
@@ -578,7 +578,7 @@ describe('prepareTransactions module', () => {
             to: '0xto' as Address,
             data: '0xdata',
 
-            gas: BigInt(100), // 50k will be added for fee currency 2 since it is non-native
+            gas: BigInt(100), // 50k padding + 25% shortcut buffer (25) added for non-native fee currency 2
             _estimatedGasUse: BigInt(50),
           },
         ],
@@ -604,12 +604,12 @@ describe('prepareTransactions module', () => {
             to: '0xto',
             data: '0xdata',
 
-            gas: BigInt(50_100),
+            gas: BigInt(50_125),
             maxFeePerGas: BigInt(1),
             maxPriorityFeePerGas: BigInt(2),
             feeCurrency: mockFeeCurrencies[1].address,
             _baseFeePerGas: BigInt(1),
-            _estimatedGasUse: BigInt(50_050),
+            _estimatedGasUse: BigInt(50_075),
           },
         ],
         feeCurrency: mockFeeCurrencies[1],
@@ -961,6 +961,54 @@ describe('prepareTransactions module', () => {
           true
         )
       ).rejects.toThrowError('App transport not available for network ethereum')
+    })
+    it('adds static padding + shortcut buffer to shortcut txs with non-native fee currency', async () => {
+      // Regression: on 2026-07-14 a Neeru deposit reverted OOG with the wallet
+      // trusting a shortcut-provided gas of 260k + 50k static padding = 310k
+      // limit. The tx consumed 306,385. The 25% shortcut buffer (65_000 extra
+      // for a 260k baseline) keeps such calls off the ceiling.
+      mocked(estimateFeesPerGas).mockResolvedValue({
+        maxFeePerGas: BigInt(10),
+        maxPriorityFeePerGas: BigInt(2),
+        baseFeePerGas: BigInt(5),
+      })
+      const estimateTransactionsOutput = await tryEstimateTransactions(
+        [{ from: '0x123', gas: BigInt(260_000), _estimatedGasUse: BigInt(260_000) }],
+        mockFeeCurrencies[1]
+      )
+      expect(estimateTransactionsOutput).toStrictEqual([
+        {
+          from: '0x123',
+          feeCurrency: mockFeeCurrencies[1].address,
+          // 260_000 + 50_000 static padding + 65_000 (25% of 260k) shortcut buffer
+          gas: BigInt(375_000),
+          _estimatedGasUse: BigInt(375_000),
+          maxFeePerGas: BigInt(10),
+          maxPriorityFeePerGas: BigInt(2),
+          _baseFeePerGas: BigInt(5),
+        },
+      ])
+    })
+    it('does not add shortcut buffer when fee currency is native', async () => {
+      mocked(estimateFeesPerGas).mockResolvedValue({
+        maxFeePerGas: BigInt(10),
+        maxPriorityFeePerGas: BigInt(2),
+        baseFeePerGas: BigInt(5),
+      })
+      const estimateTransactionsOutput = await tryEstimateTransactions(
+        [{ from: '0x123', gas: BigInt(260_000), _estimatedGasUse: BigInt(260_000) }],
+        mockFeeCurrencies[0]
+      )
+      expect(estimateTransactionsOutput).toStrictEqual([
+        {
+          from: '0x123',
+          gas: BigInt(260_000),
+          _estimatedGasUse: BigInt(260_000),
+          maxFeePerGas: BigInt(10),
+          maxPriorityFeePerGas: BigInt(2),
+          _baseFeePerGas: BigInt(5),
+        },
+      ])
     })
   })
   describe('getMaxGasFee', () => {

--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -278,12 +278,26 @@ export async function tryEstimateTransactions(
   // wallet still respects any smaller gas the RPC would have set for the
   // actual submission, so this is not an over-charge risk.
   const POST_APPROVE_FALLBACK_GAS = BigInt(300_000)
+  // Extra buffer when the shortcut pre-supplied `gas` and we are paying with a
+  // non-native fee currency (CIP-64). The hooks API cannot know the exact
+  // CIP-64 overhead nor real-world state variance, and STATIC_GAS_PADDING
+  // alone (~50k) has been observed to leave complex calls (Neeru deposit
+  // 2026-07-14) inches from the limit and OOG. This adds 25% of the
+  // shortcut's own gas on top so calls with pre-set gas retain a real
+  // safety margin. Wallet-estimated txs (`else` branch below) already get
+  // Forno's binary-search LIMIT plus STATIC_GAS_PADDING, so they are
+  // unaffected.
+  const SHORTCUT_NON_NATIVE_BUFFER_BPS = BigInt(2500)
 
   for (let i = 0; i < baseTransactions.length; i++) {
     const baseTx = baseTransactions[i]
     if (baseTx.gas) {
       // We have an estimate of gas already and don't want to recalculate it
       // e.g. if this is a swap transaction that depends on an approval transaction that hasn't been submitted yet, so simulation would fail
+      const staticPadding = BigInt(feeCurrency.isNative ? 0 : STATIC_GAS_PADDING)
+      const shortcutBuffer = feeCurrency.isNative
+        ? BigInt(0)
+        : (baseTx.gas * SHORTCUT_NON_NATIVE_BUFFER_BPS) / BigInt(10_000)
       transactions.push({
         ...baseTx,
         maxFeePerGas,
@@ -292,10 +306,11 @@ export async function tryEstimateTransactions(
         // See https://github.com/wagmi-dev/viem/blob/e0149711da5894ac5f0719414b4ecc06ccaecb7b/src/chains/celo/serializers.ts#L164-L168
         ...(feeCurrencyAddress && { feeCurrency: feeCurrencyAddress }),
         // We assume the provided gas value is with the native fee currency
-        // If it's not, we add the static padding
-        gas: baseTx.gas + BigInt(feeCurrency.isNative ? 0 : STATIC_GAS_PADDING),
+        // If it's not, we add the static padding + a percentage buffer
+        // (see SHORTCUT_NON_NATIVE_BUFFER_BPS above).
+        gas: baseTx.gas + staticPadding + shortcutBuffer,
         _estimatedGasUse: baseTx._estimatedGasUse
-          ? baseTx._estimatedGasUse + BigInt(feeCurrency.isNative ? 0 : STATIC_GAS_PADDING)
+          ? baseTx._estimatedGasUse + staticPadding + shortcutBuffer
           : undefined,
         _baseFeePerGas: baseFeePerGas,
       })


### PR DESCRIPTION
## Summary

Two related fixes triggered by the 2026-07-14 Neeru OOG incident.

1. **Wallet-side gas buffer for CIP-64 shortcut txs** ([viem/prepareTransactions.ts](src/viem/prepareTransactions.ts)). When a hooks-api shortcut supplies `rawTx.gas` and the user pays with a non-native fee currency, only `STATIC_GAS_PADDING = 50k` was being added on top. That left the failing Neeru deposit at 306,385 / 310,000 (98.8%) and OOG'd. Adds `SHORTCUT_NON_NATIVE_BUFFER_BPS = 2500` (25% of the shortcut's own gas), applied ONLY when both conditions hold. Wallet-estimated txs (else branch) unaffected because Forno's binary-search LIMIT already covers them.

2. **Feed items now render failed state** ([EarnFeedItem.tsx](src/transactions/feed/EarnFeedItem.tsx) + [SwapFeedItem.tsx](src/transactions/feed/SwapFeedItem.tsx)). Both feed items only passed `transaction.status` to the avatar image and never overrode subtitle or amount styling. Result in 1.118.7: a reverted deposit or swap renders with its normal subtitle and full-color amount, indistinguishable from a successful move. This is trust-critical for a financial feed. Both files now:
   - Override the type-specific subtitle with `feedItemFailedTransaction` when `status === Failed` (same key `TransferFeedItem` already uses via `transferFeedUtils.ts:151`).
   - Style the primary amount in `Colors.gray3` so it reads as inactive without hiding the number (retry decisions still need it).

Backend has zero action items on this PR. Their fix (raising shortcut gas hints in hooks-api) landed separately as their PR #137 on 2026-07-22.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn lint` on all modified files clean
- [x] `yarn jest src/viem/prepareTransactions.test.ts src/transactions/feed/EarnFeedItem.test.tsx src/transactions/feed/SwapFeedItem.test.tsx` -> 81 passed
- [x] `yarn jest src/transactions/feed/` -> 141 passed, 14 skipped (regression check on the whole feed dir)
- [ ] Post-merge: eyeball a known-failed Neeru deposit and a known-failed Squid swap in the activity feed to confirm the gray amount + failed subtitle render on device.

## Commits

Split by concern for reviewability:

- `fix(viem): buffer non-native shortcut gas by 25%` (gas fix, isolated to prepareTransactions).
- `fix(feed): render failed state on EarnFeedItem` (Earn render).
- `fix(feed): render failed state on SwapFeedItem` (Swap render, same pattern, closes the same gap for Squid / cross-chain / multi-leg 7702 batches).