### PR TITLE
fix(earn/neeru): correct Deposit topic0 + align data schema with on-chain layout

### DIFF
--- a/src/earn/neeru/__tests__/eventParsing.test.ts
+++ b/src/earn/neeru/__tests__/eventParsing.test.ts
@@ -8,13 +8,14 @@ const POSITION_ID = BigInt(42)
 const CATEGORY = 1
 const AMOUNT = BigInt('10000000000000000000000') // 10000 * 1e18
 const RATE_VALUE = BigInt('1000331300000000000000000000')
+const TRAILING_SLOT = BigInt('1723507200') // ignored by the parser but must be present in data
 
 type Log = TransactionReceipt['logs'][number]
 
 function buildDepositLog(): Log {
   const data = encodeAbiParameters(
-    [{ type: 'uint8' }, { type: 'uint256' }, { type: 'uint256' }],
-    [CATEGORY, AMOUNT, RATE_VALUE]
+    [{ type: 'uint8' }, { type: 'uint256' }, { type: 'uint256' }, { type: 'uint256' }],
+    [CATEGORY, AMOUNT, RATE_VALUE, TRAILING_SLOT]
   )
   return {
     address: CONTRACT,

--- a/src/earn/neeru/abi.ts
+++ b/src/earn/neeru/abi.ts
@@ -11,4 +11,5 @@ export const DEPOSIT_EVENT_DATA_SCHEMA = [
   { type: 'uint8' },
   { type: 'uint256' },
   { type: 'uint256' },
+  { type: 'uint256' },
 ] as const

--- a/src/earn/neeru/constants.ts
+++ b/src/earn/neeru/constants.ts
@@ -10,7 +10,7 @@ export const NEERU_APP_ID = 'neeru-vaults'
 export const NEERU_CONTRACT_ADDRESS = (Config.NEERU_CONTRACT_ADDRESS ??
   '0x988af5977201a0e988f2c75ea952532f6beb5082') as `0x${string}`
 export const NEERU_DEPOSIT_TOPIC0 = (Config.NEERU_DEPOSIT_TOPIC0 ??
-  '0x12ef563408f10ef4a1dde37b59a2538dcc75957c7e154bf71deea27089689653') as `0x${string}`
+  '0x8835c22a0c751188de86681e15904223c054bedd5c68ec8858945b7831290273') as `0x${string}`
 
 // 4-byte revert selectors, matched against viem's cause.data / details when
 // a write reverts. Backend indexer emits these; wallet only needs to detect

--- a/src/earn/neeru/eventParsing.ts
+++ b/src/earn/neeru/eventParsing.ts
@@ -31,12 +31,12 @@ export function parseDepositEvent(
     const [categoryRaw, amountRaw, rateRaw] = decodeAbiParameters(
       DEPOSIT_EVENT_DATA_SCHEMA,
       log.data
-    )
+    ) as [number, bigint, bigint, bigint]
     return {
       contractPositionId: hexToBigInt(log.topics[2]).toString(),
-      amount: (amountRaw as bigint).toString(),
-      category: Number(categoryRaw as number),
-      rateValue: (rateRaw as bigint).toString(),
+      amount: amountRaw.toString(),
+      category: Number(categoryRaw),
+      rateValue: rateRaw.toString(),
     }
   } catch {
     return null


### PR DESCRIPTION
## Summary

Two related bugs that shipped together in the 2026-07-12 zero-exposure sweep and stopped `parseDepositEvent` from ever succeeding. Backend flagged both after cross-checking their meta endpoint against the wallet source. Verified against `GET /api/meta/contracts/neeru` on `tucop-backend-production.up.railway.app` and against a real Deposit receipt on Celo mainnet.

**Bug 1 - Deposit `topic0` default was wrong.** `constants.ts` shipped `0x12ef563408f10ef4a1dde37b59a2538dcc75957c7e154bf71deea27089689653`; the real event hash is `0x8835c22a0c751188de86681e15904223c054bedd5c68ec8858945b7831290273`. Log filter never matched, parser always returned null, and the wallet fell back to backend polling for every deposit.

**Bug 2 - Data schema had 3 slots instead of 4.** Backend meta declares the non-indexed data as `[uint8, uint256, uint256, uint256]`. Local schema only had the first 3, so `decodeAbiParameters` threw on every real receipt (viem is strict on slot count) and the parser fell into the catch and returned null anyway.

Both bugs went unnoticed for two weeks because the backend indexer polling masks the missing optimistic-UI path.

## Changes

- `src/earn/neeru/constants.ts`: replace the incorrect `NEERU_DEPOSIT_TOPIC0` default. `Config.NEERU_DEPOSIT_TOPIC0` override unchanged.
- `src/earn/neeru/abi.ts`: extend `DEPOSIT_EVENT_DATA_SCHEMA` with the trailing `uint256`.
- `src/earn/neeru/eventParsing.ts`: destructure the first three named slots and cast to the full 4-tuple explicitly. The 4th slot is intentionally discarded (wallet does not yet use it).
- `src/earn/neeru/__tests__/eventParsing.test.ts`: fixture now encodes 4 slots so the happy-path assertion exercises the corrected layout.

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn lint` clean on all 4 touched files
- [x] `yarn jest src/earn/neeru/__tests__/eventParsing.test.ts` -> 4/4 pass
- [x] `yarn jest src/earn/neeru` -> 86/86 pass (all suites in the folder, incl. saga + slice)
- [ ] CI Mobile job green