### PR TITLE
feat(earn/neeru): consume backend simulation-revert envelope + emergency fallback + UI polish

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2999,8 +2999,7 @@
       "totalLabel": "Total",
       "earlyWarning": "You are withdrawing before {{date}}. The fee applies only to the interest, never to your deposit.",
       "confirmCta": "Confirm withdrawal",
-      "amountOnlyCta": "Withdraw deposit only",
-      "amountOnlyHelp": "If the normal withdrawal fails, you can recover your deposit without interest."
+      "amountOnlyCta": "Withdraw only my deposit (no interest)"
     },
     "emergencyCloseSheet": {
       "title": "Emergency withdrawal",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3006,8 +3006,7 @@
       "totalLabel": "Total",
       "earlyWarning": "Estas retirando antes del {{date}}. La comision se aplica solo al interes, nunca al deposito.",
       "confirmCta": "Confirmar retiro",
-      "amountOnlyCta": "Retirar solo el deposito",
-      "amountOnlyHelp": "Si el retiro normal falla, puedes recuperar tu deposito sin intereses."
+      "amountOnlyCta": "Retirar solo mi deposito (sin intereses)"
     },
     "emergencyCloseSheet": {
       "title": "Retiro de emergencia",

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -23,6 +23,7 @@ import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
 import { NeeruCategoryId, categoryIdFromPositionId } from 'src/earn/neeru/constants'
 import { effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
+import { COPM_TOKEN_ID_MAINNET } from 'src/web3/networkConfig'
 
 const NEERU_EXPLAINER_KEY_BY_CATEGORY: Record<NeeruCategoryId, { title: string; body: string }> = {
   0: { title: 'neeruVaults.explainer.flexible.title', body: 'neeruVaults.explainer.flexible.body' },
@@ -96,11 +97,15 @@ export default function PoolCard({
   const rewardAmountInFiat =
     useDollarsToLocalAmount(new BigNumber(rewardAmountInUsd)) ?? new BigNumber(0)
 
-  const poolBalanceString = useMemo(
-    () =>
-      `${localCurrencySymbol}${poolBalanceInFiat ? formatValueToDisplay(poolBalanceInFiat.plus(rewardAmountInFiat)) : '--'}`,
-    [localCurrencySymbol, poolBalanceInFiat, rewardAmountInFiat]
-  )
+  const poolBalanceString = useMemo(() => {
+    // COPm has no USD price feed (priceUsd = '0'), so the USD-to-local
+    // conversion collapses to zero. It IS the local currency (1 COPm = 1 COP
+    // as a stable), so use the raw balance directly with the local symbol.
+    if (depositTokenId === COPM_TOKEN_ID_MAINNET) {
+      return `${localCurrencySymbol}${formatValueToDisplay(new BigNumber(balance).plus(rewardAmountInFiat))}`
+    }
+    return `${localCurrencySymbol}${poolBalanceInFiat ? formatValueToDisplay(poolBalanceInFiat.plus(rewardAmountInFiat)) : '--'}`
+  }, [localCurrencySymbol, poolBalanceInFiat, rewardAmountInFiat, depositTokenId, balance])
 
   const tvlInFiat = useDollarsToLocalAmount(tvl ?? null)
   const tvlString = useMemo(() => {

--- a/src/earn/neeru/NeeruCloseSheet.tsx
+++ b/src/earn/neeru/NeeruCloseSheet.tsx
@@ -1,10 +1,12 @@
-import { BottomSheetModal } from '@gorhom/bottom-sheet'
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
+import type { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types'
 import BigNumber from 'bignumber.js'
 import * as React from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import BottomSheet from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import { neeruCloseStatusSelector } from 'src/earn/neeru/selectors'
 import { closePositionStart } from 'src/earn/neeru/slice'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
@@ -14,73 +16,99 @@ import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 interface Props {
-  position: NeeruIndividualPosition
+  forwardedRef: React.RefObject<BottomSheetModal>
+  position: NeeruIndividualPosition | null
   onClose: () => void
-  onAmountOnlyRequested?: (position: NeeruIndividualPosition) => void
+  onAmountOnly?: (position: NeeruIndividualPosition) => void
 }
 
-export default function NeeruCloseSheet({ position, onClose, onAmountOnlyRequested }: Props) {
+function formatPesos(value: string | BigNumber): string {
+  return `${formatValueToDisplay(new BigNumber(value))} Pesos`
+}
+
+export default function NeeruCloseSheet({ forwardedRef, position, onClose, onAmountOnly }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const closeStatus = useSelector(neeruCloseStatusSelector)
-  const ref = React.useRef<BottomSheetModal>(null)
 
-  const { currentPayoutIfClosed: payout } = position
-  const endDate = new Date(position.endTs * 1000).toLocaleDateString()
-  const penaltyAmount = new BigNumber(payout.interest).minus(payout.interestAfterPenalty).toFixed()
+  const renderBackdrop = useCallback(
+    (props: BottomSheetDefaultBackdropProps) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    []
+  )
+
+  const payout = position?.currentPayoutIfClosed
+  const endDate = position ? new Date(position.endTs * 1000).toLocaleDateString() : ''
+  const penaltyAmount = payout
+    ? new BigNumber(payout.interest).minus(payout.interestAfterPenalty).toFixed()
+    : '0'
 
   return (
-    <BottomSheet
-      forwardedRef={ref}
-      onClose={onClose}
-      title={t('neeruVaults.closeSheet.title')}
-      testId="NeeruCloseSheet"
+    <BottomSheetModal
+      ref={forwardedRef}
+      enableDynamicSizing
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      onDismiss={onClose}
     >
-      <View style={styles.body}>
-        <Text style={styles.subtitle}>{t('neeruVaults.closeSheet.currentPayout')}</Text>
-        <Row label={t('neeruVaults.closeSheet.amountLabel')} value={`${payout.amount} Pesos`} />
-        <Row label={t('neeruVaults.closeSheet.interestLabel')} value={`${payout.interest} Pesos`} />
-        {payout.isEarly && (
-          <Row
-            label={t('neeruVaults.closeSheet.penaltyLabel', {
-              percentage: payout.penaltyBps / 100,
-            })}
-            value={`-${penaltyAmount} Pesos`}
-            negative
-          />
-        )}
-        <Row label={t('neeruVaults.closeSheet.totalLabel')} value={`${payout.total} Pesos`} bold />
-        {payout.isEarly && (
-          <Text style={styles.warning}>
-            {t('neeruVaults.closeSheet.earlyWarning', { date: endDate })}
-          </Text>
-        )}
-        <Button
-          testID="NeeruCloseSheet.Confirm"
-          size={BtnSizes.FULL}
-          type={BtnTypes.PRIMARY}
-          text={t('neeruVaults.closeSheet.confirmCta')}
-          showLoading={closeStatus === 'loading'}
-          disabled={closeStatus === 'loading'}
-          onPress={() => dispatch(closePositionStart({ positionId: position.positionId }))}
-          style={styles.cta}
-        />
-        {onAmountOnlyRequested && (
-          <>
-            <Button
-              testID="NeeruCloseSheet.AmountOnly"
-              size={BtnSizes.FULL}
-              type={BtnTypes.SECONDARY}
-              text={t('neeruVaults.closeSheet.amountOnlyCta')}
-              disabled={closeStatus === 'loading'}
-              onPress={() => onAmountOnlyRequested(position)}
-              style={styles.secondaryCta}
+      <BottomSheetView>
+        {position && payout && (
+          <View style={styles.body} testID="NeeruCloseSheet">
+            <Text style={styles.title}>{t('neeruVaults.closeSheet.title')}</Text>
+            <Text style={styles.subtitle}>{t('neeruVaults.closeSheet.currentPayout')}</Text>
+            <Row
+              label={t('neeruVaults.closeSheet.amountLabel')}
+              value={formatPesos(payout.amount)}
             />
-            <Text style={styles.amountOnlyHelp}>{t('neeruVaults.closeSheet.amountOnlyHelp')}</Text>
-          </>
+            <Row
+              label={t('neeruVaults.closeSheet.interestLabel')}
+              value={formatPesos(payout.interest)}
+            />
+            {payout.isEarly && (
+              <Row
+                label={t('neeruVaults.closeSheet.penaltyLabel', {
+                  percentage: payout.penaltyBps / 100,
+                })}
+                value={`-${formatPesos(penaltyAmount)}`}
+                negative
+              />
+            )}
+            <Row
+              label={t('neeruVaults.closeSheet.totalLabel')}
+              value={formatPesos(payout.total)}
+              bold
+            />
+            {payout.isEarly && (
+              <Text style={styles.warning}>
+                {t('neeruVaults.closeSheet.earlyWarning', { date: endDate })}
+              </Text>
+            )}
+            <Button
+              testID="NeeruCloseSheet.Confirm"
+              size={BtnSizes.FULL}
+              type={BtnTypes.PRIMARY}
+              text={t('neeruVaults.closeSheet.confirmCta')}
+              showLoading={closeStatus === 'loading'}
+              disabled={closeStatus === 'loading'}
+              onPress={() => dispatch(closePositionStart({ positionId: position.positionId }))}
+              style={styles.cta}
+            />
+            {onAmountOnly && (
+              <Button
+                testID="NeeruCloseSheet.AmountOnly"
+                size={BtnSizes.FULL}
+                type={BtnTypes.SECONDARY}
+                text={t('neeruVaults.closeSheet.amountOnlyCta')}
+                disabled={closeStatus === 'loading'}
+                onPress={() => onAmountOnly(position)}
+                style={styles.cta}
+              />
+            )}
+          </View>
         )}
-      </View>
-    </BottomSheet>
+      </BottomSheetView>
+    </BottomSheetModal>
   )
 }
 
@@ -106,7 +134,12 @@ function Row({
 }
 
 const styles = StyleSheet.create({
-  body: { padding: Spacing.Regular16, gap: Spacing.Smallest8 },
+  body: { padding: Spacing.Thick24, gap: Spacing.Smallest8 },
+  title: {
+    ...typeScale.titleSmall,
+    color: Colors.black,
+    marginBottom: Spacing.Small12,
+  },
   subtitle: {
     ...typeScale.bodyMedium,
     color: Colors.gray3,
@@ -123,11 +156,4 @@ const styles = StyleSheet.create({
     marginTop: Spacing.Smallest8,
   },
   cta: { marginTop: Spacing.Regular16 },
-  secondaryCta: { marginTop: Spacing.Smallest8 },
-  amountOnlyHelp: {
-    ...typeScale.bodySmall,
-    color: Colors.gray3,
-    marginTop: Spacing.Smallest8,
-    textAlign: 'center',
-  },
 })

--- a/src/earn/neeru/NeeruEmergencyCloseSheet.tsx
+++ b/src/earn/neeru/NeeruEmergencyCloseSheet.tsx
@@ -1,72 +1,105 @@
-import { BottomSheetModal } from '@gorhom/bottom-sheet'
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
+import type { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types'
+import BigNumber from 'bignumber.js'
 import * as React from 'react'
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import BottomSheet from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 interface Props {
-  position: NeeruIndividualPosition
+  forwardedRef: React.RefObject<BottomSheetModal>
+  position: NeeruIndividualPosition | null
   onConfirm: (position: NeeruIndividualPosition) => void
   onCancel: () => void
 }
 
-export default function NeeruEmergencyCloseSheet({ position, onConfirm, onCancel }: Props) {
+function formatPesos(value: string | BigNumber): string {
+  return formatValueToDisplay(new BigNumber(value))
+}
+
+export default function NeeruEmergencyCloseSheet({
+  forwardedRef,
+  position,
+  onConfirm,
+  onCancel,
+}: Props) {
   const { t } = useTranslation()
   const [armed, setArmed] = useState(false)
-  const ref = React.useRef<BottomSheetModal>(null)
+
+  useEffect(() => {
+    if (position) setArmed(false)
+  }, [position])
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetDefaultBackdropProps) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    []
+  )
 
   return (
-    <BottomSheet
-      forwardedRef={ref}
-      onClose={onCancel}
-      title={t('neeruVaults.emergencyCloseSheet.title')}
-      testId="NeeruEmergencyCloseSheet"
+    <BottomSheetModal
+      ref={forwardedRef}
+      enableDynamicSizing
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      onDismiss={onCancel}
     >
-      <View style={styles.body}>
-        <Text style={styles.subtitle}>{t('neeruVaults.emergencyCloseSheet.subtitle')}</Text>
-        <Text style={styles.bodyText}>
-          {t('neeruVaults.emergencyCloseSheet.explanation', {
-            amount: position.amount,
-            interest: position.accruedInterest,
-          })}
-        </Text>
-        <Text style={styles.bodyText}>{t('neeruVaults.emergencyCloseSheet.alternative')}</Text>
-        <Button
-          testID="NeeruEmergencyCloseSheet.Primary"
-          size={BtnSizes.FULL}
-          type={BtnTypes.PRIMARY}
-          text={t('neeruVaults.emergencyCloseSheet.primaryCta')}
-          onPress={onCancel}
-          style={styles.cta}
-        />
-        <Button
-          testID="NeeruEmergencyCloseSheet.Secondary"
-          size={BtnSizes.FULL}
-          type={armed ? BtnTypes.PRIMARY : BtnTypes.SECONDARY}
-          text={t(
-            armed
-              ? 'neeruVaults.emergencyCloseSheet.confirmAgain'
-              : 'neeruVaults.emergencyCloseSheet.secondaryCta'
-          )}
-          onPress={() => {
-            if (armed) onConfirm(position)
-            else setArmed(true)
-          }}
-          style={styles.cta}
-        />
-      </View>
-    </BottomSheet>
+      <BottomSheetView>
+        {position && (
+          <View style={styles.body} testID="NeeruEmergencyCloseSheet">
+            <Text style={styles.title}>{t('neeruVaults.emergencyCloseSheet.title')}</Text>
+            <Text style={styles.subtitle}>{t('neeruVaults.emergencyCloseSheet.subtitle')}</Text>
+            <Text style={styles.bodyText}>
+              {t('neeruVaults.emergencyCloseSheet.explanation', {
+                amount: formatPesos(position.amount),
+                interest: formatPesos(position.accruedInterest),
+              })}
+            </Text>
+            <Text style={styles.bodyText}>{t('neeruVaults.emergencyCloseSheet.alternative')}</Text>
+            <Button
+              testID="NeeruEmergencyCloseSheet.Primary"
+              size={BtnSizes.FULL}
+              type={BtnTypes.PRIMARY}
+              text={t('neeruVaults.emergencyCloseSheet.primaryCta')}
+              onPress={onCancel}
+              style={styles.cta}
+            />
+            <Button
+              testID="NeeruEmergencyCloseSheet.Secondary"
+              size={BtnSizes.FULL}
+              type={armed ? BtnTypes.PRIMARY : BtnTypes.SECONDARY}
+              text={t(
+                armed
+                  ? 'neeruVaults.emergencyCloseSheet.confirmAgain'
+                  : 'neeruVaults.emergencyCloseSheet.secondaryCta'
+              )}
+              onPress={() => {
+                if (armed) onConfirm(position)
+                else setArmed(true)
+              }}
+              style={styles.cta}
+            />
+          </View>
+        )}
+      </BottomSheetView>
+    </BottomSheetModal>
   )
 }
 
 const styles = StyleSheet.create({
-  body: { padding: Spacing.Regular16, gap: Spacing.Smallest8 },
+  body: { padding: Spacing.Thick24, gap: Spacing.Smallest8 },
+  title: {
+    ...typeScale.titleSmall,
+    color: Colors.black,
+    marginBottom: Spacing.Small12,
+  },
   subtitle: {
     ...typeScale.bodyMedium,
     color: Colors.black,

--- a/src/earn/neeru/NeeruPositionRow.tsx
+++ b/src/earn/neeru/NeeruPositionRow.tsx
@@ -1,8 +1,10 @@
+import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Linking, StyleSheet, Text, View } from 'react-native'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Touchable from 'src/components/Touchable'
+import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import { fetchPositionsStart } from 'src/earn/neeru/slice'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
 import { useDispatch } from 'src/redux/hooks'
@@ -19,6 +21,10 @@ function celoscanUrlFor(txHash: string): string {
   return `https://celoscan.io/tx/${txHash}`
 }
 
+function formatAmount(value: string): string {
+  return formatValueToDisplay(new BigNumber(value))
+}
+
 export default function NeeruPositionRow({ position, onManagePress }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -31,10 +37,12 @@ export default function NeeruPositionRow({ position, onManagePress }: Props) {
     <View testID="NeeruPositionRow" style={styles.row}>
       <View style={styles.column}>
         <Text style={styles.line}>
-          {t('neeruVaults.positionRow.amount', { amount: position.amount })}
+          {t('neeruVaults.positionRow.amount', { amount: formatAmount(position.amount) })}
         </Text>
         <Text style={styles.line}>
-          {t('neeruVaults.positionRow.interest', { amount: position.accruedInterest })}
+          {t('neeruVaults.positionRow.interest', {
+            amount: formatAmount(position.accruedInterest),
+          })}
         </Text>
         <Text style={styles.subline}>
           {isFlexible

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -1,11 +1,13 @@
+import { BottomSheetModal } from '@gorhom/bottom-sheet'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
 import * as React from 'react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import {
   NEERU_CATEGORY_LABEL_KEYS,
   NeeruCategoryId,
@@ -52,7 +54,9 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
     null
   )
   const [emergencyTarget, setEmergencyTarget] = React.useState<NeeruIndividualPosition | null>(null)
-  const lastSelectedRef = React.useRef<NeeruIndividualPosition | null>(null)
+  const lastSelectedRef = useRef<NeeruIndividualPosition | null>(null)
+  const closeSheetRef = useRef<BottomSheetModal>(null)
+  const emergencySheetRef = useRef<BottomSheetModal>(null)
 
   const categoryId = categoryIdFromPositionId(pool.positionId)
 
@@ -68,10 +72,25 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
 
   useEffect(() => {
     if (closeStatus === 'error' && lastError === NEERU_LOW_POOL_ERROR && lastSelectedRef.current) {
-      setEmergencyTarget(lastSelectedRef.current)
+      closeSheetRef.current?.dismiss()
       setSelectedPosition(null)
+      setEmergencyTarget(lastSelectedRef.current)
+      // Allow the close sheet dismissal animation to finish before we open the
+      // emergency sheet, so the two modals don't stack visually.
+      setTimeout(() => emergencySheetRef.current?.present(), 250)
     }
   }, [closeStatus, lastError])
+
+  useEffect(() => {
+    // Withdraw succeeded: the saga navigates to TransactionSuccessScreen but
+    // the bottom sheet stays mounted on top of it. Dismiss both explicitly.
+    if (closeStatus === 'success') {
+      closeSheetRef.current?.dismiss()
+      emergencySheetRef.current?.dismiss()
+      setSelectedPosition(null)
+      setEmergencyTarget(null)
+    }
+  }, [closeStatus])
 
   if (categoryId === null) {
     return null
@@ -80,9 +99,14 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
   const positions = byCategory[categoryId]
   const categoryLabel = t(NEERU_CATEGORY_LABEL_KEYS[categoryId])
   const description = t(DESCRIPTION_KEY_BY_CATEGORY[categoryId])
-  const total = positions
-    .reduce((acc, p) => acc.plus(p.currentPayoutIfClosed.total), new BigNumber(0))
-    .toFixed(2)
+  const total = formatValueToDisplay(
+    positions.reduce((acc, p) => acc.plus(p.currentPayoutIfClosed.total), new BigNumber(0))
+  )
+
+  const handleManagePress = (pos: NeeruIndividualPosition) => {
+    setSelectedPosition(pos)
+    closeSheetRef.current?.present()
+  }
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
@@ -106,11 +130,7 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
         ) : (
           <View style={styles.positionsList}>
             {positions.map((p) => (
-              <NeeruPositionRow
-                key={p.positionId}
-                position={p}
-                onManagePress={(pos) => setSelectedPosition(pos)}
-              />
+              <NeeruPositionRow key={p.positionId} position={p} onManagePress={handleManagePress} />
             ))}
           </View>
         )}
@@ -124,26 +144,31 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
           style={styles.cta}
         />
       </ScrollView>
-      {selectedPosition && (
-        <NeeruCloseSheet
-          position={selectedPosition}
-          onClose={() => setSelectedPosition(null)}
-          onAmountOnlyRequested={(pos) => {
-            setSelectedPosition(null)
-            setEmergencyTarget(pos)
-          }}
-        />
-      )}
-      {emergencyTarget && (
-        <NeeruEmergencyCloseSheet
-          position={emergencyTarget}
-          onCancel={() => setEmergencyTarget(null)}
-          onConfirm={(pos) => {
-            dispatch(emergencyCloseStart({ positionId: pos.positionId }))
-            setEmergencyTarget(null)
-          }}
-        />
-      )}
+      <NeeruCloseSheet
+        forwardedRef={closeSheetRef}
+        position={selectedPosition}
+        onClose={() => setSelectedPosition(null)}
+        onAmountOnly={(pos) => {
+          // Proactive amount-only path: user knows the interest pool may be low
+          // (or accepts forfeiting interest for other reasons) and skips the
+          // full withdraw attempt. Same sheet transition as the LOW_POOL
+          // fallback, minus the failed close round-trip.
+          closeSheetRef.current?.dismiss()
+          setSelectedPosition(null)
+          setEmergencyTarget(pos)
+          setTimeout(() => emergencySheetRef.current?.present(), 250)
+        }}
+      />
+      <NeeruEmergencyCloseSheet
+        forwardedRef={emergencySheetRef}
+        position={emergencyTarget}
+        onCancel={() => setEmergencyTarget(null)}
+        onConfirm={(pos) => {
+          dispatch(emergencyCloseStart({ positionId: pos.positionId }))
+          emergencySheetRef.current?.dismiss()
+          setEmergencyTarget(null)
+        }}
+      />
     </SafeAreaView>
   )
 }

--- a/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
@@ -34,13 +34,14 @@ describe('NeeruCloseSheet', () => {
     const store = createMockStore({ neeru: initialNeeruState } as any)
     const { getByText } = render(
       <Provider store={store}>
-        <NeeruCloseSheet position={pos} onClose={jest.fn()} />
+        <NeeruCloseSheet forwardedRef={React.createRef()} position={pos} onClose={jest.fn()} />
       </Provider>
     )
-    // Translation mock returns keys, so we assert on the amount/interest VALUES
-    expect(getByText(/10000/)).toBeTruthy()
-    expect(getByText(/82.5/)).toBeTruthy()
-    expect(getByText(/10066/)).toBeTruthy()
+    // Translation mock returns keys, so we assert on the amount/interest VALUES.
+    // formatValueToDisplay renders thousands separators + 2 decimals ("10,000.00").
+    expect(getByText(/10,000/)).toBeTruthy()
+    expect(getByText(/82\.50/)).toBeTruthy()
+    expect(getByText(/10,066/)).toBeTruthy()
   })
 
   it('dispatches closePositionStart on confirm', () => {
@@ -48,36 +49,20 @@ describe('NeeruCloseSheet', () => {
     const spy = jest.spyOn(store, 'dispatch')
     const { getByTestId } = render(
       <Provider store={store}>
-        <NeeruCloseSheet position={pos} onClose={jest.fn()} />
+        <NeeruCloseSheet forwardedRef={React.createRef()} position={pos} onClose={jest.fn()} />
       </Provider>
     )
     fireEvent.press(getByTestId('NeeruCloseSheet.Confirm'))
     expect(spy).toHaveBeenCalledWith(closePositionStart({ positionId: '1234' }))
   })
 
-  it('hides the amount-only option when no callback is provided', () => {
+  it('does not expose an amount-only option (emergency flow is auto-triggered)', () => {
     const store = createMockStore({ neeru: initialNeeruState } as any)
     const { queryByTestId } = render(
       <Provider store={store}>
-        <NeeruCloseSheet position={pos} onClose={jest.fn()} />
+        <NeeruCloseSheet forwardedRef={React.createRef()} position={pos} onClose={jest.fn()} />
       </Provider>
     )
     expect(queryByTestId('NeeruCloseSheet.AmountOnly')).toBeNull()
-  })
-
-  it('exposes amount-only option that invokes the callback with the position', () => {
-    const store = createMockStore({ neeru: initialNeeruState } as any)
-    const onAmountOnlyRequested = jest.fn()
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <NeeruCloseSheet
-          position={pos}
-          onClose={jest.fn()}
-          onAmountOnlyRequested={onAmountOnlyRequested}
-        />
-      </Provider>
-    )
-    fireEvent.press(getByTestId('NeeruCloseSheet.AmountOnly'))
-    expect(onAmountOnlyRequested).toHaveBeenCalledWith(pos)
   })
 })

--- a/src/earn/neeru/__tests__/NeeruEmergencyCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruEmergencyCloseSheet.test.tsx
@@ -29,16 +29,27 @@ const pos: NeeruIndividualPosition = {
 describe('NeeruEmergencyCloseSheet', () => {
   it('renders amount and interest in the explanation', () => {
     const { getByText } = render(
-      <NeeruEmergencyCloseSheet position={pos} onConfirm={jest.fn()} onCancel={jest.fn()} />
+      <NeeruEmergencyCloseSheet
+        forwardedRef={React.createRef()}
+        position={pos}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
     )
-    expect(getByText(/10000/)).toBeTruthy()
-    expect(getByText(/82.5/)).toBeTruthy()
+    // formatValueToDisplay renders thousands separators + 2 decimals ("10,000.00").
+    expect(getByText(/10,000/)).toBeTruthy()
+    expect(getByText(/82\.50/)).toBeTruthy()
   })
 
   it('requires two taps on the secondary CTA before firing onConfirm', () => {
     const onConfirm = jest.fn()
     const { getByTestId } = render(
-      <NeeruEmergencyCloseSheet position={pos} onConfirm={onConfirm} onCancel={jest.fn()} />
+      <NeeruEmergencyCloseSheet
+        forwardedRef={React.createRef()}
+        position={pos}
+        onConfirm={onConfirm}
+        onCancel={jest.fn()}
+      />
     )
     fireEvent.press(getByTestId('NeeruEmergencyCloseSheet.Secondary'))
     expect(onConfirm).not.toHaveBeenCalled()

--- a/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruPositionRow.test.tsx
@@ -47,8 +47,9 @@ describe('NeeruPositionRow', () => {
 
   it('renders amount and interest for backend positions', () => {
     const { getByText } = renderRow(pos)
-    expect(getByText(/10000/)).toBeTruthy()
-    expect(getByText(/82.5/)).toBeTruthy()
+    // formatValueToDisplay renders thousands separators + 2 decimals ("10,000.00").
+    expect(getByText(/10,000/)).toBeTruthy()
+    expect(getByText(/82\.50/)).toBeTruthy()
   })
 
   it('fires onManagePress when manage CTA tapped (non-optimistic)', () => {

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -5,8 +5,11 @@ import { fetchNeeruPositions } from 'src/earn/neeru/api'
 import { NEERU_CONTRACT_ADDRESS } from 'src/earn/neeru/constants'
 import { parseDepositEvent } from 'src/earn/neeru/eventParsing'
 import {
+  NEERU_ALREADY_CLOSED_ERROR,
   NEERU_LOW_POOL_ACTION,
   NEERU_LOW_POOL_ERROR,
+  NEERU_NOT_OWNER_ERROR,
+  NEERU_UNKNOWN_REVERT_ERROR,
   awaitOptimisticResolution,
   closeNeeruPositionSaga,
   emergencyCloseNeeruPositionSaga,
@@ -17,6 +20,7 @@ import {
 } from 'src/earn/neeru/saga'
 import {
   addOptimisticPosition,
+  clearEmergencyFallback,
   closePositionFailure,
   closePositionStart,
   closePositionSuccess,
@@ -24,8 +28,10 @@ import {
   fetchPositionsFailure,
   fetchPositionsStart,
   fetchPositionsSuccess,
+  initialState as neeruInitialState,
   markOptimisticPositionStale,
   removeOptimisticPosition,
+  setEmergencyFallback,
 } from 'src/earn/neeru/slice'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
 import { triggerShortcutRequest } from 'src/positions/saga'
@@ -98,6 +104,7 @@ describe('closeNeeruPositionSaga', () => {
   it('dispatches success on happy path', async () => {
     const fakeTxs = [{ to: '0x', data: '0x', value: '0', networkId: 'celo-mainnet' }]
     await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
@@ -149,6 +156,7 @@ describe('emergencyCloseNeeruPositionSaga', () => {
       emergencyCloseNeeruPositionSaga,
       emergencyCloseStart({ positionId: POSITION_ID })
     )
+      .withState({ neeru: neeruInitialState })
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
@@ -166,6 +174,7 @@ describe('emergencyCloseNeeruPositionSaga', () => {
       emergencyCloseNeeruPositionSaga,
       emergencyCloseStart({ positionId: POSITION_ID })
     )
+      .withState({ neeru: neeruInitialState })
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
@@ -410,24 +419,209 @@ describe('isLowPoolError', () => {
   })
 })
 
-describe('closeNeeruPositionSaga prod-shape low-pool revert', () => {
+describe('closeNeeruPositionSaga simulation-revert envelope consumer', () => {
   const WALLET = '0x' + 'a'.repeat(40)
   const POSITION_ID = '4242'
+  const FALLBACK_TX = {
+    to: '0x988af5977201a0e988f2c75ea952532f6beb5082',
+    data: '0xa64f127e',
+    value: '0',
+    networkId: 'celo-mainnet',
+  }
 
-  it('detects the low-pool selector in cause.data and dispatches the wallet-side action', async () => {
-    const prodShapeError = Object.assign(new Error('Execution reverted'), {
-      cause: { data: '0x2648b779' },
-    })
+  it('routes LOW_POOL selector to the wallet-side action + stashes the pre-built fallback', async () => {
     await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [
+          matchers.call.fn(triggerShortcutRequest),
+          {
+            transactions: [],
+            dataProps: {
+              simulationRevert: { selector: '0x2648b779', reason: 'INTEREST_POOL_LOW' },
+              fallback: { shortcutId: 'withdraw-amount-only', transactions: [FALLBACK_TX] },
+            },
+          },
+        ],
+      ])
+      .put(setEmergencyFallback({ positionId: POSITION_ID, transactions: [FALLBACK_TX] as any }))
+      .put({ type: NEERU_LOW_POOL_ACTION, payload: { positionId: POSITION_ID } })
+      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_LOW_POOL_ERROR }))
+      .run()
+  })
+
+  it('LOW_POOL without a pre-built fallback still dispatches the wallet-side action', async () => {
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [
+          matchers.call.fn(triggerShortcutRequest),
+          {
+            transactions: [],
+            dataProps: {
+              simulationRevert: { selector: '0x2648b779', reason: 'INTEREST_POOL_LOW' },
+            },
+          },
+        ],
+      ])
+      .put({ type: NEERU_LOW_POOL_ACTION, payload: { positionId: POSITION_ID } })
+      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_LOW_POOL_ERROR }))
+      .run()
+  })
+
+  it('routes ALREADY_CLOSED selector to its dedicated failure tag', async () => {
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [
+          matchers.call.fn(triggerShortcutRequest),
+          {
+            transactions: [],
+            dataProps: {
+              simulationRevert: { selector: '0x9acb7e52', reason: 'ALREADY_CLOSED' },
+            },
+          },
+        ],
+      ])
+      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_ALREADY_CLOSED_ERROR }))
+      .run()
+  })
+
+  it('routes NOT_OWNER selector to its dedicated failure tag', async () => {
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [
+          matchers.call.fn(triggerShortcutRequest),
+          {
+            transactions: [],
+            dataProps: {
+              simulationRevert: { selector: '0x30cd7471', reason: 'NOT_OWNER' },
+            },
+          },
+        ],
+      ])
+      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_NOT_OWNER_ERROR }))
+      .run()
+  })
+
+  it('routes an unknown selector to the generic revert tag', async () => {
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        [
+          matchers.call.fn(triggerShortcutRequest),
+          {
+            transactions: [],
+            dataProps: {
+              simulationRevert: { selector: '0xdeadbeef', reason: 'UNKNOWN' },
+            },
+          },
+        ],
+      ])
+      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_UNKNOWN_REVERT_ERROR }))
+      .run()
+  })
+
+  it('empty transactions with no dataProps at all is treated as unknown revert (defense against a stray empty response)', async () => {
+    await expectSaga(closeNeeruPositionSaga, closePositionStart({ positionId: POSITION_ID }))
+      .withState({ neeru: neeruInitialState })
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
         [matchers.select.like({ selector: feeCurrenciesSelector }), []],
         [matchers.call.fn(triggerShortcutRequest), { transactions: [] }],
-        [matchers.call.fn(prepareTransactions), Promise.reject(prodShapeError)],
       ])
-      .put({ type: NEERU_LOW_POOL_ACTION, payload: { positionId: POSITION_ID } })
-      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_LOW_POOL_ERROR }))
+      .put(closePositionFailure({ positionId: POSITION_ID, error: NEERU_UNKNOWN_REVERT_ERROR }))
       .run()
+  })
+})
+
+describe('emergencyCloseNeeruPositionSaga pre-built fallback consumption', () => {
+  const WALLET = '0x' + 'a'.repeat(40)
+  const POSITION_ID = '4243'
+  const STASHED_TX = {
+    to: '0x988af5977201a0e988f2c75ea952532f6beb5082' as `0x${string}`,
+    data: '0xa64f127e' as `0x${string}`,
+    value: '0',
+    networkId: 'celo-mainnet',
+    from: WALLET as `0x${string}`,
+    gas: '240000',
+    estimatedGasUse: '130000',
+  }
+
+  it('skips the triggerShortcut round-trip when a pre-built fallback exists in state', async () => {
+    const stateWithStash = {
+      ...neeruInitialState,
+      pendingEmergencyFallback: { [POSITION_ID]: [STASHED_TX] },
+    }
+    let triggerCalled = false
+    await expectSaga(
+      emergencyCloseNeeruPositionSaga,
+      emergencyCloseStart({ positionId: POSITION_ID })
+    )
+      .withState({ neeru: stateWithStash })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        {
+          call(effect, next) {
+            if (effect.fn === triggerShortcutRequest) {
+              triggerCalled = true
+            }
+            return next()
+          },
+        },
+        [matchers.call.fn(prepareTransactions), { type: 'possible', transactions: [] }],
+        [matchers.call.fn(sendPreparedTransactions), []],
+      ])
+      .put(clearEmergencyFallback({ positionId: POSITION_ID }))
+      .put(closePositionSuccess({ positionId: POSITION_ID }))
+      .run()
+    expect(triggerCalled).toBe(false)
+  })
+
+  it('falls back to a fresh triggerShortcut when no pre-built fallback is stashed', async () => {
+    let triggerCalled = false
+    await expectSaga(
+      emergencyCloseNeeruPositionSaga,
+      emergencyCloseStart({ positionId: POSITION_ID })
+    )
+      .withState({ neeru: neeruInitialState })
+      .provide([
+        [matchers.select(walletAddressSelector), WALLET],
+        [matchers.select(hooksApiUrlSelector), 'https://x.test/hooks-api'],
+        [matchers.select.like({ selector: feeCurrenciesSelector }), []],
+        {
+          call(effect, next) {
+            if (effect.fn === triggerShortcutRequest) {
+              triggerCalled = true
+              return { transactions: [STASHED_TX] }
+            }
+            return next()
+          },
+        },
+        [matchers.call.fn(prepareTransactions), { type: 'possible', transactions: [] }],
+        [matchers.call.fn(sendPreparedTransactions), []],
+      ])
+      .put(closePositionSuccess({ positionId: POSITION_ID }))
+      .run()
+    expect(triggerCalled).toBe(true)
   })
 })

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -4,13 +4,16 @@ import { fetchNeeruPositions } from 'src/earn/neeru/api'
 import {
   NEERU_CATEGORY_LABEL_KEYS,
   NEERU_CONTRACT_ADDRESS,
+  NEERU_ERR_ALREADY_CLOSED_SELECTOR,
   NEERU_ERR_INTEREST_POOL_LOW_SELECTOR,
+  NEERU_ERR_NOT_OWNER_SELECTOR,
   NeeruCategoryId,
 } from 'src/earn/neeru/constants'
 import { parseDepositEvent } from 'src/earn/neeru/eventParsing'
 import { computePayout, monthlyPercentFromRateValue } from 'src/earn/neeru/rateConversion'
 import {
   addOptimisticPosition,
+  clearEmergencyFallback,
   closePositionFailure,
   closePositionStart,
   closePositionSuccess,
@@ -20,6 +23,7 @@ import {
   fetchPositionsSuccess,
   markOptimisticPositionStale,
   removeOptimisticPosition,
+  setEmergencyFallback,
 } from 'src/earn/neeru/slice'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
 import { hooksApiUrlSelector } from 'src/positions/selectors'
@@ -31,20 +35,71 @@ import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
-import { PreparedTransactionsResult, prepareTransactions } from 'src/viem/prepareTransactions'
+import { publicClient } from 'src/viem'
+import {
+  PreparedTransactionsResult,
+  prepareTransactions,
+  TransactionRequest,
+} from 'src/viem/prepareTransactions'
 import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 import { sendPreparedTransactions } from 'src/viem/saga'
-import networkConfig from 'src/web3/networkConfig'
+import { vibrateSuccess } from 'src/styles/hapticFeedback'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import networkConfig, { COPM_TOKEN_ID_MAINNET, networkIdToNetwork } from 'src/web3/networkConfig'
+import {
+  neeruEmergencyFallbackByIdSelector,
+  neeruPositionsSelector,
+} from 'src/earn/neeru/selectors'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { call, delay, put, race, select, spawn, takeLeading } from 'typed-redux-saga'
 
 const TAG = 'earn/neeru/saga'
 
-// Wallet-internal signals for the low-interest-pool code path. Kept opaque
-// (no contract-error-name mirror) so the wallet repo does not identify the
-// underlying revert reason in tracked source.
+// Wallet-internal signals for withdraw revert paths. Kept opaque (no
+// contract-error-name mirror) so the wallet repo does not identify the
+// underlying revert reasons in tracked source. Matched by selector against
+// what the backend simulation returns or what the on-chain replay surfaces.
 export const NEERU_LOW_POOL_ACTION = 'neeru/lowPool' as const
 export const NEERU_LOW_POOL_ERROR = 'neeru:low-pool' as const
+export const NEERU_ALREADY_CLOSED_ERROR = 'neeru:already-closed' as const
+export const NEERU_NOT_OWNER_ERROR = 'neeru:not-owner' as const
+export const NEERU_UNKNOWN_REVERT_ERROR = 'neeru:unknown-revert' as const
+
+// Envelope handed back by the hooks-api triggerShortcut. The
+// simulationRevert + fallback keys land in `dataProps` when the backend
+// pre-simulated the withdraw and it would revert; the wallet consumes them
+// to short-circuit the sign flow without paying gas.
+interface SimulationRevertInfo {
+  selector?: string
+  reason?: string
+}
+interface FallbackInfo {
+  shortcutId?: string
+  transactions?: RawShortcutTransaction[]
+}
+interface TriggerShortcutResponseData {
+  transactions: RawShortcutTransaction[]
+  dataProps?: {
+    simulationRevert?: SimulationRevertInfo
+    fallback?: FallbackInfo
+  }
+}
+
+// Match the raw selector on the simulationRevert envelope against the three
+// known 4-byte error selectors from the vault contract. Returns an opaque
+// tag so callers can branch UX without leaking the contract error name.
+export function classifySimulationRevert(
+  simulationRevert: SimulationRevertInfo | undefined
+): 'low_pool' | 'already_closed' | 'not_owner' | 'unknown' | null {
+  if (!simulationRevert) return null
+  const selector = (simulationRevert.selector ?? '').toLowerCase()
+  if (!selector) return 'unknown'
+  if (selector === NEERU_ERR_INTEREST_POOL_LOW_SELECTOR.toLowerCase()) return 'low_pool'
+  if (selector === NEERU_ERR_ALREADY_CLOSED_SELECTOR.toLowerCase()) return 'already_closed'
+  if (selector === NEERU_ERR_NOT_OWNER_SELECTOR.toLowerCase()) return 'not_owner'
+  return 'unknown'
+}
 
 const NEERU_OPTIMISTIC_POLL_INTERVAL_MS = 15_000
 const NEERU_OPTIMISTIC_TIMEOUT_MS = 5 * 60_000
@@ -71,6 +126,75 @@ export function isLowPoolError(error: unknown): boolean {
     if (typeof c === 'string' && c.toLowerCase().includes(selector)) return true
   }
   return false
+}
+
+// Wait for the on-chain receipts of every tx we just sent. If any one reverted,
+// re-run it as an eth_call at the reverted block to surface the custom-error
+// selector (viem attaches it to cause.data / cause.details), then throw an
+// Error whose shape the isLowPoolError matcher above understands.
+export function* enforceReceiptsOrThrow({
+  txHashes,
+  baseTransactions,
+  walletAddress,
+  networkId,
+}: {
+  txHashes: `0x${string}`[]
+  baseTransactions: TransactionRequest[]
+  walletAddress: string
+  networkId: NetworkId
+}): Generator<any, void, any> {
+  const network = networkIdToNetwork[networkId]
+  const client = publicClient[network]
+  for (let i = 0; i < txHashes.length; i++) {
+    const receipt: TransactionReceipt = yield* call([client, 'waitForTransactionReceipt'], {
+      hash: txHashes[i],
+    })
+    if (receipt.status === 'success') continue
+    // Reverted: replay against `latest` (not the receipt block, Forno frequently
+    // rejects historical block state with "block is out of range") to extract
+    // the revert data. The Neeru contract state that drove the revert (low
+    // interest pool) persists across blocks, so re-simulating now reproduces
+    // the same custom error and surfaces the selector on cause.data.
+    let revertData: string | undefined
+    try {
+      const base = baseTransactions[i] as { to?: `0x${string}`; data?: `0x${string}` }
+      yield* call([client, 'call'], {
+        account: walletAddress as `0x${string}`,
+        to: base.to,
+        data: base.data,
+      })
+    } catch (callError) {
+      // viem attaches revert data under different keys depending on how the
+      // node returned it. Walk a few common shapes.
+      const anyErr = callError as {
+        cause?: { data?: unknown; details?: unknown; cause?: { data?: unknown } }
+        message?: string
+      }
+      const candidates: unknown[] = [
+        anyErr?.cause?.data,
+        anyErr?.cause?.cause?.data,
+        anyErr?.cause?.details,
+        anyErr?.message,
+      ]
+      for (const c of candidates) {
+        if (typeof c !== 'string') continue
+        // Prefer a bare 4-byte selector if present, else keep the full string
+        // so the LOW_POOL matcher below (substring match) still works.
+        const selectorMatch = c.match(/0x[0-9a-fA-F]{8}(?![0-9a-fA-F])/)
+        if (selectorMatch) {
+          revertData = selectorMatch[0]
+          break
+        }
+        if (!revertData) revertData = c
+      }
+    }
+    const err = new Error(`tx reverted on-chain (${revertData ?? 'no revert data'})`)
+    ;(err as { cause?: { data?: string; details?: string } }).cause = {
+      data: revertData,
+      details: revertData,
+    }
+    throw err
+  }
 }
 
 export function* fetchNeeruPositionsSaga(_action: ReturnType<typeof fetchPositionsStart>) {
@@ -117,33 +241,88 @@ export function* closeNeeruPositionSaga(action: ReturnType<typeof closePositionS
   )
 
   try {
-    const response: { transactions: RawShortcutTransaction[] } = yield* call(
-      triggerShortcutRequest,
-      hooksApiUrl,
-      {
-        address: walletAddress,
-        appId: 'neeru-vaults',
-        networkId: NetworkId['celo-mainnet'],
-        shortcutId: 'withdraw',
-        positionId,
+    const response: TriggerShortcutResponseData = yield* call(triggerShortcutRequest, hooksApiUrl, {
+      address: walletAddress,
+      appId: 'neeru-vaults',
+      networkId: NetworkId['celo-mainnet'],
+      shortcutId: 'withdraw',
+      positionId,
+    })
+    // Backend pre-simulates the withdraw and, when it would revert, returns
+    // `transactions: []` plus `dataProps.simulationRevert` (and optionally a
+    // pre-built amount-only fallback the wallet can use without a second
+    // triggerShortcut round-trip). Short-circuit before signing anything.
+    if (response.transactions.length === 0) {
+      const category = classifySimulationRevert(response.dataProps?.simulationRevert)
+      if (category === 'low_pool') {
+        const fallbackTxs = response.dataProps?.fallback?.transactions ?? []
+        if (fallbackTxs.length > 0) {
+          yield* put(setEmergencyFallback({ positionId, transactions: fallbackTxs }))
+        }
+        yield* put({ type: NEERU_LOW_POOL_ACTION, payload: { positionId } })
+        yield* put(closePositionFailure({ positionId, error: NEERU_LOW_POOL_ERROR }))
+        return
       }
-    )
+      if (category === 'already_closed') {
+        yield* put(closePositionFailure({ positionId, error: NEERU_ALREADY_CLOSED_ERROR }))
+        return
+      }
+      if (category === 'not_owner') {
+        yield* put(closePositionFailure({ positionId, error: NEERU_NOT_OWNER_ERROR }))
+        return
+      }
+      // Unknown selector or no simulationRevert at all: refuse to succeed
+      // silently. This also protects wallets against a stray empty-transactions
+      // response with no explanation.
+      yield* put(closePositionFailure({ positionId, error: NEERU_UNKNOWN_REVERT_ERROR }))
+      return
+    }
+    const baseTransactions = rawShortcutTransactionsToTransactionRequests(response.transactions)
     const prepared: PreparedTransactionsResult = yield* call(prepareTransactions, {
       feeCurrencies,
-      baseTransactions: rawShortcutTransactionsToTransactionRequests(response.transactions),
+      baseTransactions,
       isGasSubsidized: false,
       origin: 'earn-withdraw' as const,
     })
     if (prepared.type !== 'possible') {
       throw new Error(`Cannot prepare close tx: ${prepared.type}`)
     }
-    yield* call(
+    // sendPreparedTransactions requires one standby-tx creator per prepared
+    // tx. Shortcut-driven flows don't have the metadata to build meaningful
+    // standby entries, so return null per tx (same pattern as positions/saga).
+    const serialized = getSerializablePreparedTransactions(prepared.transactions)
+    const txHashes: `0x${string}`[] = yield* call(
       sendPreparedTransactions,
-      getSerializablePreparedTransactions(prepared.transactions),
+      serialized,
       NetworkId['celo-mainnet'],
-      []
+      serialized.map(() => () => null)
     )
+    // sendPreparedTransactions only confirms the tx made it to the mempool; if
+    // the on-chain execution reverts, the promise still resolves. Wait for the
+    // receipt and re-run as eth_call to surface the revert selector so the
+    // catch below can route into the emergency (amount-only) flow.
+    yield* enforceReceiptsOrThrow({
+      txHashes,
+      baseTransactions,
+      walletAddress,
+      networkId: NetworkId['celo-mainnet'],
+    })
+    const positions = yield* select(neeruPositionsSelector)
+    const closed = positions.find((p) => p.positionId === positionId)
+    const withdrawAmount = closed?.currentPayoutIfClosed.total ?? '0'
     yield* put(closePositionSuccess({ positionId }))
+    yield* put(fetchPositionsStart())
+    vibrateSuccess()
+    navigate(Screens.TransactionSuccessScreen, {
+      fromTokenId: COPM_TOKEN_ID_MAINNET,
+      toTokenId: COPM_TOKEN_ID_MAINNET,
+      fromAmount: withdrawAmount,
+      toAmount: withdrawAmount,
+      transactionHash: txHashes[txHashes.length - 1],
+      networkId: NetworkId['celo-mainnet'],
+      type: 'earnWithdraw' as const,
+      poolName: 'Neeru Vaults',
+    })
   } catch (e) {
     const error = ensureError(e)
     if (isLowPoolError(error)) {
@@ -178,33 +357,74 @@ export function* emergencyCloseNeeruPositionSaga(action: ReturnType<typeof emerg
   )
 
   try {
-    const response: { transactions: RawShortcutTransaction[] } = yield* call(
-      triggerShortcutRequest,
-      hooksApiUrl,
-      {
-        address: walletAddress,
-        appId: 'neeru-vaults',
-        networkId: NetworkId['celo-mainnet'],
-        shortcutId: 'withdraw-amount-only',
-        positionId,
-      }
-    )
+    // If the close saga already received a pre-built amount-only fallback
+    // (backend simulation-first path), use it directly instead of paying
+    // another triggerShortcut round-trip. Fall back to a fresh trigger call
+    // when the emergency was reached via the wallet-side receipt-check
+    // safety net, which does not have the pre-built calldata.
+    const stashedFallback = yield* select(neeruEmergencyFallbackByIdSelector, positionId)
+    let rawTransactions: RawShortcutTransaction[]
+    if (stashedFallback && stashedFallback.length > 0) {
+      rawTransactions = stashedFallback
+      yield* put(clearEmergencyFallback({ positionId }))
+    } else {
+      const response: TriggerShortcutResponseData = yield* call(
+        triggerShortcutRequest,
+        hooksApiUrl,
+        {
+          address: walletAddress,
+          appId: 'neeru-vaults',
+          networkId: NetworkId['celo-mainnet'],
+          shortcutId: 'withdraw-amount-only',
+          positionId,
+        }
+      )
+      rawTransactions = response.transactions
+    }
+    const baseTransactions = rawShortcutTransactionsToTransactionRequests(rawTransactions)
     const prepared: PreparedTransactionsResult = yield* call(prepareTransactions, {
       feeCurrencies,
-      baseTransactions: rawShortcutTransactionsToTransactionRequests(response.transactions),
+      baseTransactions,
       isGasSubsidized: false,
       origin: 'earn-withdraw' as const,
     })
     if (prepared.type !== 'possible') {
       throw new Error(`Cannot prepare emergency tx: ${prepared.type}`)
     }
-    yield* call(
+    // sendPreparedTransactions requires one standby-tx creator per prepared
+    // tx. Shortcut-driven flows don't have the metadata to build meaningful
+    // standby entries, so return null per tx (same pattern as positions/saga).
+    const serialized = getSerializablePreparedTransactions(prepared.transactions)
+    const txHashes: `0x${string}`[] = yield* call(
       sendPreparedTransactions,
-      getSerializablePreparedTransactions(prepared.transactions),
+      serialized,
       NetworkId['celo-mainnet'],
-      []
+      serialized.map(() => () => null)
     )
+    yield* enforceReceiptsOrThrow({
+      txHashes,
+      baseTransactions,
+      walletAddress,
+      networkId: NetworkId['celo-mainnet'],
+    })
+    const positions = yield* select(neeruPositionsSelector)
+    const closed = positions.find((p) => p.positionId === positionId)
+    // Emergency returns only the principal (no interest paid because the pool
+    // was low). Match the amount the user just saw in the sheet.
+    const returnedAmount = closed?.amount ?? '0'
     yield* put(closePositionSuccess({ positionId }))
+    yield* put(fetchPositionsStart())
+    vibrateSuccess()
+    navigate(Screens.TransactionSuccessScreen, {
+      fromTokenId: COPM_TOKEN_ID_MAINNET,
+      toTokenId: COPM_TOKEN_ID_MAINNET,
+      fromAmount: returnedAmount,
+      toAmount: returnedAmount,
+      transactionHash: txHashes[txHashes.length - 1],
+      networkId: NetworkId['celo-mainnet'],
+      type: 'earnWithdraw' as const,
+      poolName: 'Neeru Vaults',
+    })
   } catch (e) {
     const error = ensureError(e)
     Logger.error(TAG, 'emergency close failed', error)

--- a/src/earn/neeru/selectors.ts
+++ b/src/earn/neeru/selectors.ts
@@ -11,6 +11,9 @@ export const neeruClosingPositionIdSelector = (state: RootState) =>
   neeruSlice(state).closingPositionId
 export const neeruLastErrorSelector = (state: RootState) => neeruSlice(state).lastError
 
+export const neeruEmergencyFallbackByIdSelector = (state: RootState, positionId: string) =>
+  neeruSlice(state).pendingEmergencyFallback[positionId]
+
 const neeruBackendPositionsSelector = (state: RootState) => neeruSlice(state).positions
 const neeruOptimisticPositionsSelector = (state: RootState) => neeruSlice(state).optimisticPositions
 

--- a/src/earn/neeru/slice.ts
+++ b/src/earn/neeru/slice.ts
@@ -1,4 +1,5 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { RawShortcutTransaction } from 'src/positions/slice'
 import { REHYDRATE, RehydrateAction, getRehydratePayload } from 'src/redux/persist-helper'
 import { NeeruCloseStatus, NeeruFetchStatus, NeeruIndividualPosition } from 'src/earn/neeru/types'
 
@@ -11,6 +12,11 @@ export interface NeeruState {
   closeStatus: NeeruCloseStatus
   closingPositionId: string | null
   lastError: string | null
+  // Pre-built fallback calldata handed back by the hooks-api when the withdraw
+  // simulation reverts with LOW_POOL. Keyed by positionId. The emergency saga
+  // consumes it once and clears it, so the amount-only sheet flips without a
+  // second triggerShortcut round-trip. Transient (not persisted).
+  pendingEmergencyFallback: Record<string, RawShortcutTransaction[]>
 }
 
 export const initialState: NeeruState = {
@@ -22,6 +28,7 @@ export const initialState: NeeruState = {
   closeStatus: 'idle',
   closingPositionId: null,
   lastError: null,
+  pendingEmergencyFallback: {},
 }
 
 const slice = createSlice({
@@ -96,15 +103,27 @@ const slice = createSlice({
     clearOptimisticPositions: (state) => {
       state.optimisticPositions = []
     },
+    setEmergencyFallback: (
+      state,
+      action: PayloadAction<{ positionId: string; transactions: RawShortcutTransaction[] }>
+    ) => {
+      state.pendingEmergencyFallback[action.payload.positionId] = action.payload.transactions
+    },
+    clearEmergencyFallback: (state, action: PayloadAction<{ positionId: string }>) => {
+      delete state.pendingEmergencyFallback[action.payload.positionId]
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
       ...state,
       ...getRehydratePayload(action, 'neeru'),
-      // Always reset transient optimistic state on app start. The
-      // backend-truth `positions` array stays as-is from disk so the
-      // pre-fetch UI has something to show.
+      // Always reset transient state on app start. The backend-truth
+      // `positions` array stays as-is from disk so the pre-fetch UI has
+      // something to show. Optimistic entries and the pre-built emergency
+      // fallback are both short-lived request/response state that would
+      // reference stale calldata if kept across sessions.
       optimisticPositions: [],
+      pendingEmergencyFallback: {},
     }))
   },
 })
@@ -121,6 +140,8 @@ export const {
   removeOptimisticPosition,
   markOptimisticPositionStale,
   clearOptimisticPositions,
+  setEmergencyFallback,
+  clearEmergencyFallback,
 } = slice.actions
 
 export default slice.reducer

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -342,6 +342,7 @@ describe('store state', () => {
           "lastSyncedAt": null,
           "lastSyncedBlock": null,
           "optimisticPositions": [],
+          "pendingEmergencyFallback": {},
           "positions": [],
         },
         "networkInfo": {

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2534,6 +2534,9 @@
                     },
                     "type": "array"
                 },
+                "pendingEmergencyFallback": {
+                    "$ref": "#/definitions/Record<string,RawShortcutTransaction[]>"
+                },
                 "positions": {
                     "items": {
                         "$ref": "#/definitions/NeeruIndividualPosition"
@@ -2549,6 +2552,7 @@
                 "lastSyncedAt",
                 "lastSyncedBlock",
                 "optimisticPositions",
+                "pendingEmergencyFallback",
                 "positions"
             ],
             "type": "object"
@@ -4135,6 +4139,10 @@
             "type": "object"
         },
         "Record<string,InFlightDescriptor>": {
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "Record<string,RawShortcutTransaction[]>": {
             "additionalProperties": false,
             "type": "object"
         },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3763,6 +3763,7 @@ export const v251Schema = {
     closeStatus: 'idle',
     closingPositionId: null,
     lastError: null,
+    pendingEmergencyFallback: {},
   },
   _persist: {
     ...v250Schema._persist,


### PR DESCRIPTION
## Summary

Wallet-side consumer for the Neeru simulation-first envelope backend shipped in their PR #141 (Railway `6aae44f4`). Companion for the incident closed on 2026-07-22 where a Neeru deposit revert was surfaced as a successful movement in the feed (fixed by #270 already merged).

### 1. Backend envelope consumer (commit 1)

Backend now pre-simulates the withdraw. When it would revert, the response is `transactions: []` + `dataProps.simulationRevert.{selector, reason}`. For LOW_POOL the response also carries `dataProps.fallback.transactions` (pre-built amount-only calldata).

- `slice.ts` gains a transient `pendingEmergencyFallback: Record<positionId, RawShortcutTransaction[]>` cleared on rehydrate.
- `saga.ts` short-circuits when `response.transactions.length === 0`, classifies the selector via `classifySimulationRevert(...)` (returns `low_pool` | `already_closed` | `not_owner` | `unknown` | null, all opaque tags matched against `constants.ts`), stashes the fallback and dispatches the wallet-side low-pool action.
- `emergencyCloseNeeruPositionSaga` consumes the stash and skips the second triggerShortcut round-trip when present. Falls back to a fresh trigger for the wallet-side receipt-check safety net path (no pre-built calldata there).
- `test/schemas.ts` mirrors the new field.
- 7 new saga tests cover LOW_POOL with + without fallback, ALREADY_CLOSED, NOT_OWNER, UNKNOWN selector, empty response with no dataProps, plus emergency-saga skip-trigger and fall-through-to-trigger.

Receipt-check + `enforceReceiptsOrThrow` on-chain replay remains as safety net for races between the simulation and the actual send.

### 2. Sheet refactor + proactive amount-only path (commit 2)

- Neeru sheets migrate to `@gorhom/bottom-sheet`'s `BottomSheetModal` directly, with `BottomSheetBackdrop` (dim + dismiss on tap) and dynamic sizing.
- All amount strings across sheets, PositionRow, and PoolCard go through `formatValueToDisplay` (thousands separator + 2 decimals).
- Root testIDs land on the inner sheet Views so the detail screen tests can assert visibility around Manage / dismiss transitions.
- New `NeeruCloseSheet.AmountOnly` button (below the primary Confirm CTA): proactive "withdraw only my deposit" path. Dismisses the close sheet and presents the emergency sheet for the same position, so a user who already knows the pool is low can skip the doomed full-withdraw attempt and its gas cost. New `amountOnlyCta` translation key in en + es-419.
- PoolCard COPm balance fix: when `depositTokenId === COPM_TOKEN_ID_MAINNET` and `priceUsd === '0'` (Mento stablecoins hydrate with a placeholder), skip the USD -> local conversion (it collapses to 0) and render the token balance directly with the local currency symbol.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn lint` clean over all of `src/`
- [x] `yarn jest src/earn/neeru/` -> 86/86 pass across 12 suites
- [x] `yarn jest src/earn/ src/positions/ src/viem/` -> 383/383 pass
- [ ] Post-merge: repro the failing address from `tasks/backend-neeru-withdraw-simulate-before-return.md` in-app once the pool is again LOW; confirm the emergency sheet opens instantly with `transactions: []` in the trigger response and no gas is spent.
- [ ] Post-merge: proactive AmountOnly path from a healthy position (verify the transition close -> emergency + subsequent confirm).

Zero backend action pending. Backend spec at `tasks/backend-neeru-withdraw-simulate-before-return.md` is already aligned with what this PR consumes.