### PR TITLE
chore(viem): document populate_secrets.sh and widen recoverable estimation error classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,66 @@ TuCOP Wallet is a React Native mobile application that provides digital wallet s
 ## Quick Start
 
 ```bash
-# 1. Clone and install
+# 1. Clone and install (postinstall auto-populates local secret files, see below)
 git clone https://github.com/TuCopFinance/TuCopWallet.git
 cd TuCopWallet
 nvm use 20.17.0
 yarn install
 
-# 2. Configure secrets
-cp secrets.json.template secrets.json
-# Edit secrets.json with your API keys
-
-# 3. Run on Android (mainnetdev)
+# 2. Run on Android (mainnetdev)
 yarn dev:android
 
-# 4. Run on iOS (mainnetdev)
+# 3. Run on iOS (mainnetdev)
 yarn dev:ios
 ```
 
 For detailed setup instructions, see [docs/guides/wallet-setup.md](docs/guides/wallet-setup.md).
+
+### Secret loading (`scripts/populate_secrets.sh`)
+
+`yarn install` runs the `populate_secrets.sh` postinstall hook which
+generates three gitignored files the build reads at compile time:
+
+- `ios/sentry.properties`
+- `android/sentry.properties`
+- `secrets.json`
+
+The script sources values from two places, in order:
+
+1. **Environment variables** (used by CI): `SENTRY_AUTH_TOKEN`,
+   `SENTRY_CLIENT_URL`.
+2. **macOS Keychain** (used by dev laptops): entries under
+   `acct=tucop-finance` with `svce=SENTRY_ORG_TOKEN` and
+   `svce=SENTRY_CLIENT_URL`.
+
+If neither is present the script warns and writes empty auth token +
+DSN. The app still builds, but runtime error reporting stays disabled
+and release builds cannot upload sourcemaps.
+
+**Dev setup on a fresh macOS**:
+
+```bash
+# One-time: store the Sentry token and DSN in the Keychain
+security add-generic-password -a tucop-finance -s SENTRY_ORG_TOKEN -w '<token>'
+security add-generic-password -a tucop-finance -s SENTRY_CLIENT_URL -w '<dsn>'
+# Then re-run:
+yarn postinstall
+```
+
+Ask a team lead for the current token/DSN values (or read them from a
+shared 1Password vault; do not commit them). The token should be an
+Organisation Auth Token created in Sentry Settings → Auth Tokens with
+scope `org:ci`.
+
+**CI**: `SENTRY_AUTH_TOKEN` and `SENTRY_CLIENT_URL` are set as
+repository secrets in
+[Actions → Secrets](https://github.com/TuCopFinance/TuCopWallet/settings/secrets/actions)
+and exported to the `Install dependencies` step of `.github/workflows/build.yml`.
+No manual per-run configuration is needed.
+
+This replaces the previous `yarn keys:decrypt` mechanism that depended
+on Valora's GCP KMS project (`celo-mobile-testnet`), which TuCOP does
+not have access to. See PR #285 for the migration rationale.
 
 ## Project Structure
 

--- a/src/viem/prepareTransactions.test.ts
+++ b/src/viem/prepareTransactions.test.ts
@@ -84,6 +84,17 @@ describe('prepareTransactions module', () => {
     ),
     {}
   )
+  // op-reth (Celo mainnet client from 2026-07-22) returns this catch-all
+  // wording for -32602 InvalidInputRpcError instead of op-geth's
+  // "gas required exceeds allowance". Also fires for CIP-64 fee-currency
+  // edge cases where op-reth is stricter than op-geth. Must still be
+  // classified as recoverable so the fee-currency cascade continues.
+  const mockOpRethInvalidInputRpcError = new EstimateGasExecutionError(
+    new InvalidInputRpcError(
+      new BaseError('test mock', { details: 'Missing or invalid parameters.' })
+    ),
+    {}
+  )
 
   const mockNativeFeeCurrency = {
     address: '0xfee1',
@@ -864,6 +875,24 @@ describe('prepareTransactions module', () => {
     })
     it('returns null if estimateGas throws InvalidInputRpcError with gas required exceeds allowance', async () => {
       mocked(estimateGas).mockRejectedValue(mockInvalidInputRpcError)
+      const baseTransaction: TransactionRequest = { from: '0x123' }
+      const estimateTransactionOutput = await tryEstimateTransaction({
+        client: mockPublicClient,
+        baseTransaction,
+        maxFeePerGas: BigInt(456),
+        feeCurrencySymbol: 'FEE',
+        feeCurrencyAddress: '0xabc',
+        maxPriorityFeePerGas: BigInt(789),
+        baseFeePerGas: BigInt(200),
+      })
+      expect(estimateTransactionOutput).toEqual(null)
+    })
+    it('returns null if estimateGas throws op-reth InvalidInputRpcError with Missing or invalid parameters', async () => {
+      // Verifies the widened classification: any InvalidInputRpcError is
+      // recoverable, not just op-geth's "gas required exceeds allowance"
+      // wording. If this ever throws again, the CIP-64 flow on Celo
+      // mainnet will regress the way it did before 2026-07-26.
+      mocked(estimateGas).mockRejectedValue(mockOpRethInvalidInputRpcError)
       const baseTransaction: TransactionRequest = { from: '0x123' }
       const estimateTransactionOutput = await tryEstimateTransaction({
         client: mockPublicClient,

--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -191,16 +191,42 @@ export async function tryEstimateTransaction({
       baseFeePerGas,
     })
   } catch (e) {
-    const isInsufficientFundsError =
+    // "Recoverable" here means: estimation failed for a reason we can
+    // handle by either substituting a hardcoded gas fallback (for well-
+    // known ERC-20 selectors below) or by returning null and letting the
+    // fee-currency cascade in tryEstimateTransactions try the next
+    // candidate. The alternative is `throw e` which bubbles up and
+    // presents to the user as an unclassified failure with a hung UI.
+    //
+    // Historically only "insufficient funds"-shaped errors were treated
+    // as recoverable. That class widened in practice:
+    //
+    //   1. InsufficientFundsError                                         (canonical)
+    //   2. ExecutionRevertedError with contract-emitted balance regex     (ERC-20)
+    //   3. InvalidInputRpcError with "gas required exceeds allowance"     (op-geth)
+    //   4. InvalidInputRpcError with "Missing or invalid parameters"      (op-reth, catch-all -32602)
+    //
+    // (4) is the op-reth wording for the same class op-geth surfaced as
+    // (3), plus for stricter CIP-64 fee-currency validation that op-reth
+    // added in the 2026-07-22 Celo mainnet migration. Rather than track
+    // every future wording variant with a regex, treat ALL
+    // InvalidInputRpcError sub-causes as recoverable. False positives are
+    // safe (they retry with the next fee currency or use the hardcoded
+    // ERC-20 fallback); false negatives (missing a valid recoverable
+    // shape) crash the flow, which is much worse.
+    //
+    // Observability: the return-null branch always emits a Logger.warn,
+    // and captureBusinessError fires in the downstream saga catches, so
+    // spikes in this fallback are still visible on Sentry.
+    const isRecoverableEstimationError =
       e instanceof EstimateGasExecutionError &&
       (e.cause instanceof InsufficientFundsError ||
-        (e.cause instanceof ExecutionRevertedError && // viem does not reliably label node errors as InsufficientFundsError when the user has enough to pay for the transfer, but not for the transfer + gas
+        (e.cause instanceof ExecutionRevertedError &&
           (/transfer value exceeded balance of sender/.test(e.cause.details) ||
             /transfer amount exceeds balance/.test(e.cause.details))) ||
-        (e.cause instanceof InvalidInputRpcError &&
-          /gas required exceeds allowance/.test(e.cause.details)))
+        e.cause instanceof InvalidInputRpcError)
 
-    if (isInsufficientFundsError) {
+    if (isRecoverableEstimationError) {
       // Gas estimation failed due to insufficient funds (or, for CIP-64 fee
       // currencies, a Celo Forno flake that surfaces the same class).
       // Standard ERC20 ops have well-known gas costs, so use a fallback


### PR DESCRIPTION
## Summary

Cierra dos deudas menores dejadas por la ronda reciente de Sentry / op-reth:

1. **README** — el postinstall ahora corre `populate_secrets.sh` (lo shipeamos en #285) pero el Quick Start seguía diciendo `cp secrets.json.template secrets.json`. Un dev nuevo clona el repo y no entiende por qué Sentry no reporta.
2. **`viem/prepareTransactions`** — la clasificación de errores "recoverable" (que dispara el fee-currency cascade) usaba una regex específica de op-geth (`gas required exceeds allowance`) que op-reth no matchea. En Celo mainnet post-2026-07-22 el error real es "Missing or invalid parameters" → falla, no matchea, `throw e` → app rompe.

## Cambios

**`README.md`**:
- Quick Start actualizado: quitado el paso manual `cp secrets.json.template`. Postinstall lo hace solo.
- Nueva subsección **Secret loading (`scripts/populate_secrets.sh`)** con:
  - Los 3 archivos que genera.
  - Los 2 orígenes (env vars en CI, Keychain en dev).
  - Los comandos exactos `security add-generic-password` para setear en Mac.
  - Nota sobre CI (secrets ya seteados en repo settings, link).
  - Referencia a #285 con el porqué de la migración.

**`src/viem/prepareTransactions.ts`**:
- Renombrado `isInsufficientFundsError` → `isRecoverableEstimationError` (nombre refleja semántica real).
- Widened classification: cualquier `InvalidInputRpcError` es recoverable, no solo el regex de op-geth. Comentario explica el rationale y el trade-off (false positives vs false negatives).

**`src/viem/prepareTransactions.test.ts`**:
- Nuevo `mockOpRethInvalidInputRpcError` con el wording exacto de op-reth.
- Nuevo test: `estimateGas throws op-reth InvalidInputRpcError with Missing or invalid parameters` → espera null (recoverable).
- Los 58 tests existentes siguen pasando. Total: **59/59 pass**.

## Impacto

- **README**: cero runtime, mejora onboarding.
- **Classification**: cualquier tx que en op-geth se recuperaba, en op-reth también. El comportamiento en op-reth converge al de op-geth para este edge case. False positive risk (mis-clasificar un error real como recoverable) es benign: retry con la siguiente fee currency o usa el fallback hardcodeado; Sentry sigue viendo el warn.
- **Sin regresiones**: todos los tests existentes verdes.

## Verificación

- `yarn build:ts` verde.
- `yarn lint` verde.
- `yarn jest src/viem/prepareTransactions.test.ts` — 59/59 pass.

## Test plan (post-merge)

- [ ] Simular caída de Forno con feeCurrency=COPm → verificar que la app no crashea ni queda hung en "Estimando...", debería caer al fallback de gas de approve (ya shipeado en #285).
- [ ] Verificar dev nuevo puede clonar + `yarn install` y arranca sin manualmente crear secrets.json.

## Sin dependencias

Base: `Development` (con #285-#290 mergeados). Self-contained.