### PR TITLE
refactor(earn): PoolCard prefers real priceUsd, defensive fallback for COPm

### DIFF
--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -99,13 +99,20 @@ export default function PoolCard({
     useDollarsToLocalAmount(new BigNumber(rewardAmountInUsd)) ?? new BigNumber(0)
 
   const poolBalanceString = useMemo(() => {
-    // COPm has no USD price feed (priceUsd = '0'), so the USD-to-local
-    // conversion collapses to zero. It IS the local currency (1 COPm = 1 COP
-    // as a stable), so use the raw balance directly with the local symbol.
+    // Prefer the standard USD-to-local conversion when we have a live
+    // priceUsd for the deposit token. Backend now provides real priceUsd
+    // for COPm so the pool balance renders in local currency correctly
+    // for every token that has a price feed.
+    if (poolBalanceInFiat) {
+      return `${localCurrencySymbol}${formatValueToDisplay(poolBalanceInFiat.plus(rewardAmountInFiat))}`
+    }
+    // Defensive fallback for COPm when its priceUsd degrades to 0 (backend
+    // outage or fail-soft response). 1 COPm approximates 1 COP as a peso
+    // stablecoin so the raw balance is still a meaningful headline.
     if (depositTokenId === COPM_TOKEN_ID_MAINNET) {
       return `${localCurrencySymbol}${formatValueToDisplay(new BigNumber(balance).plus(rewardAmountInFiat))}`
     }
-    return `${localCurrencySymbol}${poolBalanceInFiat ? formatValueToDisplay(poolBalanceInFiat.plus(rewardAmountInFiat)) : '--'}`
+    return `${localCurrencySymbol}--`
   }, [localCurrencySymbol, poolBalanceInFiat, rewardAmountInFiat, depositTokenId, balance])
 
   const tvlInFiat = useDollarsToLocalAmount(tvl ?? null)


### PR DESCRIPTION
## Summary

Final PR of the Neeru wire-refactor series. Reopened after Tier 3 (#281) merge, rebased onto Development.

Backend PR #152 shipped real \`priceUsd\` for COPm on \`/hooks-api/getPositions\`, so wallet no longer needs to bypass the USD-to-local conversion for COPm pool cards.

## Change

- \`PoolCard.tsx\`: order of resolution flipped. Standard \`poolBalanceInFiat\` (uses live priceUsd) is preferred. The COPm-only raw-balance shortcut becomes a defensive fallback that only kicks in when priceUsd degrades to 0 (backend outage / fail-soft response), avoiding a blank card headline in that edge case.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/earn\` -> 280/280 pass
- [ ] CI Mobile green

## Series recap (all merged to Development)

- #273 - Slice + boot fetch
- #275 - CI drift check
- #276 - Tier 1 consumers
- #280 - Tier 2 catalogue
- #281 - Tier 3 two-source safety net
- **This PR** - PoolCard consolidation