### PR TITLE
feat(gold): Sentry telemetry + circuit-breaker detection on price fetch

### DIFF
--- a/src/gold/api.test.ts
+++ b/src/gold/api.test.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/react-native'
+import { captureBusinessError } from 'src/sentry/captureBusinessError'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -5,7 +7,28 @@ jest.mock('src/utils/fetchWithTimeout', () => ({
   fetchWithTimeout: jest.fn(),
 }))
 
+jest.mock('src/sentry/captureBusinessError', () => ({
+  captureBusinessError: jest.fn(),
+}))
+
+jest.mock('@sentry/react-native', () => ({
+  setTag: jest.fn(),
+}))
+
+// SENTRY_ENABLED is read via `import { SENTRY_ENABLED } from 'src/config'`
+// and defaults to false in test env. Force it on so tagPriceSource fires,
+// but preserve the rest of the config module so downstream imports (e.g.
+// networkConfig) keep resolving the real values they need.
+jest.mock('src/config', () => ({
+  ...jest.requireActual('src/config'),
+  SENTRY_ENABLED: true,
+}))
+
 const mockFetchWithTimeout = fetchWithTimeout as jest.MockedFunction<typeof fetchWithTimeout>
+const mockCaptureBusinessError = captureBusinessError as jest.MockedFunction<
+  typeof captureBusinessError
+>
+const mockSetTag = Sentry.setTag as jest.MockedFunction<typeof Sentry.setTag>
 
 function jsonResponse(body: object, ok = true, status = 200): Response {
   return {
@@ -32,6 +55,8 @@ function loadApi(): ApiModule {
 
 beforeEach(() => {
   mockFetchWithTimeout.mockReset()
+  mockCaptureBusinessError.mockReset()
+  mockSetTag.mockReset()
 })
 
 describe('gold/api', () => {
@@ -102,5 +127,102 @@ describe('gold/api', () => {
   it('uses the URL configured on networkConfig', () => {
     expect(networkConfig.getXautPriceUrl).toMatch(/^https:\/\/.+\/api\/prices\/xaut\?vs=usd$/)
     expect(networkConfig.blockscoutProxyBase).toMatch(/^https:\/\/.+\/api\/v2$/)
+  })
+
+  describe('Sentry telemetry', () => {
+    it('tags gold_price_source=backend on primary success', async () => {
+      mockFetchWithTimeout.mockResolvedValueOnce(
+        jsonResponse({ symbol: 'XAUT0', vs: 'usd', priceUsd: 3210, asOf: 'x' })
+      )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      await fetchGoldPriceFromApi()
+
+      expect(mockSetTag).toHaveBeenCalledWith('gold_price_source', 'backend')
+      expect(mockCaptureBusinessError).not.toHaveBeenCalled()
+    })
+
+    it('tags gold_price_source=dia_data on fallback success', async () => {
+      mockFetchWithTimeout
+        .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, false, 502))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            Symbol: 'XAUT',
+            Name: 'Tether Gold',
+            Price: 3100,
+            PriceYesterday: 3000,
+            Time: 'x',
+          })
+        )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      await fetchGoldPriceFromApi()
+
+      expect(mockSetTag).toHaveBeenCalledWith('gold_price_source', 'dia_data')
+    })
+
+    it('tags gold_price_source=fallback_hardcoded when all APIs fail', async () => {
+      mockFetchWithTimeout
+        .mockResolvedValueOnce(jsonResponse({}, false, 500))
+        .mockResolvedValueOnce(jsonResponse({}, false, 500))
+
+      const { fetchGoldPriceWithFallback } = loadApi()
+      await fetchGoldPriceWithFallback()
+
+      expect(mockSetTag).toHaveBeenCalledWith('gold_price_source', 'fallback_hardcoded')
+    })
+
+    it('captures a business error with the classified HTTP error code when backend returns 5xx', async () => {
+      mockFetchWithTimeout
+        .mockResolvedValueOnce(jsonResponse({}, false, 502))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            Symbol: 'XAUT',
+            Name: 'Tether Gold',
+            Price: 3100,
+            PriceYesterday: 3000,
+            Time: 'x',
+          })
+        )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      await fetchGoldPriceFromApi()
+
+      expect(mockCaptureBusinessError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          feature: 'transactions',
+          provider: 'internal',
+          action: 'fetch_gold_price_backend',
+        })
+      )
+    })
+
+    it('tags errorCode=circuit_open when the wallet circuit breaker short-circuits the request', async () => {
+      // The circuit breaker in fetchWithTimeout returns a synthetic 503 whose
+      // statusText contains 'Service Unavailable (circuit open)'. The code
+      // path throws with that message included when response.ok is false.
+      mockFetchWithTimeout.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'Service Unavailable (circuit open)',
+      } as unknown as Response)
+      // DIA also short-circuits (unlikely but exercises both branches)
+      mockFetchWithTimeout.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'ok',
+        json: async () => ({}),
+      } as unknown as Response)
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      await expect(fetchGoldPriceFromApi()).rejects.toThrow('All XAUt price APIs failed')
+
+      const backendCall = mockCaptureBusinessError.mock.calls.find(
+        ([, ctx]) => ctx.action === 'fetch_gold_price_backend'
+      )
+      expect(backendCall).toBeDefined()
+      expect(backendCall![1].errorCode).toBe('circuit_open')
+    })
   })
 })

--- a/src/gold/api.ts
+++ b/src/gold/api.ts
@@ -1,4 +1,8 @@
+import * as Sentry from '@sentry/react-native'
+import { SENTRY_ENABLED } from 'src/config'
 import { GoldPriceData } from 'src/gold/types'
+import { captureBusinessError } from 'src/sentry/captureBusinessError'
+import { classifyHttpError } from 'src/sentry/classifyHttpError'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import Logger from 'src/utils/Logger'
 import networkConfig from 'src/web3/networkConfig'
@@ -41,6 +45,33 @@ export interface DiaAssetQuotationResponse {
   Price: number
   PriceYesterday: number
   Time: string
+}
+
+// The wallet's per-host circuit breaker (see src/lib/circuitBreaker) short-
+// circuits requests to a synthetic Response with this exact statusText once
+// FAILURE_THRESHOLD failures accumulate within FAILURE_WINDOW_MS for the
+// same host. When that happens, the fetch never actually leaves the device
+// and backend logs will show ZERO requests during the outage window.
+// Distinguishing this from a real upstream 5xx unblocks the debugging loop
+// with backend: they only need to look at their logs if this bucket is NOT
+// what fired.
+const CIRCUIT_OPEN_MARKER = 'Service Unavailable (circuit open)'
+
+function isCircuitBreakerError(error: unknown): boolean {
+  if (!error) return false
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes(CIRCUIT_OPEN_MARKER)
+}
+
+// Emits an operational signal to Sentry naming which of the three sources
+// finally produced the price the app is showing. Backend can dashboard the
+// `fallback_hardcoded` rate as a proxy for "how often is our price feed
+// degraded end-to-end". Mirrors the neeru_meta_source pattern.
+type GoldPriceSource = 'backend' | 'dia_data' | 'fallback_hardcoded'
+
+function tagPriceSource(source: GoldPriceSource): void {
+  if (!SENTRY_ENABLED) return
+  Sentry.setTag('gold_price_source', source)
 }
 
 /**
@@ -132,20 +163,38 @@ export async function fetchGoldPriceFromApi(): Promise<GoldPriceData> {
   try {
     const priceData = await fetchFromTucopBackend()
     cachedGoldPrice = priceData
+    tagPriceSource('backend')
     Logger.debug(TAG, 'Got XAUt price from TuCop backend', { price: priceData.priceUsd })
     return priceData
   } catch (primaryError: any) {
     Logger.warn(TAG, 'TuCop backend failed, trying DIA fallback', primaryError.message)
+    captureBusinessError(primaryError, {
+      feature: 'transactions',
+      provider: 'internal',
+      action: 'fetch_gold_price_backend',
+      errorCode: isCircuitBreakerError(primaryError)
+        ? 'circuit_open'
+        : classifyHttpError(primaryError),
+    })
   }
 
   // Fallback to DIA Data
   try {
     const priceData = await fetchFromDiaApi()
     cachedGoldPrice = priceData
+    tagPriceSource('dia_data')
     Logger.debug(TAG, 'Got XAUt price from DIA', { price: priceData.priceUsd })
     return priceData
   } catch (fallbackError: any) {
     Logger.error(TAG, 'DIA API also failed', fallbackError.message)
+    captureBusinessError(fallbackError, {
+      feature: 'transactions',
+      provider: 'internal',
+      action: 'fetch_gold_price_dia',
+      errorCode: isCircuitBreakerError(fallbackError)
+        ? 'circuit_open'
+        : classifyHttpError(fallbackError),
+    })
     throw new Error('All XAUt price APIs failed')
   }
 }
@@ -160,14 +209,18 @@ export async function fetchGoldPriceWithFallback(): Promise<GoldPriceData> {
   } catch (error: any) {
     Logger.warn(TAG, 'All APIs failed, using fallback', error.message)
 
-    // Return cached price if available
+    // Return cached price if available. Tag the source as fallback_hardcoded
+    // regardless of whether we hit stale cache vs the constant, because from
+    // the user's perspective both are "degraded" states worth counting.
     if (cachedGoldPrice) {
       Logger.debug(TAG, 'Returning stale cached price')
+      tagPriceSource('fallback_hardcoded')
       return cachedGoldPrice
     }
 
     // Return hardcoded fallback as last resort
     Logger.debug(TAG, 'Returning hardcoded fallback price')
+    tagPriceSource('fallback_hardcoded')
     return { ...FALLBACK_GOLD_PRICE, timestamp: Date.now() }
   }
 }


### PR DESCRIPTION
## Summary

Instrumenta el fetch del precio de oro con captureBusinessError y un tag `gold_price_source` (mirror de `neeru_meta_source`), incluyendo detección explícita del circuit breaker per-host del wallet.

## Contexto

Backend team pidió (2026-07-27) diagnosticar por qué los logs de Railway muestran **cero requests** durante las ventanas donde el wallet reporta fallback al precio hardcoded (\$3050). Las 3 hipótesis backend fueron descartadas al leer código del wallet:

- **Timeout < 500ms**: descartada. `FETCH_TIMEOUT_DURATION = 15000` en src/config.ts.
- **Wrong URL**: descartada. `GET_XAUT_PRICE_URL` apunta al proxy correcto.
- **CMC upstream 48h**: posible, no verificable sin captura.

**Hipótesis nueva (client-side)**: el wallet tiene un circuit breaker per-host en `src/lib/circuitBreaker/circuitBreaker.ts`: 5 fallas en 60s abren el breaker durante 30s. Cuando abre, `fetchWithTimeout` retorna una `Response` sintética con `statusText: 'Service Unavailable (circuit open)'` **sin llegar al servidor**. Si requests a otros paths del mismo host (positions, hooks-api, tx/status) queman el budget, `/api/prices/xaut` recibe el 503 sintético y dispara el fallback hardcoded.

**Explica exactamente lo que backend reporta**: 0 requests en logs + wallet reportando fallo.

## Cambios

**`src/gold/api.ts`**:

- Helper `isCircuitBreakerError(err)`: detecta si el mensaje del error contiene `CIRCUIT_OPEN_MARKER` (literal exacto que genera el circuit breaker).
- 2 llamadas nuevas a `captureBusinessError` en los catch de primary (backend) y fallback (DIA):
  ```
  feature: 'transactions'
  provider: 'internal'
  action:   'fetch_gold_price_backend' | 'fetch_gold_price_dia'
  errorCode: 'circuit_open' (si breaker) | classifyHttpError(error) (network_error / timeout / http_5xx / etc)
  ```
- Helper `tagPriceSource(source)`: `Sentry.setTag('gold_price_source', ...)` con 3 valores:
  - `'backend'` en éxito primary
  - `'dia_data'` en éxito fallback
  - `'fallback_hardcoded'` cuando se usa cache stale o el constante \$3050

**`src/gold/api.test.ts`**:
- 5 tests nuevos: tag por cada source, captureBusinessError con la shape esperada, detección del `circuit_open` marker.
- Suite ahora en 10 tests, 100% pass.

## Impacto

- **Runtime**: cero cambios en el flujo funcional. Solo agrega side-effects de observabilidad detrás del guard `SENTRY_ENABLED`.
- **Backend**: puede dashboardear `errorCode:circuit_open` para saber cuándo el fallo fue client-side (no debe revisar sus logs) vs cuándo fue upstream real (sí debe revisar).
- **Producto**: `gold_price_source:fallback_hardcoded` es proxy directo de "cuán degradado está el precio de oro end-to-end". Alerta base.
- **Sin cambios en circuit breaker thresholds, timeouts, URL, retry policy** — todos correctos según diagnóstico.

## Test plan (post-merge, con Sentry ya habilitado)

- [ ] Reload en simulador; forzar caída del backend gold price (bloquear el hostname en Charles / matar Railway container). Verificar en Sentry:
  - Issue con `errorCode:http_5xx` (o `network_error`) y `action:fetch_gold_price_backend`.
  - Tag `gold_price_source:dia_data` (fallback exitoso) o `fallback_hardcoded` si DIA también cae.
- [ ] Forzar 5+ failures rápidas al mismo host (curl + Metro reload). Verificar issue con `errorCode:circuit_open`.

## Sin dependencias

Independiente de #289 (CI secrets). Se puede mergear en cualquier orden.

## Followup opcional (NO en este PR)

Si backend shippea stale-cache con header `X-Stale`, agregar 10 LOC en `fetchFromTucopBackend` para taggear `gold_price_stale:true|false`.