### PR TITLE
refactor(earn/neeru): Tier 2 - PoolCard + optimistic UI consume /catalogue at runtime

### DIFF
--- a/src/earn/EarnHome.tsx
+++ b/src/earn/EarnHome.tsx
@@ -34,6 +34,7 @@ import {
   positionsStatusSelector,
 } from 'src/positions/selectors'
 import { useDispatch, useSelector } from 'src/redux/hooks'
+import { fetchCatalogueStart } from 'src/earn/neeru/configSlice'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
@@ -351,7 +352,10 @@ export default function EarnHome({ navigation, route }: Props) {
       // Corregir el error de promesa no manejada
       void loadStakes()
     }
-  }, [walletAddress])
+    // Refresh the Neeru catalogue on every EarnHome mount so pool cards
+    // pick up backend retunes without waiting for the next boot cycle.
+    dispatch(fetchCatalogueStart())
+  }, [walletAddress, dispatch])
 
   const flatPools = useMemo(() => {
     const marranitos =

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -22,6 +22,7 @@ import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
 import { NeeruCategoryId, categoryIdFromPositionId } from 'src/earn/neeru/constants'
+import { neeruCatalogueCategoryByIdSelector } from 'src/earn/neeru/configSelectors'
 import { effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
 import { COPM_TOKEN_ID_MAINNET } from 'src/web3/networkConfig'
 
@@ -119,12 +120,29 @@ export default function PoolCard({
   // comparable to bank promos and other DeFi surfaces the user browses. Keep
   // the monthly rate visible as a smaller subtitle so no context is lost.
   const isNeeruPool = pool.appId === 'neeru-vaults'
+  const neeruCategoryId = useMemo(
+    () => (isNeeruPool ? categoryIdFromPositionId(pool.positionId) : null),
+    [isNeeruPool, pool.positionId]
+  )
+  // Backend catalogue is the source of truth for both rates (retunes without a
+  // contract upgrade would otherwise leave stale numbers on the card). Falls
+  // back to the local monthly-to-annual conversion only when the catalogue is
+  // not loaded yet, so the UI still surfaces something reasonable pre-fetch.
+  const catalogueCategory = useSelector((state) =>
+    neeruCategoryId !== null ? neeruCatalogueCategoryByIdSelector(state, neeruCategoryId) : null
+  )
   const neeruRates = useMemo(() => {
     if (!isNeeruPool) return null
+    if (catalogueCategory) {
+      return {
+        mv: catalogueCategory.monthlyRatePercentage.toFixed(2),
+        ea: catalogueCategory.annualEffectivePercentage.toFixed(2),
+      }
+    }
     const mv = rawYieldRate
     const ea = effectiveAnnualPercentFromMonthly(mv)
     return { mv: mv.toFixed(2), ea: ea.toFixed(2) }
-  }, [isNeeruPool, rawYieldRate])
+  }, [isNeeruPool, rawYieldRate, catalogueCategory])
 
   // Card title is always the user-friendly token display name per the wallet manual
   // (cCOP -> Pesos, USDT/USDC/USDm -> Dolares, etc).

--- a/src/earn/neeru/__tests__/rateConversion.test.ts
+++ b/src/earn/neeru/__tests__/rateConversion.test.ts
@@ -1,14 +1,12 @@
-import { computePayout, monthlyPercentFromRateValue } from 'src/earn/neeru/rateConversion'
+import { computePayout, effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
 
-describe('monthlyPercentFromRateValue', () => {
-  it('returns 0 for RAY (1e27)', () => {
-    expect(monthlyPercentFromRateValue('1000000000000000000000000000')).toBeCloseTo(0, 4)
+describe('effectiveAnnualPercentFromMonthly', () => {
+  it('returns 0 for a non-positive monthly rate', () => {
+    expect(effectiveAnnualPercentFromMonthly(0)).toBe(0)
+    expect(effectiveAnnualPercentFromMonthly(-1)).toBe(0)
   })
-  it('computes ~1% monthly for the launch 30d rate', () => {
-    // rateValue corresponding to ~1%/30d compounding
-    const rate = monthlyPercentFromRateValue('1000331300000000000000000000')
-    expect(rate).toBeGreaterThan(0.9)
-    expect(rate).toBeLessThan(1.1)
+  it('compounds 1% monthly to ~12.68% annual (matches backend catalogue)', () => {
+    expect(effectiveAnnualPercentFromMonthly(1)).toBeCloseTo(12.6825, 3)
   })
 })
 

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -2,7 +2,11 @@ import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { TransactionReceipt } from 'viem'
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
-import { NEERU_META_HARDCODED_FALLBACK, neeruMetaSelector } from 'src/earn/neeru/configSelectors'
+import {
+  NEERU_META_HARDCODED_FALLBACK,
+  neeruCatalogueCategoryByIdSelector,
+  neeruMetaSelector,
+} from 'src/earn/neeru/configSelectors'
 import { parseDepositEvent } from 'src/earn/neeru/eventParsing'
 import {
   NEERU_ALREADY_CLOSED_ERROR,
@@ -54,6 +58,25 @@ const RESOLVED_META = {
   source: 'fallback' as const,
   isDegraded: true,
 }
+
+// Resolved catalogue category rows used by handleNeeruDepositOptimistic when
+// it needs to synthesise an optimistic position row.
+const CAT_ROWS: Record<
+  number,
+  { secs: string; monthlyRatePercentage: number; annualEffectivePercentage: number }
+> = {
+  0: { secs: '0', monthlyRatePercentage: 0.8, annualEffectivePercentage: 10.033869 },
+  1: { secs: '2592000', monthlyRatePercentage: 1.0, annualEffectivePercentage: 12.682503 },
+  2: { secs: '5184000', monthlyRatePercentage: 1.05, annualEffectivePercentage: 13.35373 },
+  3: { secs: '7776000', monthlyRatePercentage: 1.1, annualEffectivePercentage: 14.02862 },
+}
+const catalogueRowProvide = (category: number) => [
+  matchers.select.like({
+    selector: neeruCatalogueCategoryByIdSelector,
+    args: [category] as const,
+  }),
+  CAT_ROWS[category] ?? null,
+]
 
 describe('fetchNeeruPositionsSaga', () => {
   const WALLET = '0x' + 'a'.repeat(40)
@@ -360,6 +383,7 @@ describe('handleNeeruDepositOptimistic', () => {
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(neeruMetaSelector), RESOLVED_META],
+        catalogueRowProvide(1) as any,
         {
           put: (effect: any, next: any) => {
             if (effect.action?.type === addOptimisticPosition.type) {
@@ -391,6 +415,7 @@ describe('handleNeeruDepositOptimistic', () => {
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(neeruMetaSelector), RESOLVED_META],
+        catalogueRowProvide(0) as any,
         [matchers.call.fn(awaitOptimisticResolution), 'timedOut' as const],
       ])
       .put(markOptimisticPositionStale({ depositTxHash: TX.toLowerCase() }))
@@ -410,6 +435,7 @@ describe('handleNeeruDepositOptimistic', () => {
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(neeruMetaSelector), RESOLVED_META],
+        catalogueRowProvide(2) as any,
         {
           call: (effect: any, next: any) => {
             if (effect.fn === awaitOptimisticResolution) {

--- a/src/earn/neeru/configSelectors.ts
+++ b/src/earn/neeru/configSelectors.ts
@@ -81,3 +81,22 @@ export function neeruCatalogueSelector(state: RootState): ResolvedNeeruCatalogue
     hasError: catalogueFetchStatus === 'error',
   }
 }
+
+// Convenience: look up a single category by id from the current catalogue.
+// Returns null when the catalogue is empty OR when the id is not present so
+// callers must handle the missing case (skeleton / retry) rather than
+// silently using stale hardcoded rates.
+export function neeruCatalogueCategoryByIdSelector(
+  state: RootState,
+  id: number
+): { secs: string; monthlyRatePercentage: number; annualEffectivePercentage: number } | null {
+  const catalogue = state.neeruConfig.catalogue
+  if (!catalogue) return null
+  const found = catalogue.categories.find((c) => c.id === id)
+  if (!found) return null
+  return {
+    secs: found.secs,
+    monthlyRatePercentage: found.monthlyRatePercentage,
+    annualEffectivePercentage: found.annualEffectivePercentage,
+  }
+}

--- a/src/earn/neeru/rateConversion.ts
+++ b/src/earn/neeru/rateConversion.ts
@@ -1,19 +1,12 @@
 import BigNumber from 'bignumber.js'
 
-const RAY = new BigNumber(10).pow(27)
-
-export function monthlyPercentFromRateValue(rateValue: string): number {
-  const daily = new BigNumber(rateValue).dividedBy(RAY)
-  if (daily.isLessThanOrEqualTo(1)) return 0
-  const monthly = daily.pow(30).minus(1).multipliedBy(100)
-  return Number(monthly.toFixed(6))
-}
-
 // Colombian financial-rate convention: the earn feature quotes a monthly
 // effective rate (M.V. = mensual vencido). The user-facing headline should
 // be the annual effective rate (E.A. = efectivo anual) so the number
 // compares against every other yield surface (bank promos, other DeFi
-// cards). Exact conversion: E.A. = ((1 + M.V./100)^12 - 1) * 100.
+// cards). Exact conversion: E.A. = ((1 + M.V./100)^12 - 1) * 100. Kept as a
+// pre-catalogue fallback for PoolCard so a cold boot without a fresh /catalogue
+// still surfaces a reasonable E.A. from the position's monthly rate.
 export function effectiveAnnualPercentFromMonthly(monthlyPercent: number): number {
   if (monthlyPercent <= 0) return 0
   const monthlyRate = new BigNumber(monthlyPercent).dividedBy(100)

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -2,10 +2,14 @@ import BigNumber from 'bignumber.js'
 import { TransactionReceipt } from 'viem'
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
 import { neeruConfigSaga } from 'src/earn/neeru/configSaga'
-import { neeruMetaSelector } from 'src/earn/neeru/configSelectors'
+import {
+  neeruCatalogueCategoryByIdSelector,
+  neeruMetaSelector,
+} from 'src/earn/neeru/configSelectors'
+import { fetchCatalogueStart } from 'src/earn/neeru/configSlice'
 import { NEERU_CATEGORY_LABEL_KEYS, NeeruCategoryId } from 'src/earn/neeru/constants'
 import { parseDepositEvent } from 'src/earn/neeru/eventParsing'
-import { computePayout, monthlyPercentFromRateValue } from 'src/earn/neeru/rateConversion'
+import { computePayout } from 'src/earn/neeru/rateConversion'
 import {
   addOptimisticPosition,
   clearEmergencyFallback,
@@ -105,13 +109,6 @@ export function classifySimulationRevert(
 
 const NEERU_OPTIMISTIC_POLL_INTERVAL_MS = 15_000
 const NEERU_OPTIMISTIC_TIMEOUT_MS = 5 * 60_000
-
-const CATEGORY_DURATION_SECONDS: Record<NeeruCategoryId, number> = {
-  0: 0,
-  1: 30 * 86_400,
-  2: 60 * 86_400,
-  3: 90 * 86_400,
-}
 
 // Match the low-interest-pool custom-error selector. viem surfaces custom
 // error reverts as raw hex in cause.data / cause.details / message when the
@@ -450,16 +447,20 @@ function buildOptimisticPosition({
   category,
   amountRaw,
   rateValue,
+  secs,
+  monthlyRatePercentage,
 }: {
   txHash: string
   blockNumber: number
   category: NeeruCategoryId
   amountRaw: string
   rateValue: string
+  secs: number
+  monthlyRatePercentage: number
 }): NeeruIndividualPosition {
   const amountDecimal = new BigNumber(amountRaw).shiftedBy(-18).toFixed()
   const startTs = Math.floor(Date.now() / 1000)
-  const endTs = category === 0 ? 0 : startTs + CATEGORY_DURATION_SECONDS[category]
+  const endTs = secs === 0 ? 0 : startTs + secs
   return {
     positionId: `optimistic:${txHash}`,
     category,
@@ -467,7 +468,7 @@ function buildOptimisticPosition({
     amount: amountDecimal,
     accruedInterest: '0',
     rateValue,
-    monthlyRatePercentage: monthlyPercentFromRateValue(rateValue),
+    monthlyRatePercentage,
     startTs,
     endTs,
     depositBlock: blockNumber,
@@ -556,6 +557,20 @@ export function* handleNeeruDepositOptimistic(receipt: TransactionReceipt) {
     Logger.warn(TAG, 'category out of range in deposit event', { category })
     return
   }
+  // Optimistic UI needs the lock-period (secs) and the monthly rate to
+  // render the position row properly. Both come from the runtime catalogue
+  // (no fallback: rates fluctuate operationally). If it is not loaded yet,
+  // trigger the fetch in the background and let backend indexer polling
+  // surface the position instead.
+  const categoryConfig = yield* select(neeruCatalogueCategoryByIdSelector, category)
+  if (!categoryConfig) {
+    Logger.warn(TAG, 'no catalogue entry for category, falling back to backend fetch', {
+      category,
+    })
+    yield* put(fetchCatalogueStart())
+    yield* put(fetchPositionsStart())
+    return
+  }
   const txHash = receipt.transactionHash.toLowerCase()
   const optimistic = buildOptimisticPosition({
     txHash,
@@ -563,6 +578,8 @@ export function* handleNeeruDepositOptimistic(receipt: TransactionReceipt) {
     category: category as NeeruCategoryId,
     amountRaw: parsed.amount,
     rateValue: parsed.rateValue,
+    secs: Number(categoryConfig.secs),
+    monthlyRatePercentage: categoryConfig.monthlyRatePercentage,
   })
   yield* put(addOptimisticPosition(optimistic))
 


### PR DESCRIPTION
## Summary

Fourth PR of the 5-PR series (after #273 slice + #275 CI drift + #276 Tier 1). Wires the second half of the backend endpoints: `/api/earn/neeru/catalogue`. PoolCard reads its E.A. + M.V. straight from the backend response, and the optimistic-UI saga picks up secs + monthly rate from the same source.

Consistent with backend's 2026-07-25 policy: **catalogue has NO fallback**. Rates fluctuate operationally, so stale hardcoded values would mislead the user. When the catalogue is not loaded yet, PoolCard falls back to the local monthly-to-annual conversion (only bridges the cold-boot pre-fetch window), and the optimistic saga bails to backend-driven position fetch.

## Changes

- **`neeruCatalogueCategoryByIdSelector`**: new helper in `configSelectors.ts` returning `{secs, monthlyRatePercentage, annualEffectivePercentage}` for a category id, or null when the catalogue is empty / missing the id.
- **`saga.ts`** (`handleNeeruDepositOptimistic` + `buildOptimisticPosition`):
  - Reads the target category row from the catalogue via the new selector.
  - When missing, dispatches `fetchCatalogueStart()` in the background and falls back to `fetchPositionsStart()`.
  - `buildOptimisticPosition` now takes `secs` and `monthlyRatePercentage` as explicit args.
  - Removes `CATEGORY_DURATION_SECONDS` hardcoded map.
  - Drops the `monthlyPercentFromRateValue` import.
- **`PoolCard.tsx`**: reads `annualEffectivePercentage` and `monthlyRatePercentage` from the catalogue when present; falls back to `effectiveAnnualPercentFromMonthly(rawYieldRate)` only when the catalogue is not loaded yet.
- **`EarnHome.tsx`**: dispatches `fetchCatalogueStart()` on mount so the catalogue refreshes every time the user visits Earn, catching backend retunes without waiting for the next app boot.
- **`rateConversion.ts`**: deletes `monthlyPercentFromRateValue` + `RAY` (no consumers left). `effectiveAnnualPercentFromMonthly` stays as the PoolCard pre-catalogue fallback. `computePayout` stays for optimistic preview.

## Base branch

Chained on top of #276 because it consumes the neeruMetaSelector integration. GitHub will auto-rebase to Development after #276 lands.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean on all touched files
- [x] \`yarn jest src/earn/neeru src/earn/EarnHome\` -> 112/112 pass
- [x] \`yarn jest src/earn\` -> 273/273 pass
- [ ] CI Mobile green
- [ ] Neeru meta drift check green (structural category ids + secs assertion covers this PR's catalogue reads)