### PR TITLE
feat(gold): consume backend X-Stale header for stale-cache telemetry

### DIFF
--- a/src/gold/api.test.ts
+++ b/src/gold/api.test.ts
@@ -30,12 +30,20 @@ const mockCaptureBusinessError = captureBusinessError as jest.MockedFunction<
 >
 const mockSetTag = Sentry.setTag as jest.MockedFunction<typeof Sentry.setTag>
 
-function jsonResponse(body: object, ok = true, status = 200): Response {
+function jsonResponse(
+  body: object,
+  ok = true,
+  status = 200,
+  headers: Record<string, string> = {}
+): Response {
   return {
     ok,
     status,
     json: async () => body,
     text: async () => JSON.stringify(body),
+    headers: {
+      get: (name: string) => headers[name] ?? null,
+    },
   } as unknown as Response
 }
 
@@ -196,6 +204,76 @@ describe('gold/api', () => {
           action: 'fetch_gold_price_backend',
         })
       )
+    })
+
+    it('surfaces X-Stale headers on the GoldPriceData when backend serves from stale cache', async () => {
+      mockFetchWithTimeout.mockResolvedValueOnce(
+        jsonResponse({ symbol: 'XAUT0', vs: 'usd', priceUsd: 3210, asOf: 'x' }, true, 200, {
+          'X-Stale': 'true',
+          'X-Stale-Age': '342',
+        })
+      )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      const result = await fetchGoldPriceFromApi()
+
+      expect(result.isStale).toBe(true)
+      expect(result.staleAgeSeconds).toBe(342)
+    })
+
+    it('leaves isStale unset when backend returns a fresh response (no X-Stale header)', async () => {
+      mockFetchWithTimeout.mockResolvedValueOnce(
+        jsonResponse({ symbol: 'XAUT0', vs: 'usd', priceUsd: 3210, asOf: 'x' })
+      )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      const result = await fetchGoldPriceFromApi()
+
+      expect(result.isStale).toBe(false)
+      expect(result.staleAgeSeconds).toBe(0)
+    })
+
+    it('tags gold_price_source=backend_stale + stale_age_bucket when backend serves from stale cache', async () => {
+      mockFetchWithTimeout.mockResolvedValueOnce(
+        jsonResponse(
+          { symbol: 'XAUT0', vs: 'usd', priceUsd: 3210, asOf: 'x' },
+          true,
+          200,
+          { 'X-Stale': 'true', 'X-Stale-Age': '342' } // 342s = 5m42s
+        )
+      )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      await fetchGoldPriceFromApi()
+
+      expect(mockSetTag).toHaveBeenCalledWith('gold_price_source', 'backend_stale')
+      // 342s falls in the 5-15min bucket (5*60=300 <= 342 < 15*60=900)
+      expect(mockSetTag).toHaveBeenCalledWith('gold_price_stale_age_bucket', '5-15min')
+      // Must NOT also tag the plain 'backend' variant (it's an either/or).
+      expect(mockSetTag).not.toHaveBeenCalledWith('gold_price_source', 'backend')
+    })
+
+    it.each([
+      [10, '<5min'],
+      [299, '<5min'],
+      [300, '5-15min'],
+      [899, '5-15min'],
+      [900, '15-60min'],
+      [3599, '15-60min'],
+      [3600, '>1h'],
+      [86400, '>1h'],
+    ] as const)('bucketizes staleAge=%is to %s', async (staleAgeSeconds, expectedBucket) => {
+      mockFetchWithTimeout.mockResolvedValueOnce(
+        jsonResponse({ symbol: 'XAUT0', vs: 'usd', priceUsd: 3210, asOf: 'x' }, true, 200, {
+          'X-Stale': 'true',
+          'X-Stale-Age': String(staleAgeSeconds),
+        })
+      )
+
+      const { fetchGoldPriceFromApi } = loadApi()
+      await fetchGoldPriceFromApi()
+
+      expect(mockSetTag).toHaveBeenCalledWith('gold_price_stale_age_bucket', expectedBucket)
     })
 
     it('tags errorCode=circuit_open when the wallet circuit breaker short-circuits the request', async () => {

--- a/src/gold/api.ts
+++ b/src/gold/api.ts
@@ -67,11 +67,28 @@ function isCircuitBreakerError(error: unknown): boolean {
 // finally produced the price the app is showing. Backend can dashboard the
 // `fallback_hardcoded` rate as a proxy for "how often is our price feed
 // degraded end-to-end". Mirrors the neeru_meta_source pattern.
-type GoldPriceSource = 'backend' | 'dia_data' | 'fallback_hardcoded'
+//
+// `backend_stale` is a sub-state of a successful backend fetch: the response
+// came from the 24h stale cache (upstream unreachable but backend still
+// served a recent-ish value). Counted separately from `backend` so backend
+// can alert on the ratio without losing "the fetch itself succeeded".
+type GoldPriceSource = 'backend' | 'backend_stale' | 'dia_data' | 'fallback_hardcoded'
 
 function tagPriceSource(source: GoldPriceSource): void {
   if (!SENTRY_ENABLED) return
   Sentry.setTag('gold_price_source', source)
+}
+
+// Bucketed age so Sentry aggregations do not explode into per-second
+// cardinality while still surfacing the operational shape: is the stale
+// cache serving fresh-ish reads or hours-old ones?
+type StaleAgeBucket = '<5min' | '5-15min' | '15-60min' | '>1h'
+
+function bucketizeStaleAge(seconds: number): StaleAgeBucket {
+  if (seconds < 5 * 60) return '<5min'
+  if (seconds < 15 * 60) return '5-15min'
+  if (seconds < 60 * 60) return '15-60min'
+  return '>1h'
 }
 
 /**
@@ -110,10 +127,18 @@ async function fetchFromTucopBackend(): Promise<GoldPriceData> {
     throw new Error('Invalid priceUsd in TuCop price proxy response')
   }
 
+  // Backend contract (shipped 2026-07-27): X-Stale + X-Stale-Age headers set
+  // when the response body came from the 24h stale cache instead of the
+  // fresh (60s TTL) upstream fetch. Absence of the header means fresh.
+  const isStale = response.headers.get('X-Stale') === 'true'
+  const staleAgeSeconds = isStale ? Number(response.headers.get('X-Stale-Age') ?? 0) : 0
+
   return {
     priceUsd: data.priceUsd,
     price24hChange: 0,
     timestamp: Date.now(),
+    isStale,
+    staleAgeSeconds,
   }
 }
 
@@ -163,8 +188,22 @@ export async function fetchGoldPriceFromApi(): Promise<GoldPriceData> {
   try {
     const priceData = await fetchFromTucopBackend()
     cachedGoldPrice = priceData
-    tagPriceSource('backend')
-    Logger.debug(TAG, 'Got XAUt price from TuCop backend', { price: priceData.priceUsd })
+    if (priceData.isStale) {
+      tagPriceSource('backend_stale')
+      if (SENTRY_ENABLED) {
+        Sentry.setTag(
+          'gold_price_stale_age_bucket',
+          bucketizeStaleAge(priceData.staleAgeSeconds ?? 0)
+        )
+      }
+    } else {
+      tagPriceSource('backend')
+    }
+    Logger.debug(TAG, 'Got XAUt price from TuCop backend', {
+      price: priceData.priceUsd,
+      isStale: priceData.isStale ?? false,
+      staleAgeSeconds: priceData.staleAgeSeconds ?? 0,
+    })
     return priceData
   } catch (primaryError: any) {
     Logger.warn(TAG, 'TuCop backend failed, trying DIA fallback', primaryError.message)

--- a/src/gold/types.ts
+++ b/src/gold/types.ts
@@ -22,6 +22,12 @@ export interface GoldPriceData {
   priceUsd: number // Price per troy ounce in USD
   price24hChange: number // Percentage change
   timestamp: number
+  // TuCop backend price proxy responds with X-Stale: true when the value was
+  // served from the 24h stale cache (upstream unreachable but a recent-ish
+  // price is available). Only set on backend responses; DIA and the
+  // hardcoded fallback leave both undefined.
+  isStale?: boolean
+  staleAgeSeconds?: number
 }
 
 export interface GoldSwapQuote {


### PR DESCRIPTION
## Summary

Cierra la vuelta al backend fix del 2026-07-27: `GET /api/prices/xaut?vs=usd` ahora tiene stale-cache fallback (24h TTL). El body no cambia, solo agrega headers cuando sirve desde stale. El wallet los consume y emite telemetría diferenciada a Sentry.

## Backend contract

- Fresh path (TTL 60s): sin headers extra.
- Stale path (24h TTL): agrega `X-Stale: true`, `X-Stale-Age: <sec>`, `Cache-Control: max-age=0, must-revalidate`.
- Si upstream falla Y stale también está vacío (Redis cold): 502, igual que antes.

## Cambios

**`src/gold/types.ts`**:
- `GoldPriceData` gana `isStale?: boolean` + `staleAgeSeconds?: number`. Opcionales — DIA y hardcoded los dejan undefined.

**`src/gold/api.ts`**:
- `fetchFromTucopBackend()` lee los headers y propaga en el return.
- `fetchGoldPriceFromApi()` branch en `priceData.isStale`:
  - Fresh: tag `gold_price_source = backend` (sin cambio).
  - Stale: tag `gold_price_source = backend_stale` + `gold_price_stale_age_bucket = <bucket>`.
- Nuevo helper `bucketizeStaleAge(sec)` → `'<5min' | '5-15min' | '15-60min' | '>1h'`. Bucketizado para no explotar cardinality en Sentry.
- Nueva variant en el union `GoldPriceSource`: `'backend_stale'`.

**`src/gold/api.test.ts`**:
- 11 tests nuevos (3 header-propagation, 8 bucketize edges cubriendo cada threshold).
- Total 21/21 pass.

## Impacto

- **Runtime**: cero cambios funcionales. Solo lee headers adicionales y agrega tags Sentry.
- **Backend**: dashboards pueden separar `backend` (fresh, salud OK) de `backend_stale` (upstream degradado pero servimos algo reciente). El bucket de edad indica si el stale es fresco (~min) o horas viejo.
- **UI**: Task 3 (follow-up) leerá `isStale + staleAgeSeconds` del hook para mostrar badge "cotización desactualizada". Este PR es solo la telemetría; UI viene aparte para poder screenshot en simulador antes de mergear.

## Verificación

- `yarn build:ts` verde (12.89s).
- `yarn lint` verde (32.74s).
- `yarn jest src/gold/api.test.ts` — 21/21 pass.

## Sin dependencias

Contra `Development` (post #290). Task 2 (circuit-breaker per-path) es independiente y va en paralelo. Task 3 (UI badge) depende de este.