### PR TITLE
chore(ci): expose SENTRY_AUTH_TOKEN + SENTRY_CLIENT_URL to postinstall

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,9 @@ jobs:
           build-tools: 35.0.0
 
       - name: Install dependencies
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_CLIENT_URL: ${{ secrets.SENTRY_CLIENT_URL }}
         run: |
           yarn install --frozen-lockfile
           yarn postinstall
@@ -127,6 +130,10 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn postinstall
+        env:
+          # See build-android/Install dependencies for rationale.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_CLIENT_URL: ${{ secrets.SENTRY_CLIENT_URL }}
 
       - name: Setup environment
         run: cp .env.mainnet .env


### PR DESCRIPTION
## Summary

Cierra el gap del PR #285 en CI: el postinstall corre `populate_secrets.sh`, que lee env vars cuando no hay Keychain (o sea, en GitHub Actions). Sin este PR, CI ejecutaba el script y warneaba silenciosamente porque las env vars no existían, dejando `auth.token` y `SENTRY_CLIENT_URL` vacíos.

## Cambios

**`.github/workflows/build.yml`** — 2 bloques `env:` iguales, uno por job:

- `build-android` step "Install dependencies"
- `build-ios` step "Install dependencies"

Ambos expone `SENTRY_AUTH_TOKEN` y `SENTRY_CLIENT_URL` desde repo secrets.

## Repo secrets

Ya seteados en https://github.com/TuCopFinance/TuCopWallet/settings/secrets/actions:

- `SENTRY_AUTH_TOKEN` — Org Auth Token (sntrys_) con scope org:ci
- `SENTRY_CLIENT_URL` — DSN de proyecto tucopwallet

## Impacto

- **Android release build**: sentry.gradle plugin (activado en #285) sube sourcemaps con auth token real. Antes: intento fallido silencioso.
- **iOS release build**: xcode debug files phase sube sourcemaps/dSYMs con auth token real. Igual.
- **App shippeada**: `secrets.json` embebe el DSN real, runtime reporta errores a Sentry. Antes: DSN vacío = app muda.

## Sin regresiones

- Solo agrega env vars a 2 pasos existentes. No cambia comandos ni order de ejecución.
- Si un secreto no existiera (deshabilitado en repo), populate_secrets.sh sigue con warn y no falla el build.

## Test plan

- [ ] Merge y dispararlo con `workflow_dispatch` desde Actions tab.
- [ ] Confirmar en logs del step "Install dependencies" que NO aparece el WARN "sentry auth token not found".
- [ ] Confirmar en logs del "Build Android Bundle" que sentry-cli sube sourcemaps sin 401/403.
- [ ] Después de que se cree el release en la próxima build de main, verificar en Sentry > Releases que aparece la versión + artifacts.