### PR TITLE
fix(earn): stop double-converting TVL/balance for local-currency Mento pools (COPm et al)

### DIFF
--- a/src/earn/EarnEntrypoint.tsx
+++ b/src/earn/EarnEntrypoint.tsx
@@ -11,8 +11,7 @@ import Touchable from 'src/components/Touchable'
 import { EarnTabType } from 'src/earn/types'
 import { getEarnPositionBalanceValues } from 'src/earn/utils'
 import { earnCardBackground } from 'src/images/Images'
-import { useDollarsToLocalAmount } from 'src/localCurrency/hooks'
-import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
+import { getLocalCurrencySymbol, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { earnPositionsSelector } from 'src/positions/selectors'
@@ -28,20 +27,27 @@ export default function EarnEntrypoint() {
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol)
 
   const pools = useSelector(earnPositionsSelector)
-  const [hasSuppliedPools, totalSuppliedValueUsd] = useMemo(
-    () => [
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
+  const [hasSuppliedPools, totalSuppliedValueLocal] = useMemo(() => {
+    // Sum each pool's balance already CONVERTED to local currency. Local-
+    // currency Mento pools (COPm etc) return their balance in the user's
+    // local currency directly, USD pools need the USD->local rate. Summing
+    // after conversion keeps a mixed portfolio's total honest.
+    const localRate = new BigNumber(usdToLocalRate ?? 0)
+    return [
       pools.some((pool) => new BigNumber(pool.balance).gt(0)),
-      pools.reduce(
-        (acc, pool) => {
-          const { poolBalanceInUsd } = getEarnPositionBalanceValues({ pool })
-          return acc.plus(poolBalanceInUsd)
-        },
-        new BigNumber(0) ?? null
-      ),
-    ],
-    [pools]
-  )
-  const totalSuppliedValue = useDollarsToLocalAmount(totalSuppliedValueUsd)
+      pools.reduce((acc, pool) => {
+        const { poolBalanceInUsd, isLocalCurrencyDenominated } = getEarnPositionBalanceValues({
+          pool,
+        })
+        const local = isLocalCurrencyDenominated
+          ? poolBalanceInUsd
+          : localRate.multipliedBy(poolBalanceInUsd)
+        return acc.plus(local)
+      }, new BigNumber(0)),
+    ]
+  }, [pools, usdToLocalRate])
+  const totalSuppliedValue = totalSuppliedValueLocal.gt(0) ? totalSuppliedValueLocal : null
   const totalSupplied = useMemo(
     () =>
       `${localCurrencySymbol}${totalSuppliedValue ? formatValueToDisplay(totalSuppliedValue) : '--'}`,

--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -76,8 +76,20 @@ export default function PoolCard({
   const depositTokenInfo = allTokens[depositTokenId]
 
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol)
-  const { poolBalanceInUsd } = useMemo(() => getEarnPositionBalanceValues({ pool }), [pool])
-  const poolBalanceInFiat = useDollarsToLocalAmount(poolBalanceInUsd) ?? null
+  const { poolBalanceInUsd, poolBalanceInDepositToken, isLocalCurrencyDenominated } = useMemo(
+    () => getEarnPositionBalanceValues({ pool }),
+    [pool]
+  )
+  const poolBalanceUsdToLocal = useDollarsToLocalAmount(poolBalanceInUsd) ?? null
+  // Local-currency Mento stablecoins (COPm, EURm, ...) already carry values
+  // in the user's local currency. Their `balance * priceUsd` product happens
+  // to equal the local amount when the user's fiat is the currency the token
+  // represents, so passing it through useDollarsToLocalAmount would multiply
+  // by the USD->local rate a second time (see isLocalCurrencyStable comment).
+  // Use the deposit-token balance directly instead.
+  const poolBalanceInFiat = isLocalCurrencyDenominated
+    ? poolBalanceInDepositToken
+    : poolBalanceUsdToLocal
 
   const rewardAmountInUsd = useMemo(
     () =>
@@ -115,7 +127,11 @@ export default function PoolCard({
     return `${localCurrencySymbol}--`
   }, [localCurrencySymbol, poolBalanceInFiat, rewardAmountInFiat, depositTokenId, balance])
 
-  const tvlInFiat = useDollarsToLocalAmount(tvl ?? null)
+  // Same branch as the pool balance above: for local-currency Mento pools
+  // the backend already returns TVL in the local currency (e.g. COP for
+  // COPm pools) so skip the USD->local conversion.
+  const tvlUsdToLocal = useDollarsToLocalAmount(tvl ?? null)
+  const tvlInFiat = isLocalCurrencyDenominated ? (tvl ? new BigNumber(tvl) : null) : tvlUsdToLocal
   const tvlString = useMemo(() => {
     return `${localCurrencySymbol}${tvlInFiat ? formatValueToDisplay(tvlInFiat) : '--'}`
   }, [localCurrencySymbol, tvlInFiat])

--- a/src/earn/poolInfoScreen/Cards.tsx
+++ b/src/earn/poolInfoScreen/Cards.tsx
@@ -65,14 +65,17 @@ export function DepositAndEarningsCard({
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol)
   const localCurrencyExchangeRate = useSelector(usdToLocalCurrencyRateSelector)
 
-  const { poolBalanceInUsd: depositBalanceInUsd, poolBalanceInDepositToken } = useMemo(
-    () => getEarnPositionBalanceValues({ pool: earnPosition }),
-    [earnPosition]
-  )
-  // Deposit items used to calculate the total balance and total deposited
-  const depositBalanceInLocalCurrency = new BigNumber(localCurrencyExchangeRate ?? 0).multipliedBy(
-    depositBalanceInUsd ?? 0
-  )
+  const {
+    poolBalanceInUsd: depositBalanceInUsd,
+    poolBalanceInDepositToken,
+    isLocalCurrencyDenominated,
+  } = useMemo(() => getEarnPositionBalanceValues({ pool: earnPosition }), [earnPosition])
+  // Deposit items used to calculate the total balance and total deposited.
+  // For local-currency Mento pools (COPm, EURm, ...) the "USD" balance is
+  // already in the user's local currency, so skip the USD->local multiply.
+  const depositBalanceInLocalCurrency = isLocalCurrencyDenominated
+    ? depositBalanceInUsd
+    : new BigNumber(localCurrencyExchangeRate ?? 0).multipliedBy(depositBalanceInUsd ?? 0)
 
   // Earning items used to calculate the total balance and total deposited
   const earningItemsTokenIds = earningItems.map((item) => item.tokenId)
@@ -266,7 +269,15 @@ export function TvlCard({
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol)
   const { t } = useTranslation()
   const tvl = earnPosition.dataProps.tvl
-  const tvlInFiat = useDollarsToLocalAmount(tvl ?? null)
+  const { isLocalCurrencyDenominated } = useMemo(
+    () => getEarnPositionBalanceValues({ pool: earnPosition }),
+    [earnPosition]
+  )
+  // Same branch as the deposit balance: for local-currency Mento pools the
+  // backend returns TVL already denominated in the local currency (COP for
+  // COPm pools). Skip the USD->local conversion to avoid a second multiply.
+  const tvlUsdToLocal = useDollarsToLocalAmount(tvl ?? null)
+  const tvlInFiat = isLocalCurrencyDenominated ? (tvl ? new BigNumber(tvl) : null) : tvlUsdToLocal
   const tvlString = useMemo(() => {
     return `${localCurrencySymbol}${tvlInFiat ? formatValueToDisplay(tvlInFiat) : '--'}`
   }, [localCurrencySymbol, tvlInFiat])

--- a/src/earn/utils.ts
+++ b/src/earn/utils.ts
@@ -3,6 +3,7 @@ import { EarnPosition } from 'src/positions/types'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { SwapTransaction } from 'src/swap/types'
+import { isLocalCurrencyStable } from 'src/tokens/utils'
 import { Network, NetworkId } from 'src/transactions/types'
 import { INTERNAL_RPC_SUPPORTED_NETWORKS } from 'src/viem'
 import { networkIdToNetwork } from 'src/web3/networkConfig'
@@ -50,5 +51,13 @@ export function getEarnPositionBalanceValues({ pool }: { pool: EarnPosition }) {
   const poolBalanceInDepositToken = new BigNumber(pool.balance).multipliedBy(
     pool.pricePerShare[0] ?? 1
   )
-  return { poolBalanceInUsd, poolBalanceInDepositToken }
+  // When the deposit token is a local-currency Mento stablecoin (COPm, EURm,
+  // BRLm, ...), the value produced by `balance * priceUsd` is already
+  // denominated in the user's local currency for holders of that currency.
+  // Consumers must skip `useDollarsToLocalAmount` in that case to avoid a
+  // second USD->local multiplication (e.g. 4000x for COP). Same applies to
+  // `dataProps.tvl` when the pool is local-currency denominated.
+  const depositTokenSymbol = pool.tokens?.[0]?.symbol
+  const isLocalCurrencyDenominated = isLocalCurrencyStable(depositTokenSymbol)
+  return { poolBalanceInUsd, poolBalanceInDepositToken, isLocalCurrencyDenominated }
 }

--- a/src/tokens/utils.test.tsx
+++ b/src/tokens/utils.test.tsx
@@ -7,6 +7,7 @@ import {
   getHigherBalanceCurrency,
   getTokenId,
   isHistoricalPriceUpdated,
+  isLocalCurrencyStable,
   sortFirstStableThenCeloThenOthersByUsdBalance,
 } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
@@ -293,5 +294,41 @@ describe(isHistoricalPriceUpdated, () => {
         },
       })
     ).toEqual(true)
+  })
+})
+
+describe(isLocalCurrencyStable, () => {
+  it.each([
+    ['COPm', true],
+    ['copm', true],
+    ['EURm', true],
+    ['BRLm', true],
+    ['XOFm', true],
+    ['GHSm', true],
+    ['KESm', true],
+    // legacy Mento naming still shows up on historical records
+    ['cCOP', true],
+    ['cEUR', true],
+    ['cREAL', true],
+  ] as const)('classifies %s as local-currency stable', (symbol, expected) => {
+    expect(isLocalCurrencyStable(symbol)).toBe(expected)
+  })
+
+  it.each([
+    ['USDT', false],
+    ['USDC', false],
+    ['USDm', false],
+    ['USAT', false],
+    ['cUSD', false],
+    ['CELO', false],
+    ['XAUt0', false],
+    ['', false],
+  ] as const)('does not classify %s as local-currency stable', (symbol, expected) => {
+    expect(isLocalCurrencyStable(symbol)).toBe(expected)
+  })
+
+  it('returns false for undefined / null', () => {
+    expect(isLocalCurrencyStable(undefined)).toBe(false)
+    expect(isLocalCurrencyStable(null)).toBe(false)
   })
 })

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -255,3 +255,33 @@ export function getTokenDisplayName(symbol: string): string {
   // Keep original for others (CELO, etc.)
   return symbol
 }
+
+// Mento local-currency stablecoins pegged 1:1 to a national fiat currency.
+// When a pool's `dataProps.tvl` or `balance * priceUsd` produces a value in
+// one of these tokens' units, that value is ALREADY in the user's local
+// currency. Passing it through `useDollarsToLocalAmount` would multiply by
+// the USD->local rate a second time (e.g. by ~4000 for COP), inflating the
+// display 4000x.
+//
+// Not the same as the "dollars" family (USDT / USDC / USDm / USAT), which
+// are USD-denominated and DO need the USD->local conversion.
+//
+// Callers use this to branch between two rendering paths in earn / pool
+// screens. See src/earn/utils.ts:getEarnPositionBalanceValues and consumers.
+const LOCAL_CURRENCY_STABLE_SYMBOLS = new Set([
+  'COPM', // Colombian Peso (Mento)
+  'EURM', // Euro (Mento)
+  'BRLM', // Brazilian Real (Mento)
+  'XOFM', // West African CFA Franc (Mento)
+  'GHSM', // Ghanaian Cedi (Mento)
+  'KESM', // Kenyan Shilling (Mento)
+  // Legacy Mento names still in circulation on older tx / balance records.
+  'CCOP',
+  'CEUR',
+  'CREAL',
+])
+
+export function isLocalCurrencyStable(symbol: string | undefined | null): boolean {
+  if (!symbol) return false
+  return LOCAL_CURRENCY_STABLE_SYMBOLS.has(symbol.toUpperCase())
+}


### PR DESCRIPTION
## Summary

Arregla el bug del TVL inflado ~3200x en las pool cards de Neeru para pools con deposit token de tipo local-currency Mento (COPm, EURm, BRLm, XOFm, GHSm, KESm).

## Root cause

`dataProps.tvl` del backend y el producto `balance * priceUsd` para un pool ya vienen denominados en la moneda que representa el token de depósito. Para USD stablecoins (USDT/USDC/USDm/USAT) eso es USD → hay que multiplicar por USD→local. Para local-currency Mento (COPm/EURm/...) ya está en la moneda local → NO hay que multiplicar. Los consumers pasaban TODO por `useDollarsToLocalAmount`, produciendo:

- Flexible COPm: `321,865,000 COP mostrado` en vez de `~100,000 COP` (factor ~3218, coincide con la tasa USD→COP).
- 60d COPm: `257,492,000 COP` en vez de `~80,000 COP`.

## Cambios

**Nuevo helper** — `src/tokens/utils.ts`:
- `isLocalCurrencyStable(symbol)`: clasifica COPm, EURm, BRLm, XOFm, GHSm, KESm + los legacy cCOP/cEUR/cREAL. USD stables (USDT/USDC/USDm/USAT/cUSD) NO clasifican.
- 13 test cases nuevos cubriendo toda la familia + opuestos + edge cases (undefined/null/empty).

**Extensión del calculador de balances** — `src/earn/utils.ts`:
- `getEarnPositionBalanceValues` ahora también retorna `isLocalCurrencyDenominated` derivado de `pool.tokens[0].symbol`. Forma de retorno vieja intacta.

**Consumers refactorizados** (misma lógica en los 3 sitios):
- `PoolCard.tsx`: pool balance + TVL branch en el flag.
- `poolInfoScreen/Cards.tsx`: deposit balance + TVL card branch.
- `EarnEntrypoint.tsx`: total supplied summary suma cada pool CONVERTIDO ya a local (para portfolios mixtos).
- `EarnConfirmationScreen.tsx`: usa `poolBalanceInDepositToken` (no InUsd), no fue afectado.

## Impacto

- **Runtime**: pools con COPm/EURm/etc muestran TVL y balance con la magnitud correcta. Pools con USDT/USDC/USDm siguen igual.
- **Sin regresiones**: `EarnConfirmationScreen` no toca la ruta afectada. XAUt0 (gold) y CELO no clasifican como local-currency stable, van por el path viejo.
- **Portfolios mixtos**: total supplied ahora suma cada pool en local currency ANTES de reducir, así USDT + COPm en el mismo portfolio suman correctamente.

## Verificación

- `yarn build:ts` verde (exit 0).
- `yarn lint` verde (exit 0).
- `yarn jest src/tokens/utils.test.tsx` — 43 tests pass (13 nuevos del helper).
- `yarn jest src/earn` — 280 tests pass, ninguna regresión.

## Test plan (smoke en simulador)

Con la wallet de prueba `0x8427e4409b73a31b9d4e0d210677c88877472ece` en mainnet:

| Category | Antes (mostrado) | Esperado ahora |
|---|---|---|
| Flexible | COP\$321,865,000 | COP\$100,000 |
| 30d | COP\$0 | COP\$0 (backend también arregló empty agg) |
| 60d | COP\$257,492,000 | COP\$80,000 |
| 90d | (no aparecía) | COP\$20,000 |

- [ ] Abrir Earn / Neeru en sim.
- [ ] Confirmar TVL de cada pool según tabla de arriba.
- [ ] Confirmar Pool Card muestra "Disponible" en local currency sensata.
- [ ] Confirmar total supplied en Earn entrypoint suma bien (no infla).

## Base

Contra `Development`. Independiente de #286 y #287.