### PR TITLE
feat(earn/neeru): neeruConfig slice + boot fetch of /meta and /catalogue

### DIFF
--- a/src/earn/neeru/__tests__/configSaga.test.ts
+++ b/src/earn/neeru/__tests__/configSaga.test.ts
@@ -1,0 +1,62 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { fetchNeeruCatalogue, fetchNeeruMeta } from 'src/earn/neeru/api'
+import { fetchNeeruCatalogueSaga, fetchNeeruMetaSaga } from 'src/earn/neeru/configSaga'
+import {
+  fetchCatalogueFailure,
+  fetchCatalogueSuccess,
+  fetchMetaFailure,
+  fetchMetaSuccess,
+} from 'src/earn/neeru/configSlice'
+import { NEERU_META_HARDCODED_FALLBACK } from 'src/earn/neeru/configSelectors'
+import { NeeruCatalogue } from 'src/earn/neeru/types'
+
+const META = { ...NEERU_META_HARDCODED_FALLBACK, version: 'v2-2026-08-01' }
+const CATALOGUE: NeeruCatalogue = {
+  categories: [
+    { id: 0, secs: '0', rateRay: '1', monthlyRatePercentage: 0.8, annualEffectivePercentage: 10 },
+  ],
+  token: { address: '0x8a567e2aE79CA692Bd748aB832081C45de4041eA', decimals: 18, symbol: 'COPm' },
+  fetchedAt: '2026-07-25T00:00:00.000Z',
+}
+
+describe('fetchNeeruMetaSaga', () => {
+  it('dispatches fetchMetaSuccess on backend OK', async () => {
+    const dispatched: any[] = []
+    await expectSaga(fetchNeeruMetaSaga)
+      .provide([[matchers.call.fn(fetchNeeruMeta), META]])
+      .dispatch({ type: 'noop' })
+      .run()
+      .then((result) => {
+        dispatched.push(...result.allEffects)
+      })
+    // Verify the dispatch via a fresh expectSaga that also asserts the action.
+    return expectSaga(fetchNeeruMetaSaga)
+      .provide([[matchers.call.fn(fetchNeeruMeta), META]])
+      .put.actionType(fetchMetaSuccess.type)
+      .run()
+  })
+
+  it('dispatches fetchMetaFailure on backend error', async () => {
+    return expectSaga(fetchNeeruMetaSaga)
+      .provide([[matchers.call.fn(fetchNeeruMeta), Promise.reject(new Error('timeout'))]])
+      .put(fetchMetaFailure({ error: 'timeout' }))
+      .run()
+  })
+})
+
+describe('fetchNeeruCatalogueSaga', () => {
+  it('dispatches fetchCatalogueSuccess on backend OK', async () => {
+    return expectSaga(fetchNeeruCatalogueSaga)
+      .provide([[matchers.call.fn(fetchNeeruCatalogue), CATALOGUE]])
+      .put(fetchCatalogueSuccess({ catalogue: CATALOGUE }))
+      .run()
+  })
+
+  it('dispatches fetchCatalogueFailure on backend error', async () => {
+    return expectSaga(fetchNeeruCatalogueSaga)
+      .provide([[matchers.call.fn(fetchNeeruCatalogue), Promise.reject(new Error('502'))]])
+      .put(fetchCatalogueFailure({ error: '502' }))
+      .run()
+  })
+})

--- a/src/earn/neeru/__tests__/configSlice.test.ts
+++ b/src/earn/neeru/__tests__/configSlice.test.ts
@@ -1,0 +1,198 @@
+import reducer, {
+  fetchCatalogueFailure,
+  fetchCatalogueSuccess,
+  fetchMetaFailure,
+  fetchMetaStart,
+  fetchMetaSuccess,
+  initialState,
+  NEERU_META_CACHE_FRESH_MS,
+} from 'src/earn/neeru/configSlice'
+import {
+  NEERU_META_HARDCODED_FALLBACK,
+  neeruCatalogueSelector,
+  neeruMetaSelector,
+} from 'src/earn/neeru/configSelectors'
+import { NeeruCatalogue, NeeruMeta } from 'src/earn/neeru/types'
+import { RootState } from 'src/redux/reducers'
+import { REHYDRATE } from 'src/redux/persist-helper'
+
+const META: NeeruMeta = {
+  ...NEERU_META_HARDCODED_FALLBACK,
+  version: 'v2-2026-08-01',
+}
+
+const CATALOGUE: NeeruCatalogue = {
+  categories: [
+    { id: 0, secs: '0', rateRay: '1', monthlyRatePercentage: 0.8, annualEffectivePercentage: 10 },
+  ],
+  token: { address: '0x8a567e2aE79CA692Bd748aB832081C45de4041eA', decimals: 18, symbol: 'COPm' },
+  fetchedAt: '2026-07-25T00:00:00.000Z',
+}
+
+const buildState = (overrides: Partial<typeof initialState> = {}) =>
+  ({ neeruConfig: { ...initialState, ...overrides } }) as unknown as RootState
+
+describe('neeruConfig slice', () => {
+  it('marks meta loading on fetchMetaStart', () => {
+    const state = reducer(initialState, fetchMetaStart())
+    expect(state.metaFetchStatus).toBe('loading')
+    expect(state.metaLastError).toBeNull()
+  })
+
+  it('stores meta + backend source on fetchMetaSuccess', () => {
+    const state = reducer(
+      initialState,
+      fetchMetaSuccess({ meta: META, fetchedAt: '2026-07-25T00:00:00.000Z' })
+    )
+    expect(state.meta).toEqual(META)
+    expect(state.metaSource).toBe('backend')
+    expect(state.metaFetchedAt).toBe('2026-07-25T00:00:00.000Z')
+    expect(state.metaFetchStatus).toBe('success')
+  })
+
+  it('preserves prior meta on fetchMetaFailure', () => {
+    const prior = reducer(
+      initialState,
+      fetchMetaSuccess({ meta: META, fetchedAt: '2026-07-25T00:00:00.000Z' })
+    )
+    const state = reducer(prior, fetchMetaFailure({ error: 'network down' }))
+    expect(state.meta).toEqual(META)
+    expect(state.metaSource).toBe('backend')
+    expect(state.metaFetchStatus).toBe('error')
+    expect(state.metaLastError).toBe('network down')
+  })
+
+  it('stores catalogue on fetchCatalogueSuccess', () => {
+    const state = reducer(initialState, fetchCatalogueSuccess({ catalogue: CATALOGUE }))
+    expect(state.catalogue).toEqual(CATALOGUE)
+    expect(state.catalogueFetchStatus).toBe('success')
+  })
+
+  it('does not preserve catalogue on fetchCatalogueFailure (no fallback)', () => {
+    const prior = reducer(initialState, fetchCatalogueSuccess({ catalogue: CATALOGUE }))
+    const state = reducer(prior, fetchCatalogueFailure({ error: 'timeout' }))
+    // Catalogue value stays until the next success, but consumers read the
+    // status: hasError=true -> renders skeleton, not stale rates.
+    expect(state.catalogueFetchStatus).toBe('error')
+    expect(state.catalogueLastError).toBe('timeout')
+  })
+
+  it('drops source to cache and resets runtime state on rehydrate with meta', () => {
+    const rehydrated = reducer(initialState, {
+      type: REHYDRATE,
+      key: 'root',
+      payload: {
+        neeruConfig: {
+          meta: META,
+          metaSource: 'backend',
+          metaFetchedAt: '2026-07-24T00:00:00.000Z',
+          catalogue: CATALOGUE,
+          catalogueFetchStatus: 'success',
+        },
+      },
+    })
+    expect(rehydrated.meta).toEqual(META)
+    expect(rehydrated.metaSource).toBe('cache')
+    expect(rehydrated.metaFetchStatus).toBe('idle')
+    expect(rehydrated.catalogue).toBeNull()
+    expect(rehydrated.catalogueFetchStatus).toBe('idle')
+  })
+
+  it('leaves source null when rehydrate has no meta', () => {
+    const rehydrated = reducer(initialState, {
+      type: REHYDRATE,
+      key: 'root',
+      payload: { neeruConfig: {} },
+    })
+    expect(rehydrated.meta).toBeNull()
+    expect(rehydrated.metaSource).toBeNull()
+  })
+})
+
+describe('neeruMetaSelector', () => {
+  it('returns hardcoded fallback when no meta cached', () => {
+    const result = neeruMetaSelector(buildState())
+    expect(result.meta).toEqual(NEERU_META_HARDCODED_FALLBACK)
+    expect(result.source).toBe('fallback')
+    expect(result.isDegraded).toBe(true)
+  })
+
+  it('returns backend meta when source is backend (not degraded)', () => {
+    const result = neeruMetaSelector(
+      buildState({ meta: META, metaSource: 'backend', metaFetchedAt: '2026-07-24T00:00:00.000Z' })
+    )
+    expect(result.meta).toEqual(META)
+    expect(result.source).toBe('backend')
+    expect(result.isDegraded).toBe(false)
+  })
+
+  it('returns cache meta as not degraded within TTL', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-25T06:00:00.000Z'))
+    const result = neeruMetaSelector(
+      buildState({
+        meta: META,
+        metaSource: 'cache',
+        metaFetchedAt: '2026-07-25T00:00:00.000Z',
+      })
+    )
+    expect(result.isDegraded).toBe(false)
+    jest.useRealTimers()
+  })
+
+  it('marks cache meta as degraded past TTL', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'))
+    const result = neeruMetaSelector(
+      buildState({
+        meta: META,
+        metaSource: 'cache',
+        metaFetchedAt: '2026-07-25T00:00:00.000Z',
+      })
+    )
+    // 48h > 24h TTL
+    expect(result.isDegraded).toBe(true)
+    expect(result.source).toBe('cache')
+    jest.useRealTimers()
+  })
+
+  it('treats a cache row with no fetchedAt as degraded', () => {
+    const result = neeruMetaSelector(
+      buildState({ meta: META, metaSource: 'cache', metaFetchedAt: null })
+    )
+    expect(result.isDegraded).toBe(true)
+  })
+
+  it('uses the exact TTL boundary', () => {
+    const fetchedAt = '2026-07-25T00:00:00.000Z'
+    const exactlyAtBoundary = Date.parse(fetchedAt) + NEERU_META_CACHE_FRESH_MS
+    jest.useFakeTimers().setSystemTime(new Date(exactlyAtBoundary))
+    const result = neeruMetaSelector(
+      buildState({ meta: META, metaSource: 'cache', metaFetchedAt: fetchedAt })
+    )
+    // At the boundary, treated as fresh (ageMs === TTL, not >)
+    expect(result.isDegraded).toBe(false)
+    jest.useRealTimers()
+  })
+})
+
+describe('neeruCatalogueSelector', () => {
+  it('reports loading and empty catalogue on cold state', () => {
+    const result = neeruCatalogueSelector(buildState({ catalogueFetchStatus: 'loading' }))
+    expect(result.catalogue).toBeNull()
+    expect(result.isLoading).toBe(true)
+    expect(result.hasError).toBe(false)
+  })
+
+  it('reports catalogue and no error on success', () => {
+    const result = neeruCatalogueSelector(
+      buildState({ catalogue: CATALOGUE, catalogueFetchStatus: 'success' })
+    )
+    expect(result.catalogue).toEqual(CATALOGUE)
+    expect(result.isLoading).toBe(false)
+    expect(result.hasError).toBe(false)
+  })
+
+  it('surfaces error status so callers render skeleton', () => {
+    const result = neeruCatalogueSelector(buildState({ catalogueFetchStatus: 'error' }))
+    expect(result.hasError).toBe(true)
+  })
+})

--- a/src/earn/neeru/api.ts
+++ b/src/earn/neeru/api.ts
@@ -1,13 +1,19 @@
 import BigNumber from 'bignumber.js'
 import { NeeruCategoryId } from 'src/earn/neeru/constants'
 import {
+  NeeruCatalogue,
   NeeruIndividualPosition,
+  NeeruMeta,
   NeeruPositionPayout,
   NeeruPositionsResponse,
 } from 'src/earn/neeru/types'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 
 const NEERU_FETCH_TIMEOUT_MS = 15_000
+// Config endpoints (meta + catalogue) have short backend cache, so a shorter
+// wallet-side timeout is enough. Falling back to hardcoded defaults is quick
+// and always safe, no reason to keep the boot flow waiting.
+const NEERU_CONFIG_FETCH_TIMEOUT_MS = 5_000
 
 interface RawPayout {
   amount: string
@@ -95,4 +101,37 @@ export async function fetchNeeruPositions({
     lastSyncedBlock: raw.lastSyncedBlock,
     lastSyncedAt: raw.lastSyncedAt,
   }
+}
+
+// Fetches the earn-vault meta descriptor (proxy address, event topic0, data
+// schema, error selectors, deposit token identity). Backend caches 5min and
+// returns the same payload byte-for-byte so wallet can compare against the
+// hardcoded defaults in a CI drift check.
+export async function fetchNeeruMeta({ baseUrl }: { baseUrl: string }): Promise<NeeruMeta> {
+  const url = new URL('/api/meta/contracts/neeru', baseUrl)
+  const response = await fetchWithTimeout(url.toString(), null, NEERU_CONFIG_FETCH_TIMEOUT_MS)
+  if (!response.ok) {
+    throw new Error(`fetchNeeruMeta failed: ${response.status} ${response.statusText}`)
+  }
+  const body = await response.json()
+  return body as NeeruMeta
+}
+
+// Fetches the current catalogue of earn categories (id, lock period, rate,
+// monthly + annual effective percentages) and the deposit token metadata.
+// Rates fluctuate operationally (operator retunes via setTranche) so wallet
+// never caches this payload past the current session.
+export async function fetchNeeruCatalogue({
+  baseUrl,
+}: {
+  baseUrl: string
+}): Promise<NeeruCatalogue> {
+  const url = new URL('/api/earn/neeru/catalogue', baseUrl)
+  const response = await fetchWithTimeout(url.toString(), null, NEERU_CONFIG_FETCH_TIMEOUT_MS)
+  if (!response.ok) {
+    throw new Error(`fetchNeeruCatalogue failed: ${response.status} ${response.statusText}`)
+  }
+  const body = await response.json()
+  const raw = body.data as NeeruCatalogue
+  return raw
 }

--- a/src/earn/neeru/configSaga.ts
+++ b/src/earn/neeru/configSaga.ts
@@ -1,0 +1,56 @@
+import { call, put, spawn, takeLatest } from 'typed-redux-saga'
+import { fetchNeeruCatalogue, fetchNeeruMeta } from 'src/earn/neeru/api'
+import {
+  fetchCatalogueFailure,
+  fetchCatalogueStart,
+  fetchCatalogueSuccess,
+  fetchMetaFailure,
+  fetchMetaStart,
+  fetchMetaSuccess,
+} from 'src/earn/neeru/configSlice'
+import networkConfig from 'src/web3/networkConfig'
+import Logger from 'src/utils/Logger'
+import { ensureError } from 'src/utils/ensureError'
+
+const TAG = 'earn/neeru/configSaga'
+
+export function* fetchNeeruMetaSaga() {
+  try {
+    const meta = yield* call(fetchNeeruMeta, { baseUrl: networkConfig.tucopBackendApiUrl })
+    yield* put(fetchMetaSuccess({ meta, fetchedAt: new Date().toISOString() }))
+  } catch (e) {
+    const error = ensureError(e)
+    Logger.warn(TAG, 'meta fetch failed, cache or fallback will be used', error)
+    yield* put(fetchMetaFailure({ error: error.message }))
+  }
+}
+
+export function* fetchNeeruCatalogueSaga() {
+  try {
+    const catalogue = yield* call(fetchNeeruCatalogue, {
+      baseUrl: networkConfig.tucopBackendApiUrl,
+    })
+    yield* put(fetchCatalogueSuccess({ catalogue }))
+  } catch (e) {
+    const error = ensureError(e)
+    Logger.warn(TAG, 'catalogue fetch failed, callers will render loading/retry', error)
+    yield* put(fetchCatalogueFailure({ error: error.message }))
+  }
+}
+
+export function* watchFetchNeeruMeta() {
+  yield* takeLatest(fetchMetaStart.type, fetchNeeruMetaSaga)
+}
+
+export function* watchFetchNeeruCatalogue() {
+  yield* takeLatest(fetchCatalogueStart.type, fetchNeeruCatalogueSaga)
+}
+
+// Kicks off the meta fetch once at app boot. Catalogue is fetched on-demand
+// from the Earn screen so we do not burn a request on users who never open
+// the feature.
+export function* neeruConfigSaga() {
+  yield* spawn(watchFetchNeeruMeta)
+  yield* spawn(watchFetchNeeruCatalogue)
+  yield* put(fetchMetaStart())
+}

--- a/src/earn/neeru/configSelectors.ts
+++ b/src/earn/neeru/configSelectors.ts
@@ -1,0 +1,83 @@
+import { RootState } from 'src/redux/reducers'
+import { NEERU_META_CACHE_FRESH_MS, NeeruConfigSource } from 'src/earn/neeru/configSlice'
+import { NeeruCatalogue, NeeruMeta } from 'src/earn/neeru/types'
+
+// Hardcoded fallback used when the wallet has never received a meta payload
+// from the backend AND is currently offline. Values MUST match live /meta,
+// enforced by a CI drift check. If backend rotates any of these, the CI check
+// fails and this fallback must be updated in the same PR.
+export const NEERU_META_HARDCODED_FALLBACK: NeeruMeta = {
+  proxyAddress: '0x988Af5977201a0e988F2C75eA952532F6beb5082' as `0x${string}`,
+  events: {
+    Deposit: {
+      topic0: '0x8835c22a0c751188de86681e15904223c054bedd5c68ec8858945b7831290273' as `0x${string}`,
+      dataSchema: [
+        { type: 'uint8' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+      ],
+    },
+  },
+  errorSelectors: {
+    INTEREST_POOL_LOW: '0x2648b779' as `0x${string}`,
+    ALREADY_CLOSED: '0x9acb7e52' as `0x${string}`,
+    NOT_OWNER: '0x30cd7471' as `0x${string}`,
+  },
+  depositToken: {
+    address: '0x8a567e2aE79CA692Bd748aB832081C45de4041eA' as `0x${string}`,
+    chainId: 42220,
+    networkId: 'celo-mainnet',
+  },
+  version: 'v1-2026-06-29',
+}
+
+export interface ResolvedNeeruMeta {
+  meta: NeeruMeta
+  source: NeeruConfigSource
+  isDegraded: boolean
+}
+
+// Central resolver. Returns backend meta if fresh, cache if within TTL, cache
+// as degraded if past TTL, or the hardcoded fallback as last resort (cold boot
+// offline). Consumers should never bypass this: it enforces the TTL / poison
+// pill contract agreed with backend.
+export function neeruMetaSelector(state: RootState): ResolvedNeeruMeta {
+  const { meta, metaSource, metaFetchedAt } = state.neeruConfig
+  if (!meta || !metaSource) {
+    return {
+      meta: NEERU_META_HARDCODED_FALLBACK,
+      source: 'fallback',
+      isDegraded: true,
+    }
+  }
+  if (metaSource === 'backend') {
+    return { meta, source: 'backend', isDegraded: false }
+  }
+  // 'cache' branch: check whether it is still within the freshness window.
+  const fetchedAt = metaFetchedAt ? Date.parse(metaFetchedAt) : NaN
+  const ageMs = Number.isFinite(fetchedAt) ? Date.now() - fetchedAt : Infinity
+  return {
+    meta,
+    source: 'cache',
+    isDegraded: ageMs > NEERU_META_CACHE_FRESH_MS,
+  }
+}
+
+export interface ResolvedNeeruCatalogue {
+  catalogue: NeeruCatalogue | null
+  isLoading: boolean
+  hasError: boolean
+}
+
+// Catalogue has no fallback by design (rates fluctuate operationally). If
+// there is no fresh backend response, the caller renders a skeleton and
+// triggers a retry. Never returns a stale-with-fallback shape.
+export function neeruCatalogueSelector(state: RootState): ResolvedNeeruCatalogue {
+  const { catalogue, catalogueFetchStatus } = state.neeruConfig
+  return {
+    catalogue,
+    isLoading: catalogueFetchStatus === 'loading',
+    hasError: catalogueFetchStatus === 'error',
+  }
+}

--- a/src/earn/neeru/configSlice.ts
+++ b/src/earn/neeru/configSlice.ts
@@ -1,0 +1,98 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { REHYDRATE, RehydrateAction, getRehydratePayload } from 'src/redux/persist-helper'
+import { NeeruCatalogue, NeeruFetchStatus, NeeruMeta } from 'src/earn/neeru/types'
+
+// A backend /meta payload cached longer than this is considered stale and the
+// UI surfaces a "modo offline" banner. Backend-owned so a bump on their side
+// is detected within 24h regardless of network state on the device.
+export const NEERU_META_CACHE_FRESH_MS = 24 * 60 * 60 * 1000
+
+export type NeeruConfigSource = 'backend' | 'cache' | 'fallback'
+
+export interface NeeruConfigState {
+  // Meta: persisted with cache + fallback. Structural, rarely changes.
+  meta: NeeruMeta | null
+  metaSource: NeeruConfigSource | null
+  metaFetchedAt: string | null
+  metaFetchStatus: NeeruFetchStatus
+  metaLastError: string | null
+
+  // Catalogue: runtime-only, not persisted. No fallback: rates fluctuate
+  // operationally so stale hardcoded values would mislead the user.
+  catalogue: NeeruCatalogue | null
+  catalogueFetchStatus: NeeruFetchStatus
+  catalogueLastError: string | null
+}
+
+export const initialState: NeeruConfigState = {
+  meta: null,
+  metaSource: null,
+  metaFetchedAt: null,
+  metaFetchStatus: 'idle',
+  metaLastError: null,
+  catalogue: null,
+  catalogueFetchStatus: 'idle',
+  catalogueLastError: null,
+}
+
+const slice = createSlice({
+  name: 'neeruConfig',
+  initialState,
+  reducers: {
+    fetchMetaStart: (state) => {
+      state.metaFetchStatus = 'loading'
+      state.metaLastError = null
+    },
+    fetchMetaSuccess: (state, action: PayloadAction<{ meta: NeeruMeta; fetchedAt: string }>) => {
+      state.metaFetchStatus = 'success'
+      state.meta = action.payload.meta
+      state.metaSource = 'backend'
+      state.metaFetchedAt = action.payload.fetchedAt
+    },
+    fetchMetaFailure: (state, action: PayloadAction<{ error: string }>) => {
+      state.metaFetchStatus = 'error'
+      state.metaLastError = action.payload.error
+    },
+    fetchCatalogueStart: (state) => {
+      state.catalogueFetchStatus = 'loading'
+      state.catalogueLastError = null
+    },
+    fetchCatalogueSuccess: (state, action: PayloadAction<{ catalogue: NeeruCatalogue }>) => {
+      state.catalogueFetchStatus = 'success'
+      state.catalogue = action.payload.catalogue
+    },
+    fetchCatalogueFailure: (state, action: PayloadAction<{ error: string }>) => {
+      state.catalogueFetchStatus = 'error'
+      state.catalogueLastError = action.payload.error
+    },
+  },
+  extraReducers: (builder) => {
+    // After rehydration, preserve the disk-persisted meta but downgrade its
+    // source to 'cache' so consumers know it did not come from a fresh backend
+    // hit yet. The boot saga will refresh it and upgrade back to 'backend'.
+    builder.addCase(REHYDRATE, (state, action: RehydrateAction) => {
+      const payload = getRehydratePayload(action, 'neeruConfig') as Partial<NeeruConfigState>
+      const merged = { ...state, ...payload }
+      return {
+        ...merged,
+        metaSource: merged.meta ? 'cache' : null,
+        metaFetchStatus: 'idle',
+        metaLastError: null,
+        catalogue: null,
+        catalogueFetchStatus: 'idle',
+        catalogueLastError: null,
+      }
+    })
+  },
+})
+
+export const {
+  fetchMetaStart,
+  fetchMetaSuccess,
+  fetchMetaFailure,
+  fetchCatalogueStart,
+  fetchCatalogueSuccess,
+  fetchCatalogueFailure,
+} = slice.actions
+
+export default slice.reducer

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { TransactionReceipt } from 'viem'
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
+import { neeruConfigSaga } from 'src/earn/neeru/configSaga'
 import {
   NEERU_CATEGORY_LABEL_KEYS,
   NEERU_CONTRACT_ADDRESS,
@@ -568,6 +569,7 @@ export function* handleNeeruDepositOptimistic(receipt: TransactionReceipt) {
 }
 
 export function* neeruSaga() {
+  yield* spawn(neeruConfigSaga)
   yield* spawn(watchFetchNeeruPositions)
   yield* spawn(watchCloseNeeruPosition)
   yield* spawn(watchEmergencyCloseNeeruPosition)

--- a/src/earn/neeru/types.ts
+++ b/src/earn/neeru/types.ts
@@ -36,3 +36,53 @@ export interface NeeruPositionsResponse {
 
 export type NeeruFetchStatus = 'idle' | 'loading' | 'success' | 'error'
 export type NeeruCloseStatus = 'idle' | 'loading' | 'success' | 'error'
+
+// Backend meta endpoint payload shape. Any type (0x-hex, structural schema)
+// is preserved as-is so callers can compare against local hardcoded defaults
+// byte-for-byte.
+export interface NeeruMetaDataSchemaSlot {
+  type: string
+}
+
+export interface NeeruMeta {
+  proxyAddress: `0x${string}`
+  events: {
+    Deposit: {
+      topic0: `0x${string}`
+      dataSchema: NeeruMetaDataSchemaSlot[]
+    }
+  }
+  errorSelectors: {
+    INTEREST_POOL_LOW: `0x${string}`
+    ALREADY_CLOSED: `0x${string}`
+    NOT_OWNER: `0x${string}`
+  }
+  depositToken: {
+    address: `0x${string}`
+    chainId: number
+    networkId: string
+  }
+  version: string
+}
+
+// Backend catalogue endpoint payload shape. Rates fluctuate operationally
+// so wallet never persists them (see NeeruConfigState); only meta is cached.
+export interface NeeruCatalogueCategory {
+  id: number
+  secs: string
+  rateRay: string
+  monthlyRatePercentage: number
+  annualEffectivePercentage: number
+}
+
+export interface NeeruCatalogueToken {
+  address: `0x${string}`
+  decimals: number
+  symbol: string
+}
+
+export interface NeeruCatalogue {
+  categories: NeeruCatalogueCategory[]
+  token: NeeruCatalogueToken
+  fetchedAt: string
+}

--- a/src/redux/reducersList.ts
+++ b/src/redux/reducersList.ts
@@ -7,6 +7,7 @@ import dappsReducer from 'src/dapps/slice'
 import dollarsSpendReducer from 'src/dollarsSpend/slice'
 import earnReducer from 'src/earn/slice'
 import neeruReducer from 'src/earn/neeru/slice'
+import neeruConfigReducer from 'src/earn/neeru/configSlice'
 import { reducer as fiatExchanges } from 'src/fiatExchanges/reducer'
 import fiatConnectReducer from 'src/fiatconnect/slice'
 import { homeReducer as home } from 'src/home/reducers'
@@ -61,6 +62,7 @@ export const reducersList = {
   points: pointsReducer,
   earn: earnReducer,
   neeru: neeruReducer,
+  neeruConfig: neeruConfigReducer,
   buckspay: bucksPayReducer,
   gold: goldReducer,
   transactionInFlight: transactionInFlightReducer,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -345,6 +345,16 @@ describe('store state', () => {
           "pendingEmergencyFallback": {},
           "positions": [],
         },
+        "neeruConfig": {
+          "catalogue": null,
+          "catalogueFetchStatus": "idle",
+          "catalogueLastError": null,
+          "meta": null,
+          "metaFetchStatus": "idle",
+          "metaFetchedAt": null,
+          "metaLastError": null,
+          "metaSource": null,
+        },
         "networkInfo": {
           "connected": false,
           "rehydrated": true,

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2367,6 +2367,80 @@
             ],
             "type": "string"
         },
+        "NeeruCatalogue": {
+            "additionalProperties": false,
+            "properties": {
+                "categories": {
+                    "items": {
+                        "$ref": "#/definitions/NeeruCatalogueCategory"
+                    },
+                    "type": "array"
+                },
+                "fetchedAt": {
+                    "type": "string"
+                },
+                "token": {
+                    "$ref": "#/definitions/NeeruCatalogueToken"
+                }
+            },
+            "required": [
+                "categories",
+                "fetchedAt",
+                "token"
+            ],
+            "type": "object"
+        },
+        "NeeruCatalogueCategory": {
+            "additionalProperties": false,
+            "properties": {
+                "annualEffectivePercentage": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "number"
+                },
+                "monthlyRatePercentage": {
+                    "type": "number"
+                },
+                "rateRay": {
+                    "type": "string"
+                },
+                "secs": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "annualEffectivePercentage",
+                "id",
+                "monthlyRatePercentage",
+                "rateRay",
+                "secs"
+            ],
+            "type": "object"
+        },
+        "NeeruCatalogueToken": {
+            "additionalProperties": false,
+            "properties": {
+                "address": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "decimals": {
+                    "type": "number"
+                },
+                "symbol": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "address",
+                "decimals",
+                "symbol"
+            ],
+            "type": "object"
+        },
         "NeeruCategoryId": {
             "enum": [
                 0,
@@ -2384,6 +2458,81 @@
                 "success"
             ],
             "type": "string"
+        },
+        "NeeruConfigState": {
+            "additionalProperties": false,
+            "properties": {
+                "catalogue": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NeeruCatalogue"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "catalogueFetchStatus": {
+                    "$ref": "#/definitions/NeeruFetchStatus"
+                },
+                "catalogueLastError": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "meta": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NeeruMeta"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "metaFetchStatus": {
+                    "$ref": "#/definitions/NeeruFetchStatus"
+                },
+                "metaFetchedAt": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "metaLastError": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "metaSource": {
+                    "anyOf": [
+                        {
+                            "enum": [
+                                "backend",
+                                "cache",
+                                "fallback"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "catalogue",
+                "catalogueFetchStatus",
+                "catalogueLastError",
+                "meta",
+                "metaFetchStatus",
+                "metaFetchedAt",
+                "metaLastError",
+                "metaSource"
+            ],
+            "type": "object"
         },
         "NeeruFetchStatus": {
             "enum": [
@@ -2460,6 +2609,123 @@
                 "rateValue",
                 "renewedFromPositionId",
                 "startTs"
+            ],
+            "type": "object"
+        },
+        "NeeruMeta": {
+            "additionalProperties": false,
+            "properties": {
+                "depositToken": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "address": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "chainId": {
+                            "type": "number"
+                        },
+                        "networkId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "address",
+                        "chainId",
+                        "networkId"
+                    ],
+                    "type": "object"
+                },
+                "errorSelectors": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ALREADY_CLOSED": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "INTEREST_POOL_LOW": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NOT_OWNER": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ALREADY_CLOSED",
+                        "INTEREST_POOL_LOW",
+                        "NOT_OWNER"
+                    ],
+                    "type": "object"
+                },
+                "events": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Deposit": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "dataSchema": {
+                                    "items": {
+                                        "$ref": "#/definitions/NeeruMetaDataSchemaSlot"
+                                    },
+                                    "type": "array"
+                                },
+                                "topic0": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "dataSchema",
+                                "topic0"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "Deposit"
+                    ],
+                    "type": "object"
+                },
+                "proxyAddress": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "depositToken",
+                "errorSelectors",
+                "events",
+                "proxyAddress",
+                "version"
+            ],
+            "type": "object"
+        },
+        "NeeruMetaDataSchemaSlot": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
             ],
             "type": "object"
         },
@@ -8379,6 +8645,9 @@
         "neeru": {
             "$ref": "#/definitions/NeeruState"
         },
+        "neeruConfig": {
+            "$ref": "#/definitions/NeeruConfigState"
+        },
         "networkInfo": {
             "$ref": "#/definitions/State_2"
         },
@@ -8468,6 +8737,7 @@
         "keylessBackup",
         "localCurrency",
         "neeru",
+        "neeruConfig",
         "networkInfo",
         "nfts",
         "points",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3805,6 +3805,25 @@ export const v252Schema = {
   },
 }
 
+// neeruConfig slice: caches backend /meta payload with source + fetchedAt so
+// the wallet can survive backend outages without reintroducing hardcoded
+// contract state as a permanent fallback. Slice is added unconditionally, no
+// persist version bump (autoMergeLevel2 folds the initial state for existing
+// users; migration 252 is still the last release cut).
+export const v252SchemaWithNeeruConfig = {
+  ...v252Schema,
+  neeruConfig: {
+    meta: null,
+    metaSource: null,
+    metaFetchedAt: null,
+    metaFetchStatus: 'idle',
+    metaLastError: null,
+    catalogue: null,
+    catalogueFetchStatus: 'idle',
+    catalogueLastError: null,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v252Schema as Partial<RootState>
+  return v252SchemaWithNeeruConfig as Partial<RootState>
 }


### PR DESCRIPTION
## Summary

First step of the 5-PR series to drop hardcoded Neeru contract state from the wallet (agreed with backend on 2026-07-25 as the fix for the structural class of bug that shipped PR #272). This PR only installs the plumbing: no consumers switch to reading from the slice yet, so there is zero behaviour change in production.

- New `neeruConfig` slice with two independent tracks. **Meta** persists across sessions with a `source` tag (`backend | cache | fallback`) and a `fetchedAt` timestamp; a 24h TTL splits fresh from degraded. **Catalogue** never persists and has no fallback because on-chain rates fluctuate operationally.
- `fetchNeeruMeta` + `fetchNeeruCatalogue` API helpers with a shorter 5s timeout than the position fetcher (falling back to hardcoded or a skeleton is always safe, no reason to keep the boot flow waiting).
- Boot saga fires `fetchMetaStart` once inside `neeruSaga`; catalogue is left for consumers to trigger on demand (PR 3 wires this).
- Resolver `neeruMetaSelector` returns `{ meta, source, isDegraded }`. Consumers read this in the follow-up PRs (Tier 1) and never bypass it. `NEERU_META_HARDCODED_FALLBACK` is exported so the future CI drift check (PR 1b) can compare it against live `/meta`.
- `neeruCatalogueSelector` returns `{ catalogue, isLoading, hasError }`. Consumers render skeleton on `isLoading` and retry on `hasError`.

## Design agreement with backend

Backend approved the fallback-with-mitigations approach (their message 2026-07-25) after we proposed 3 refinements they asked for: TTL / poison pill (24h then degraded, cold-boot-offline as last resort), fallback for `/meta` but not `/catalogue`, CI drift check blocking (PR 1b next).

## Persist version

No bump. `_persist.version` stays at 252. `autoMergeLevel2` folds `neeruConfig`'s initialState for existing users at rehydrate. Bumping before publishing 252 to stores would trigger an unnecessary migration for dogfood users (documented in `feedback_no_persist_version_bump_pre_release`).

## Changes

- New: `src/earn/neeru/configSlice.ts`, `configSelectors.ts`, `configSaga.ts`
- New: `src/earn/neeru/__tests__/configSlice.test.ts` (16 tests), `configSaga.test.ts` (4 tests)
- Modified: `src/earn/neeru/{api,saga,types}.ts`, `src/redux/reducersList.ts`
- Test infra: `test/RootStateSchema.json` regen, `test/schemas.ts` sibling schema, `src/redux/store.test.ts` rehydration snapshot refresh

## Test plan

- [x] `yarn build:ts` clean
- [x] `yarn lint` clean on all touched files
- [x] `yarn jest src/earn/neeru/__tests__/configSlice.test.ts` -> 16/16 pass
- [x] `yarn jest src/earn/neeru/__tests__/configSaga.test.ts` -> 4/4 pass
- [x] `yarn jest src/earn/neeru src/redux/store` -> 112/112 pass, 15/15 suites
- [ ] CI Mobile green (schema regen + snapshot refresh both landed in same push)