### PR TITLE
fix(viem): dedicated CIP-64 fee estimator with 100% headroom for op-reth

### DIFF
--- a/src/viem/estimateFeesPerGas.test.ts
+++ b/src/viem/estimateFeesPerGas.test.ts
@@ -41,32 +41,49 @@ describe(estimateFeesPerGas, () => {
     expect(getBlock).toHaveBeenCalledWith(client, { blockTag: 'latest' })
   })
 
-  it('should return the correct fees per gas on Celo when fee currency is specified', async () => {
+  it('should build a CIP-64 fee envelope from eth_gasPrice(feeCurrency) when fee currency is specified', async () => {
+    // Block header baseFee is intentionally in NATIVE units; the CIP-64 path
+    // must NOT mix it with the fee-currency gas price. Set it to a value
+    // that would be nonsensical if the code accidentally used it as the
+    // baseFee for a CIP-64 tx.
     const mockBlock = {
       baseFeePerGas: BigInt('100000000'),
       hash: '0x123',
       number: BigInt(100),
-    } as any as Block // 0.1 Gwei
+    } as any as Block
     jest.mocked(getBlock).mockResolvedValue(mockBlock)
+
+    // Fee-currency gas price = 2 Gwei-equivalent in fee-currency units.
+    const gasPriceInFc = BigInt('0x77359400') // 2_000_000_000
 
     const client = {
       chain: { id: networkConfig.viemChain.celo.id },
       request: jest.fn(async ({ method, params }) => {
-        if (method === 'eth_gasPrice' && params?.[0] === '0x456') return '0x77359400' // 2 Gwei with fee currency
-        if (method === 'eth_gasPrice') return '0x3b9aca00' // 1 Gwei fallback
+        if (method === 'eth_gasPrice' && params?.[0] === '0x456') return '0x77359400'
         throw new Error(`Unknown method ${method}`)
       }),
     }
 
     const fees = await estimateFeesPerGas(client as any, '0x456' as Address)
 
-    // Critical validations
-    expect(fees.baseFeePerGas).toBe(BigInt('100000000')) // 0.1 Gwei (matches CELO_MIN_GAS_PRICES.CELO)
-    expect(fees.maxPriorityFeePerGas).toBeGreaterThan(BigInt(0))
-    expect(fees.maxFeePerGas).toBeGreaterThan(fees.baseFeePerGas)
+    // maxFee: 2x current gas price = 4 Gwei-equivalent (100% headroom)
+    expect(fees.maxFeePerGas).toBe(gasPriceInFc * BigInt(2))
+    // priority: 25% of current gas price
+    expect(fees.maxPriorityFeePerGas).toBe(gasPriceInFc / BigInt(4))
+    // baseFee (reported): current - priority (approximate, in fee-currency units)
+    expect(fees.baseFeePerGas).toBe(gasPriceInFc - gasPriceInFc / BigInt(4))
+
+    // The invariant that matters: maxFee > baseFee + priority (op-reth requires
+    // real headroom so the tx survives base-fee movement between estimation
+    // and inclusion).
     expect(fees.maxFeePerGas).toBeGreaterThan(fees.baseFeePerGas + fees.maxPriorityFeePerGas)
 
+    // Block header baseFee (native units) must not have leaked into the result.
+    expect(fees.baseFeePerGas).not.toBe(BigInt('100000000'))
+
+    // Native-only helpers must not have been called on the CIP-64 path.
     expect(defaultEstimateFeesPerGas).not.toHaveBeenCalled()
+    expect(getBlock).not.toHaveBeenCalled()
   })
 
   it('should return the default fees per gas on other networks', async () => {

--- a/src/viem/estimateFeesPerGas.ts
+++ b/src/viem/estimateFeesPerGas.ts
@@ -42,6 +42,23 @@ async function estimateCeloL2FeesPerGas(
   feeCurrency: Address | undefined,
   chainId: number
 ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint; baseFeePerGas: bigint }> {
+  // CIP-64 non-native fee currency: use eth_gasPrice(feeCurrency) as the sole
+  // authoritative source and build a wide envelope around it. Do NOT mix with
+  // block.baseFeePerGas, which is denominated in native (CELO wei) and is
+  // therefore not directly comparable with the fee-currency gas price.
+  //
+  // The previous shared path subtracted (gasPrice(fc) - baseFee(native)) to
+  // derive a "priority" fee, which produced priority ≈ gasPrice(fc) and left
+  // maxFee within ~2-3% of the current price. op-geth tolerated the tight
+  // margin; op-reth (Celo mainnet migrated 2026-07-22) is stricter about
+  // validating that maxFee >= actual on-chain baseFee + priority and rejects
+  // the request as "Missing or invalid parameters" whenever the base moves
+  // up between estimation and inclusion. This branch fixes the class of
+  // Forno rejections we observed on Gold buys.
+  if (feeCurrency) {
+    return estimateCip64FeesPerGas(client, feeCurrency)
+  }
+
   // Get the most recent block to ensure we have current base fee
   const block = await getBlock(client, { blockTag: 'latest' })
 
@@ -166,4 +183,67 @@ async function estimateCeloL2FeesPerGas(
     maxPriorityFeePerGas: adjustedPriorityFee,
     baseFeePerGas: adjustedBaseFee,
   }
+}
+
+/**
+ * Dedicated estimator for CIP-64 non-native fee currency transactions.
+ *
+ * Rationale: on Celo, `eth_gasPrice(feeCurrency)` returns the current total
+ * gas price in fee-currency units (baseFee + a small priority) already
+ * scaled through the fee currency adapter. Block header baseFeePerGas is in
+ * native units and cannot be mixed with it. This function treats the fee-
+ * currency gas price as authoritative:
+ *
+ *   - maxFeePerGas   = gasPrice(fc) * 2         (100% headroom for base drift)
+ *   - maxPriorityFee = gasPrice(fc) / 4         (25% of current price)
+ *   - baseFeePerGas  = gasPrice(fc) - priority  (approximate, reported for UI)
+ *
+ * The 100% headroom is deliberately generous because op-reth rejects on any
+ * borderline case and the cost of a rejected tx (user-visible error) is
+ * higher than the cost of a slightly-overestimated maxFee (user is never
+ * actually charged above realBaseFee + priority regardless of maxFee).
+ */
+async function estimateCip64FeesPerGas(
+  client: Client,
+  feeCurrency: Address
+): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint; baseFeePerGas: bigint }> {
+  let gasPriceInFeeCurrency: bigint
+  try {
+    const raw = await client.request({
+      method: 'eth_gasPrice',
+      params: [feeCurrency],
+    } as any)
+    gasPriceInFeeCurrency = BigInt(raw as string)
+  } catch (error) {
+    // If the node refuses the fee-currency variant, fall back to the plain
+    // eth_gasPrice and let downstream estimation surface the error. Do NOT
+    // silently substitute the native gas price into a CIP-64 tx — units
+    // would mismatch again.
+    Logger.warn('estimateFeesPerGas', 'CIP-64 eth_gasPrice(feeCurrency) failed:', {
+      feeCurrency,
+      error,
+    })
+    throw error
+  }
+
+  if (gasPriceInFeeCurrency <= BigInt(0)) {
+    throw new Error(
+      `CIP-64 eth_gasPrice(${feeCurrency}) returned non-positive value: ${gasPriceInFeeCurrency}`
+    )
+  }
+
+  const maxFeePerGas = gasPriceInFeeCurrency * BigInt(2)
+  const maxPriorityFeePerGas = gasPriceInFeeCurrency / BigInt(4)
+  const baseFeePerGas = gasPriceInFeeCurrency - maxPriorityFeePerGas
+
+  Logger.debug('estimateFeesPerGas', 'CIP-64 estimation:', {
+    feeCurrency,
+    gasPriceInFeeCurrency: gasPriceInFeeCurrency.toString(),
+    maxFeePerGas: maxFeePerGas.toString(),
+    maxPriorityFeePerGas: maxPriorityFeePerGas.toString(),
+    baseFeePerGas: baseFeePerGas.toString(),
+    headroomMultiple: '2x',
+  })
+
+  return { maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas }
 }


### PR DESCRIPTION
## Summary

Reemplaza el band-aid del [PR #285](https://github.com/TuCopFinance/TuCopWallet/pull/285) (fallback de gas hardcodeado para approve) con un fix estructural en el cálculo de `estimateFeesPerGas` para CIP-64 (fee currency no nativa).

## Contexto

Celo mainnet migró de op-geth a op-reth el 2026-07-22 ([forum post](https://forum.celo.org/t/13594)). op-reth valida `maxFee >= baseFee + priority` más estricto que op-geth y rechaza con "Missing or invalid parameters" cualquier request donde el max esté muy pegado al precio actual.

**El bug**: el path compartido de Celo L2 en `estimateFeesPerGas` calculaba `priority = eth_gasPrice(feeCurrency) - block.baseFeePerGas`. Esos dos números están **en unidades distintas** para CIP-64:

- `block.baseFeePerGas` está en CELO wei (nativo).
- `eth_gasPrice(feeCurrency)` está en unidades de la fee currency.

La resta produce `priority ≈ gasPrice(fc)`, dejando `maxFee` a solo 2-3% del precio actual. op-geth toleraba; op-reth rechaza.

Observado en vivo el 2026-07-26 con `feeCurrency=COPm`:
```
maxFeePerGas:        47,471,822,740,439
maxPriorityFeePerGas: 46,321,394,843,568
headroom for base:    1,150,427,896,871  (2.4% - insuficiente)
```

## Cambios

**`src/viem/estimateFeesPerGas.ts`**:
- Nueva función `estimateCip64FeesPerGas` cuando `feeCurrency` está definida.
- Usa `eth_gasPrice(feeCurrency)` como única fuente autoritativa (unidades coherentes, no mezcla).
- Envelope amplio:
  - `maxFeePerGas = gasPrice(fc) * 2` (100% headroom)
  - `maxPriorityFeePerGas = gasPrice(fc) / 4` (25% del precio actual)
  - `baseFeePerGas = gasPrice(fc) - priority` (para display en UI)
- El path nativo (sin feeCurrency) queda igual, sin cambios.

**`src/viem/estimateFeesPerGas.test.ts`**:
- Test del caso CIP-64 actualizado para las nuevas invariantes (baseFee del block header NO puede filtrarse al resultado; maxFee debe superar baseFee + priority en unidades de fee-currency).

## Impacto

- **Runtime**: transacciones con fee currency (COPm, USDT, USDC, USDm, etc.) dejan de fallar intermitentemente con "Missing or invalid parameters" cuando el base fee de la currency se mueve.
- **Sin over-charge**: el usuario NUNCA paga más que `realBaseFee + priority`, independiente de maxFee. Un ceiling generoso solo sirve para que la tx no se rechace en el input validation.
- **Complementa el fallback de approve** ([PR #285](https://github.com/TuCopFinance/TuCopWallet/pull/285) commit 7): ese fallback sigue vivo como red de contención si op-reth cambia otra vez las reglas y este fix también cae.
- Path nativo (sin feeCurrency) sin cambios.

## Verificación

- `yarn build:ts` verde (exit 0).
- `yarn jest src/viem/estimateFeesPerGas.test.ts` 8/8 pass.
- `yarn jest src/viem/prepareTransactions.test.ts` 58/58 pass (downstream sin regresiones).

## Test plan

- [ ] Compra Gold con feeCurrency COPm — no falla con "Missing or invalid parameters" incluso con ventanas de tráfico.
- [ ] Swap USDT -> COPm con fee currency USDT — completa normalmente.
- [ ] Cualquier flow que usa CIP-64 (Neeru deposit, Squid swap, jumpstart send con USDT como fee) — ninguno regresa.

## Base

Contra `Development` (post merge de #285). Self-contained.