### PR TITLE
refactor(earn): PoolCard prefers real priceUsd, defensive fallback for COPm

### DIFF
--- a/src/earn/EarnHome.tsx
+++ b/src/earn/EarnHome.tsx
@@ -34,6 +34,7 @@ import {
   positionsStatusSelector,
 } from 'src/positions/selectors'
 import { useDispatch, useSelector } from 'src/redux/hooks'
+import { fetchCatalogueStart } from 'src/earn/neeru/configSlice'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
@@ -351,7 +352,10 @@ export default function EarnHome({ navigation, route }: Props) {
       // Corregir el error de promesa no manejada
       void loadStakes()
     }
-  }, [walletAddress])
+    // Refresh the Neeru catalogue on every EarnHome mount so pool cards
+    // pick up backend retunes without waiting for the next boot cycle.
+    dispatch(fetchCatalogueStart())
+  }, [walletAddress, dispatch])
 
   const flatPools = useMemo(() => {
     const marranitos =

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -99,13 +99,20 @@ export default function PoolCard({
     useDollarsToLocalAmount(new BigNumber(rewardAmountInUsd)) ?? new BigNumber(0)
 
   const poolBalanceString = useMemo(() => {
-    // COPm has no USD price feed (priceUsd = '0'), so the USD-to-local
-    // conversion collapses to zero. It IS the local currency (1 COPm = 1 COP
-    // as a stable), so use the raw balance directly with the local symbol.
+    // Prefer the standard USD-to-local conversion when we have a live
+    // priceUsd for the deposit token. Backend now provides real priceUsd
+    // for COPm so the pool balance renders in local currency correctly
+    // for every token that has a price feed.
+    if (poolBalanceInFiat) {
+      return `${localCurrencySymbol}${formatValueToDisplay(poolBalanceInFiat.plus(rewardAmountInFiat))}`
+    }
+    // Defensive fallback for COPm when its priceUsd degrades to 0 (backend
+    // outage or fail-soft response). 1 COPm approximates 1 COP as a peso
+    // stablecoin so the raw balance is still a meaningful headline.
     if (depositTokenId === COPM_TOKEN_ID_MAINNET) {
       return `${localCurrencySymbol}${formatValueToDisplay(new BigNumber(balance).plus(rewardAmountInFiat))}`
     }
-    return `${localCurrencySymbol}${poolBalanceInFiat ? formatValueToDisplay(poolBalanceInFiat.plus(rewardAmountInFiat)) : '--'}`
+    return `${localCurrencySymbol}--`
   }, [localCurrencySymbol, poolBalanceInFiat, rewardAmountInFiat, depositTokenId, balance])
 
   const tvlInFiat = useDollarsToLocalAmount(tvl ?? null)

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -22,6 +22,7 @@ import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenDisplayName } from 'src/tokens/utils'
 import { NeeruCategoryId, categoryIdFromPositionId } from 'src/earn/neeru/constants'
+import { neeruCatalogueCategoryByIdSelector } from 'src/earn/neeru/configSelectors'
 import { effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
 import { COPM_TOKEN_ID_MAINNET } from 'src/web3/networkConfig'
 
@@ -119,12 +120,29 @@ export default function PoolCard({
   // comparable to bank promos and other DeFi surfaces the user browses. Keep
   // the monthly rate visible as a smaller subtitle so no context is lost.
   const isNeeruPool = pool.appId === 'neeru-vaults'
+  const neeruCategoryId = useMemo(
+    () => (isNeeruPool ? categoryIdFromPositionId(pool.positionId) : null),
+    [isNeeruPool, pool.positionId]
+  )
+  // Backend catalogue is the source of truth for both rates (retunes without a
+  // contract upgrade would otherwise leave stale numbers on the card). Falls
+  // back to the local monthly-to-annual conversion only when the catalogue is
+  // not loaded yet, so the UI still surfaces something reasonable pre-fetch.
+  const catalogueCategory = useSelector((state) =>
+    neeruCategoryId !== null ? neeruCatalogueCategoryByIdSelector(state, neeruCategoryId) : null
+  )
   const neeruRates = useMemo(() => {
     if (!isNeeruPool) return null
+    if (catalogueCategory) {
+      return {
+        mv: catalogueCategory.monthlyRatePercentage.toFixed(2),
+        ea: catalogueCategory.annualEffectivePercentage.toFixed(2),
+      }
+    }
     const mv = rawYieldRate
     const ea = effectiveAnnualPercentFromMonthly(mv)
     return { mv: mv.toFixed(2), ea: ea.toFixed(2) }
-  }, [isNeeruPool, rawYieldRate])
+  }, [isNeeruPool, rawYieldRate, catalogueCategory])
 
   // Card title is always the user-friendly token display name per the wallet manual
   // (cCOP -> Pesos, USDT/USDC/USDm -> Dolares, etc).

--- a/src/earn/neeru/__tests__/rateConversion.test.ts
+++ b/src/earn/neeru/__tests__/rateConversion.test.ts
@@ -1,14 +1,12 @@
-import { computePayout, monthlyPercentFromRateValue } from 'src/earn/neeru/rateConversion'
+import { computePayout, effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
 
-describe('monthlyPercentFromRateValue', () => {
-  it('returns 0 for RAY (1e27)', () => {
-    expect(monthlyPercentFromRateValue('1000000000000000000000000000')).toBeCloseTo(0, 4)
+describe('effectiveAnnualPercentFromMonthly', () => {
+  it('returns 0 for a non-positive monthly rate', () => {
+    expect(effectiveAnnualPercentFromMonthly(0)).toBe(0)
+    expect(effectiveAnnualPercentFromMonthly(-1)).toBe(0)
   })
-  it('computes ~1% monthly for the launch 30d rate', () => {
-    // rateValue corresponding to ~1%/30d compounding
-    const rate = monthlyPercentFromRateValue('1000331300000000000000000000')
-    expect(rate).toBeGreaterThan(0.9)
-    expect(rate).toBeLessThan(1.1)
+  it('compounds 1% monthly to ~12.68% annual (matches backend catalogue)', () => {
+    expect(effectiveAnnualPercentFromMonthly(1)).toBeCloseTo(12.6825, 3)
   })
 })
 

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -2,7 +2,11 @@ import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { TransactionReceipt } from 'viem'
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
-import { NEERU_META_HARDCODED_FALLBACK, neeruMetaSelector } from 'src/earn/neeru/configSelectors'
+import {
+  NEERU_META_HARDCODED_FALLBACK,
+  neeruCatalogueCategoryByIdSelector,
+  neeruMetaSelector,
+} from 'src/earn/neeru/configSelectors'
 import { parseDepositEvent } from 'src/earn/neeru/eventParsing'
 import {
   NEERU_ALREADY_CLOSED_ERROR,
@@ -54,6 +58,25 @@ const RESOLVED_META = {
   source: 'fallback' as const,
   isDegraded: true,
 }
+
+// Resolved catalogue category rows used by handleNeeruDepositOptimistic when
+// it needs to synthesise an optimistic position row.
+const CAT_ROWS: Record<
+  number,
+  { secs: string; monthlyRatePercentage: number; annualEffectivePercentage: number }
+> = {
+  0: { secs: '0', monthlyRatePercentage: 0.8, annualEffectivePercentage: 10.033869 },
+  1: { secs: '2592000', monthlyRatePercentage: 1.0, annualEffectivePercentage: 12.682503 },
+  2: { secs: '5184000', monthlyRatePercentage: 1.05, annualEffectivePercentage: 13.35373 },
+  3: { secs: '7776000', monthlyRatePercentage: 1.1, annualEffectivePercentage: 14.02862 },
+}
+const catalogueRowProvide = (category: number) => [
+  matchers.select.like({
+    selector: neeruCatalogueCategoryByIdSelector,
+    args: [category] as const,
+  }),
+  CAT_ROWS[category] ?? null,
+]
 
 describe('fetchNeeruPositionsSaga', () => {
   const WALLET = '0x' + 'a'.repeat(40)
@@ -360,6 +383,7 @@ describe('handleNeeruDepositOptimistic', () => {
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(neeruMetaSelector), RESOLVED_META],
+        catalogueRowProvide(1) as any,
         {
           put: (effect: any, next: any) => {
             if (effect.action?.type === addOptimisticPosition.type) {
@@ -391,6 +415,7 @@ describe('handleNeeruDepositOptimistic', () => {
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(neeruMetaSelector), RESOLVED_META],
+        catalogueRowProvide(0) as any,
         [matchers.call.fn(awaitOptimisticResolution), 'timedOut' as const],
       ])
       .put(markOptimisticPositionStale({ depositTxHash: TX.toLowerCase() }))
@@ -410,6 +435,7 @@ describe('handleNeeruDepositOptimistic', () => {
       .provide([
         [matchers.select(walletAddressSelector), WALLET],
         [matchers.select(neeruMetaSelector), RESOLVED_META],
+        catalogueRowProvide(2) as any,
         {
           call: (effect: any, next: any) => {
             if (effect.fn === awaitOptimisticResolution) {

--- a/src/earn/neeru/__tests__/saga.test.ts
+++ b/src/earn/neeru/__tests__/saga.test.ts
@@ -20,6 +20,7 @@ import {
   fetchNeeruPositionsSaga,
   handleNeeruDepositOptimistic,
   isLowPoolError,
+  resolveRevert,
   pollUntilBackendCatchesUp,
 } from 'src/earn/neeru/saga'
 import {
@@ -450,6 +451,51 @@ describe('handleNeeruDepositOptimistic', () => {
     expect(observed.baseUrl).toBe(networkConfig.tucopBackendApiUrl)
     expect(observed.walletAddress).toBe(WALLET)
     expect(observed.txHash).toBe(TX.toLowerCase())
+  })
+})
+
+describe('resolveRevert (two-source cross-check matrix)', () => {
+  const LOW_POOL = '0x2648b779'
+  const OTHER = '0x9acb7e52'
+  const backendReverted = (selector: string | null) => ({
+    status: 'reverted' as const,
+    transactionHash: '0x' + 'a'.repeat(64),
+    revert: { selector, reason: selector ? 'X' : 'UNKNOWN' },
+  })
+
+  it('both sources agree on the same selector -> confirmed', () => {
+    const r = resolveRevert(LOW_POOL, backendReverted(LOW_POOL))
+    expect(r).toEqual({ selector: LOW_POOL, confidence: 'confirmed' })
+  })
+
+  it('backend sees selector, wallet does not -> transient (already resolved on-chain)', () => {
+    const r = resolveRevert(null, backendReverted(LOW_POOL))
+    expect(r).toEqual({ selector: LOW_POOL, confidence: 'transient' })
+  })
+
+  it('wallet sees selector, backend does not -> live-only (new reason after mining)', () => {
+    const r = resolveRevert(LOW_POOL, backendReverted(null))
+    expect(r).toEqual({ selector: LOW_POOL, confidence: 'live-only' })
+  })
+
+  it('neither source extracts a selector -> unknown', () => {
+    const r = resolveRevert(null, backendReverted(null))
+    expect(r).toEqual({ selector: null, confidence: 'unknown' })
+  })
+
+  it('two sources disagree on the selector -> prefers wallet-side, flags live-only', () => {
+    const r = resolveRevert(LOW_POOL, backendReverted(OTHER))
+    expect(r).toEqual({ selector: LOW_POOL, confidence: 'live-only' })
+  })
+
+  it('backend response missing entirely -> falls back to wallet-only', () => {
+    const r = resolveRevert(LOW_POOL, null)
+    expect(r).toEqual({ selector: LOW_POOL, confidence: 'live-only' })
+  })
+
+  it('backend response missing + wallet null -> unknown', () => {
+    const r = resolveRevert(null, null)
+    expect(r).toEqual({ selector: null, confidence: 'unknown' })
   })
 })
 

--- a/src/earn/neeru/api.ts
+++ b/src/earn/neeru/api.ts
@@ -135,3 +135,34 @@ export async function fetchNeeruCatalogue({
   const raw = body.data as NeeruCatalogue
   return raw
 }
+
+// Backend transaction status endpoint. Backend replays eth_call at N-1
+// (block before mining) against its fallback RPC chain and returns the
+// revert selector. Wallet cross-checks against its own eth_call at latest
+// (see enforceReceiptsOrThrow). Agreement raises confidence, disagreement
+// surfaces "estado incierto" to the user.
+export interface NeeruTxStatusResponse {
+  status: 'success' | 'reverted'
+  blockNumber?: string
+  transactionHash: string
+  revert?: {
+    selector: string | null
+    reason: string
+  }
+}
+
+export async function fetchNeeruTxStatus({
+  baseUrl,
+  txHash,
+}: {
+  baseUrl: string
+  txHash: string
+}): Promise<NeeruTxStatusResponse> {
+  const url = new URL('/api/tx/status', baseUrl)
+  url.searchParams.set('hash', txHash)
+  const response = await fetchWithTimeout(url.toString(), null, NEERU_CONFIG_FETCH_TIMEOUT_MS)
+  if (!response.ok) {
+    throw new Error(`fetchNeeruTxStatus failed: ${response.status} ${response.statusText}`)
+  }
+  return (await response.json()) as NeeruTxStatusResponse
+}

--- a/src/earn/neeru/configSelectors.ts
+++ b/src/earn/neeru/configSelectors.ts
@@ -81,3 +81,22 @@ export function neeruCatalogueSelector(state: RootState): ResolvedNeeruCatalogue
     hasError: catalogueFetchStatus === 'error',
   }
 }
+
+// Convenience: look up a single category by id from the current catalogue.
+// Returns null when the catalogue is empty OR when the id is not present so
+// callers must handle the missing case (skeleton / retry) rather than
+// silently using stale hardcoded rates.
+export function neeruCatalogueCategoryByIdSelector(
+  state: RootState,
+  id: number
+): { secs: string; monthlyRatePercentage: number; annualEffectivePercentage: number } | null {
+  const catalogue = state.neeruConfig.catalogue
+  if (!catalogue) return null
+  const found = catalogue.categories.find((c) => c.id === id)
+  if (!found) return null
+  return {
+    secs: found.secs,
+    monthlyRatePercentage: found.monthlyRatePercentage,
+    annualEffectivePercentage: found.annualEffectivePercentage,
+  }
+}

--- a/src/earn/neeru/rateConversion.ts
+++ b/src/earn/neeru/rateConversion.ts
@@ -1,19 +1,12 @@
 import BigNumber from 'bignumber.js'
 
-const RAY = new BigNumber(10).pow(27)
-
-export function monthlyPercentFromRateValue(rateValue: string): number {
-  const daily = new BigNumber(rateValue).dividedBy(RAY)
-  if (daily.isLessThanOrEqualTo(1)) return 0
-  const monthly = daily.pow(30).minus(1).multipliedBy(100)
-  return Number(monthly.toFixed(6))
-}
-
 // Colombian financial-rate convention: the earn feature quotes a monthly
 // effective rate (M.V. = mensual vencido). The user-facing headline should
 // be the annual effective rate (E.A. = efectivo anual) so the number
 // compares against every other yield surface (bank promos, other DeFi
-// cards). Exact conversion: E.A. = ((1 + M.V./100)^12 - 1) * 100.
+// cards). Exact conversion: E.A. = ((1 + M.V./100)^12 - 1) * 100. Kept as a
+// pre-catalogue fallback for PoolCard so a cold boot without a fresh /catalogue
+// still surfaces a reasonable E.A. from the position's monthly rate.
 export function effectiveAnnualPercentFromMonthly(monthlyPercent: number): number {
   if (monthlyPercent <= 0) return 0
   const monthlyRate = new BigNumber(monthlyPercent).dividedBy(100)

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -2,10 +2,14 @@ import BigNumber from 'bignumber.js'
 import { TransactionReceipt } from 'viem'
 import { fetchNeeruPositions } from 'src/earn/neeru/api'
 import { neeruConfigSaga } from 'src/earn/neeru/configSaga'
-import { neeruMetaSelector } from 'src/earn/neeru/configSelectors'
+import {
+  neeruCatalogueCategoryByIdSelector,
+  neeruMetaSelector,
+} from 'src/earn/neeru/configSelectors'
+import { fetchCatalogueStart } from 'src/earn/neeru/configSlice'
 import { NEERU_CATEGORY_LABEL_KEYS, NeeruCategoryId } from 'src/earn/neeru/constants'
 import { parseDepositEvent } from 'src/earn/neeru/eventParsing'
-import { computePayout, monthlyPercentFromRateValue } from 'src/earn/neeru/rateConversion'
+import { computePayout } from 'src/earn/neeru/rateConversion'
 import {
   addOptimisticPosition,
   clearEmergencyFallback,
@@ -105,13 +109,6 @@ export function classifySimulationRevert(
 
 const NEERU_OPTIMISTIC_POLL_INTERVAL_MS = 15_000
 const NEERU_OPTIMISTIC_TIMEOUT_MS = 5 * 60_000
-
-const CATEGORY_DURATION_SECONDS: Record<NeeruCategoryId, number> = {
-  0: 0,
-  1: 30 * 86_400,
-  2: 60 * 86_400,
-  3: 90 * 86_400,
-}
 
 // Match the low-interest-pool custom-error selector. viem surfaces custom
 // error reverts as raw hex in cause.data / cause.details / message when the
@@ -450,16 +447,20 @@ function buildOptimisticPosition({
   category,
   amountRaw,
   rateValue,
+  secs,
+  monthlyRatePercentage,
 }: {
   txHash: string
   blockNumber: number
   category: NeeruCategoryId
   amountRaw: string
   rateValue: string
+  secs: number
+  monthlyRatePercentage: number
 }): NeeruIndividualPosition {
   const amountDecimal = new BigNumber(amountRaw).shiftedBy(-18).toFixed()
   const startTs = Math.floor(Date.now() / 1000)
-  const endTs = category === 0 ? 0 : startTs + CATEGORY_DURATION_SECONDS[category]
+  const endTs = secs === 0 ? 0 : startTs + secs
   return {
     positionId: `optimistic:${txHash}`,
     category,
@@ -467,7 +468,7 @@ function buildOptimisticPosition({
     amount: amountDecimal,
     accruedInterest: '0',
     rateValue,
-    monthlyRatePercentage: monthlyPercentFromRateValue(rateValue),
+    monthlyRatePercentage,
     startTs,
     endTs,
     depositBlock: blockNumber,
@@ -556,6 +557,20 @@ export function* handleNeeruDepositOptimistic(receipt: TransactionReceipt) {
     Logger.warn(TAG, 'category out of range in deposit event', { category })
     return
   }
+  // Optimistic UI needs the lock-period (secs) and the monthly rate to
+  // render the position row properly. Both come from the runtime catalogue
+  // (no fallback: rates fluctuate operationally). If it is not loaded yet,
+  // trigger the fetch in the background and let backend indexer polling
+  // surface the position instead.
+  const categoryConfig = yield* select(neeruCatalogueCategoryByIdSelector, category)
+  if (!categoryConfig) {
+    Logger.warn(TAG, 'no catalogue entry for category, falling back to backend fetch', {
+      category,
+    })
+    yield* put(fetchCatalogueStart())
+    yield* put(fetchPositionsStart())
+    return
+  }
   const txHash = receipt.transactionHash.toLowerCase()
   const optimistic = buildOptimisticPosition({
     txHash,
@@ -563,6 +578,8 @@ export function* handleNeeruDepositOptimistic(receipt: TransactionReceipt) {
     category: category as NeeruCategoryId,
     amountRaw: parsed.amount,
     rateValue: parsed.rateValue,
+    secs: Number(categoryConfig.secs),
+    monthlyRatePercentage: categoryConfig.monthlyRatePercentage,
   })
   yield* put(addOptimisticPosition(optimistic))
 

--- a/src/earn/neeru/saga.ts
+++ b/src/earn/neeru/saga.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { TransactionReceipt } from 'viem'
-import { fetchNeeruPositions } from 'src/earn/neeru/api'
+import { fetchNeeruPositions, fetchNeeruTxStatus, NeeruTxStatusResponse } from 'src/earn/neeru/api'
 import { neeruConfigSaga } from 'src/earn/neeru/configSaga'
 import {
   neeruCatalogueCategoryByIdSelector,
@@ -129,10 +129,88 @@ export function isLowPoolError(error: unknown, lowPoolSelector: `0x${string}`): 
   return false
 }
 
+export type NeeruRevertConfidence =
+  | 'confirmed' // wallet + backend agree on the same selector
+  | 'transient' // backend saw selector at N-1, wallet no longer reproduces at latest
+  | 'live-only' // wallet sees selector at latest, backend did not at N-1
+  | 'unknown' // neither source extracted a selector
+
+// Runs wallet-side eth_call at `latest` for a reverted tx and extracts the
+// 4-byte custom-error selector from viem's cause/message. Returns null when
+// no selector could be pulled out (call succeeded now, no error data, etc).
+function* extractSelectorFromWalletReplay({
+  base,
+  walletAddress,
+  client,
+}: {
+  base: { to?: `0x${string}`; data?: `0x${string}` }
+  walletAddress: string
+  client: (typeof publicClient)[keyof typeof publicClient]
+}): Generator<any, string | null, any> {
+  try {
+    yield* call([client, 'call'], {
+      account: walletAddress as `0x${string}`,
+      to: base.to,
+      data: base.data,
+    })
+    // Call succeeded: state at latest no longer reproduces the revert (transient).
+    return null
+  } catch (callError) {
+    const anyErr = callError as {
+      cause?: { data?: unknown; details?: unknown; cause?: { data?: unknown } }
+      message?: string
+    }
+    const candidates: unknown[] = [
+      anyErr?.cause?.data,
+      anyErr?.cause?.cause?.data,
+      anyErr?.cause?.details,
+      anyErr?.message,
+    ]
+    for (const c of candidates) {
+      if (typeof c !== 'string') continue
+      const selectorMatch = c.match(/0x[0-9a-fA-F]{8}(?![0-9a-fA-F])/)
+      if (selectorMatch) return selectorMatch[0]
+    }
+    return null
+  }
+}
+
+// Two-source cross-check per the design agreed with backend on 2026-07-25.
+// Wallet eth_call at `latest` + backend /tx/status (replay at N-1) build a
+// resolved revert view. Disagreement is not an error, it is information: the
+// caller can surface a different UX (transient vs live-only vs unknown).
+export function resolveRevert(
+  walletSelector: string | null,
+  backend: NeeruTxStatusResponse | null
+): { selector: string | null; confidence: NeeruRevertConfidence } {
+  const backendSelector = backend?.revert?.selector ?? null
+  if (walletSelector && backendSelector) {
+    if (walletSelector.toLowerCase() === backendSelector.toLowerCase()) {
+      return { selector: walletSelector, confidence: 'confirmed' }
+    }
+    // Different selectors is an unusual case, surface the wallet-side one
+    // (it reflects current state) and log the disagreement so we notice.
+    Logger.warn(TAG, 'two-source revert selectors disagree', {
+      walletSelector,
+      backendSelector,
+    })
+    return { selector: walletSelector, confidence: 'live-only' }
+  }
+  if (!walletSelector && backendSelector) {
+    return { selector: backendSelector, confidence: 'transient' }
+  }
+  if (walletSelector && !backendSelector) {
+    return { selector: walletSelector, confidence: 'live-only' }
+  }
+  return { selector: null, confidence: 'unknown' }
+}
+
 // Wait for the on-chain receipts of every tx we just sent. If any one reverted,
-// re-run it as an eth_call at the reverted block to surface the custom-error
-// selector (viem attaches it to cause.data / cause.details), then throw an
-// Error whose shape the isLowPoolError matcher above understands.
+// cross-check wallet eth_call at latest against backend /tx/status (replay at
+// N-1) and throw an Error whose cause carries the resolved selector plus the
+// confidence tag so callers can branch UX. Selector-matching helpers
+// (isLowPoolError, classifySimulationRevert) still work because cause.data
+// carries the raw hex selector byte-for-byte.
 export function* enforceReceiptsOrThrow({
   txHashes,
   baseTransactions,
@@ -151,48 +229,43 @@ export function* enforceReceiptsOrThrow({
       hash: txHashes[i],
     })
     if (receipt.status === 'success') continue
-    // Reverted: replay against `latest` (not the receipt block, Forno frequently
-    // rejects historical block state with "block is out of range") to extract
-    // the revert data. The Neeru contract state that drove the revert (low
-    // interest pool) persists across blocks, so re-simulating now reproduces
-    // the same custom error and surfaces the selector on cause.data.
-    let revertData: string | undefined
+
+    const base = baseTransactions[i] as { to?: `0x${string}`; data?: `0x${string}` }
+    // Wallet-side eth_call replay at latest. Persistent state (e.g. LOW_POOL
+    // still active) reproduces the error; race conditions post-mining do not.
+    const walletSelector: string | null = yield* extractSelectorFromWalletReplay({
+      base,
+      walletAddress,
+      client,
+    })
+    // Backend /tx/status: replay at N-1 against their RPC fallback chain.
+    // Fail-soft: if backend is down we still throw with wallet-side data.
+    let backendStatus: NeeruTxStatusResponse | null = null
     try {
-      const base = baseTransactions[i] as { to?: `0x${string}`; data?: `0x${string}` }
-      yield* call([client, 'call'], {
-        account: walletAddress as `0x${string}`,
-        to: base.to,
-        data: base.data,
+      backendStatus = yield* call(fetchNeeruTxStatus, {
+        baseUrl: networkConfig.tucopBackendApiUrl,
+        txHash: txHashes[i],
       })
-    } catch (callError) {
-      // viem attaches revert data under different keys depending on how the
-      // node returned it. Walk a few common shapes.
-      const anyErr = callError as {
-        cause?: { data?: unknown; details?: unknown; cause?: { data?: unknown } }
-        message?: string
-      }
-      const candidates: unknown[] = [
-        anyErr?.cause?.data,
-        anyErr?.cause?.cause?.data,
-        anyErr?.cause?.details,
-        anyErr?.message,
-      ]
-      for (const c of candidates) {
-        if (typeof c !== 'string') continue
-        // Prefer a bare 4-byte selector if present, else keep the full string
-        // so the LOW_POOL matcher below (substring match) still works.
-        const selectorMatch = c.match(/0x[0-9a-fA-F]{8}(?![0-9a-fA-F])/)
-        if (selectorMatch) {
-          revertData = selectorMatch[0]
-          break
-        }
-        if (!revertData) revertData = c
-      }
+    } catch (e) {
+      Logger.warn(TAG, 'backend /tx/status unreachable, degrading to wallet-only', e)
     }
-    const err = new Error(`tx reverted on-chain (${revertData ?? 'no revert data'})`)
-    ;(err as { cause?: { data?: string; details?: string } }).cause = {
-      data: revertData,
-      details: revertData,
+    const resolved = resolveRevert(walletSelector, backendStatus)
+
+    const err = new Error(
+      `tx reverted on-chain (${resolved.selector ?? 'no revert data'}, confidence=${resolved.confidence})`
+    )
+    ;(
+      err as {
+        cause?: {
+          data?: string | null
+          details?: string | null
+          confidence?: NeeruRevertConfidence
+        }
+      }
+    ).cause = {
+      data: resolved.selector ?? undefined,
+      details: resolved.selector ?? undefined,
+      confidence: resolved.confidence,
     }
     throw err
   }


### PR DESCRIPTION
## Summary

Sixth and final PR of the Neeru wire-refactor series. Backend PR #152 shipped real \`priceUsd\` for COPm on \`/hooks-api/getPositions\` + \`getEarnPositions\`, so wallet no longer needs to bypass the USD-to-local conversion for COPm pool cards.

## Change

- \`PoolCard.tsx\`: order of resolution flipped. Standard \`poolBalanceInFiat\` (uses live priceUsd) is preferred. The COPm-only raw-balance shortcut becomes a defensive fallback that only kicks in when priceUsd degrades to 0 (backend outage / fail-soft response), avoiding a blank card headline in that edge case.

## Base branch

Chained on top of #278 (two-source safety net). Rebases to Development automatically.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/earn\` -> 280/280 pass
- [ ] Sim in Alfajores + prod after all 6 PRs land: pool cards show correct headline with real backend priceUsd

## Series recap

- #273 (MERGED) - Slice + boot fetch
- #275 - CI drift check test
- #276 - Tier 1 consumers
- #277 - Tier 2 catalogue
- #278 - Tier 3 two-source safety net
- **This PR** - PoolCard consolidation