### PR TITLE
refactor(circuit-breaker): key by host+path so unrelated endpoints do not contaminate

### DIFF
--- a/src/lib/circuitBreaker/circuitBreaker.test.ts
+++ b/src/lib/circuitBreaker/circuitBreaker.test.ts
@@ -68,4 +68,36 @@ describe('circuitBreaker', () => {
     // Only 1 fresh failure -> still closed
     expect(shouldShortCircuit('api.example.test')).toBe(false)
   })
+
+  it('isolates the breaker per key (host+path), not per host', () => {
+    // Simulates the real problem this refactor addresses: 5 failures on
+    // `/hooks-api` on tucop-backend used to open the breaker for the whole
+    // host, blocking unrelated calls to `/api/prices/xaut` on the same host.
+    // After the switch to `${host}${pathname}` keys, the two routes are
+    // isolated even though they share a host component in the string.
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) {
+      recordFailure('tucop-backend-production.up.railway.app/hooks-api/triggerShortcut')
+    }
+    expect(
+      shouldShortCircuit('tucop-backend-production.up.railway.app/hooks-api/triggerShortcut')
+    ).toBe(true)
+    expect(shouldShortCircuit('tucop-backend-production.up.railway.app/api/prices/xaut')).toBe(
+      false
+    )
+    expect(shouldShortCircuit('tucop-backend-production.up.railway.app/api/positions')).toBe(false)
+  })
+
+  it('recordSuccess on one key does not affect another key', () => {
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) {
+      recordFailure('host.test/pathA')
+      recordFailure('host.test/pathB')
+    }
+    expect(shouldShortCircuit('host.test/pathA')).toBe(true)
+    expect(shouldShortCircuit('host.test/pathB')).toBe(true)
+
+    recordSuccess('host.test/pathA')
+    expect(shouldShortCircuit('host.test/pathA')).toBe(false)
+    // pathB is still open, success on pathA must not have cleared it.
+    expect(shouldShortCircuit('host.test/pathB')).toBe(true)
+  })
 })

--- a/src/lib/circuitBreaker/circuitBreaker.ts
+++ b/src/lib/circuitBreaker/circuitBreaker.ts
@@ -1,11 +1,18 @@
 /**
- * Per-host circuit breaker.
+ * Per-key circuit breaker.
  *
- * Tracks recent failures per host. After {@link FAILURE_THRESHOLD} failures
+ * Tracks recent failures per key. After {@link FAILURE_THRESHOLD} failures
  * within {@link FAILURE_WINDOW_MS}, the breaker opens for {@link OPEN_DURATION_MS}.
  * While open, callers should short-circuit instead of dispatching the request.
  *
- * State is held in a module-level Map keyed by host (e.g. "api.example.com").
+ * The key is an opaque string chosen by the caller. `fetchWithTimeout`
+ * historically used the URL host (e.g. "api.example.com") but that
+ * contaminated unrelated endpoints: a burst of 502s on `/hooks-api` would
+ * open the breaker for `/api/prices/xaut` on the same host. `fetchWithTimeout`
+ * now uses `${host}${pathname}` so failures on one route do not affect
+ * others; see `extractCircuitKey` in `src/utils/fetchWithTimeout.ts`.
+ *
+ * State is held in a module-level Map keyed by the caller-supplied string.
  * Exported {@link _resetForTests} resets state between unit tests.
  */
 
@@ -13,33 +20,33 @@ export const FAILURE_THRESHOLD = 5
 export const FAILURE_WINDOW_MS = 60_000
 export const OPEN_DURATION_MS = 30_000
 
-interface HostState {
+interface KeyState {
   failures: number[]
   openedAt: number | null
 }
 
-const state = new Map<string, HostState>()
+const state = new Map<string, KeyState>()
 
-function getOrCreate(host: string): HostState {
-  let entry = state.get(host)
+function getOrCreate(key: string): KeyState {
+  let entry = state.get(key)
   if (!entry) {
     entry = { failures: [], openedAt: null }
-    state.set(host, entry)
+    state.set(key, entry)
   }
   return entry
 }
 
-function prune(entry: HostState, now: number): void {
+function prune(entry: KeyState, now: number): void {
   const cutoff = now - FAILURE_WINDOW_MS
   entry.failures = entry.failures.filter((t) => t >= cutoff)
 }
 
 /**
- * True if requests to this host should be short-circuited.
+ * True if requests for this key should be short-circuited.
  * Auto-closes the breaker once the open duration has elapsed.
  */
-export function shouldShortCircuit(host: string): boolean {
-  const entry = state.get(host)
+export function shouldShortCircuit(key: string): boolean {
+  const entry = state.get(key)
   if (!entry || entry.openedAt === null) return false
   const now = Date.now()
   if (now - entry.openedAt >= OPEN_DURATION_MS) {
@@ -51,11 +58,11 @@ export function shouldShortCircuit(host: string): boolean {
 }
 
 /**
- * Record a failed request to `host`. If the failure count within the rolling
- * window reaches the threshold, the breaker opens.
+ * Record a failed request under `key`. If the failure count within the
+ * rolling window reaches the threshold, the breaker opens.
  */
-export function recordFailure(host: string): void {
-  const entry = getOrCreate(host)
+export function recordFailure(key: string): void {
+  const entry = getOrCreate(key)
   const now = Date.now()
   if (entry.openedAt !== null) return
   entry.failures.push(now)
@@ -69,14 +76,14 @@ export function recordFailure(host: string): void {
  * Record a successful request. Clears recent failure history and closes the
  * breaker if it was open.
  */
-export function recordSuccess(host: string): void {
-  const entry = state.get(host)
+export function recordSuccess(key: string): void {
+  const entry = state.get(key)
   if (!entry) return
   entry.failures = []
   entry.openedAt = null
 }
 
-/** Test-only helper to clear all host state between cases. */
+/** Test-only helper to clear all state between cases. */
 export function _resetForTests(): void {
   state.clear()
 }

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -9,9 +9,15 @@ import {
 const MAX_ATTEMPTS = 3
 const BASE_BACKOFF_MS = 250
 
-function extractHost(url: string): string | null {
+// Circuit-breaker key is `${host}${pathname}` (query string intentionally
+// excluded so that different query params on the same route do not fragment
+// the failure counter). Path-level scoping prevents cross-endpoint
+// contamination on shared hosts: a burst of 502s on `/hooks-api` no longer
+// opens the breaker for `/api/prices/xaut` on the same tucop-backend host.
+function extractCircuitKey(url: string): string | null {
   try {
-    return new URL(url).host
+    const u = new URL(url)
+    return `${u.host}${u.pathname}`
   } catch {
     return null
   }
@@ -29,7 +35,7 @@ function backoffDelayMs(attempt: number): number {
 }
 
 function addRetryBreadcrumb(
-  host: string | null,
+  circuitKey: string | null,
   attempt: number,
   data: { status?: number; error?: string }
 ): void {
@@ -37,7 +43,7 @@ function addRetryBreadcrumb(
     Sentry.addBreadcrumb({
       category: 'fetch',
       level: 'warning',
-      message: `Retry attempt ${attempt} for ${host ?? 'unknown'}`,
+      message: `Retry attempt ${attempt} for ${circuitKey ?? 'unknown'}`,
       data,
     })
   } catch {
@@ -62,13 +68,16 @@ async function attemptFetch(
 }
 
 /**
- * Fetch with timeout, retry on transient failures, and per-host circuit breaker.
+ * Fetch with timeout, retry on transient failures, and per-endpoint circuit
+ * breaker.
  *
  * - Retries up to {@link MAX_ATTEMPTS} times on 5xx responses or network errors.
  * - Does NOT retry on 4xx (client errors are not transient).
  * - Exponential backoff between attempts: 250ms * 2^attempt + jitter.
- * - Per-host circuit breaker: after sustained failures the breaker opens and
- *   subsequent requests short-circuit with a synthetic 503 until it closes.
+ * - Circuit breaker keyed by `${host}${pathname}` (see `extractCircuitKey`):
+ *   after sustained failures on a specific route the breaker opens and
+ *   subsequent requests to that same route short-circuit with a synthetic
+ *   503 until it closes. Other routes on the same host are unaffected.
  *
  * External signature is unchanged (returns `Promise<Response>`); callers do
  * not need updating.
@@ -78,9 +87,9 @@ export const fetchWithTimeout = async (
   options: RequestInit | null = null,
   duration: number = FETCH_TIMEOUT_DURATION
 ): Promise<Response> => {
-  const host = extractHost(url)
+  const circuitKey = extractCircuitKey(url)
 
-  if (host && shouldShortCircuit(host)) {
+  if (circuitKey && shouldShortCircuit(circuitKey)) {
     return new Response('', {
       status: 503,
       statusText: 'Service Unavailable (circuit open)',
@@ -95,8 +104,8 @@ export const fetchWithTimeout = async (
       const response = await attemptFetch(url, options, duration)
       if (response.status >= 500) {
         lastResponse = response
-        if (host) recordFailure(host)
-        addRetryBreadcrumb(host, attempt + 1, { status: response.status })
+        if (circuitKey) recordFailure(circuitKey)
+        addRetryBreadcrumb(circuitKey, attempt + 1, { status: response.status })
         if (attempt < MAX_ATTEMPTS - 1) {
           await sleep(backoffDelayMs(attempt))
           continue
@@ -104,12 +113,14 @@ export const fetchWithTimeout = async (
         return response
       }
       // 2xx, 3xx, 4xx: do not retry. 2xx clears breaker, others leave as-is.
-      if (response.status < 400 && host) recordSuccess(host)
+      if (response.status < 400 && circuitKey) recordSuccess(circuitKey)
       return response
     } catch (err) {
       lastError = err
-      if (host) recordFailure(host)
-      addRetryBreadcrumb(host, attempt + 1, { error: (err as Error)?.message ?? String(err) })
+      if (circuitKey) recordFailure(circuitKey)
+      addRetryBreadcrumb(circuitKey, attempt + 1, {
+        error: (err as Error)?.message ?? String(err),
+      })
       if (attempt < MAX_ATTEMPTS - 1) {
         await sleep(backoffDelayMs(attempt))
         continue


### PR DESCRIPTION
## Summary

Fixea el punto valido que levantó backend en el thread del price fix: nuestro circuit breaker (`src/lib/circuitBreaker/circuitBreaker.ts`) apagaba TODO el host cuando un endpoint acumulaba 5 fallas en 60s. Squid upstream tira 502 legítimos por diseño (low liquidity, 3+ quotes seguidas), y esos legítimos contagiaban paths sanos del mismo host: `/api/prices/xaut`, `/api/positions`, `/api/tx/status`, `/api/earn/neeru/catalogue`.

**Nota al backend**: nuestro código NO cuenta 400/429 contra el breaker. Solo `status >= 500` y errores de red en catch. Verificado en `src/utils/fetchWithTimeout.ts:96-108`. Solo el problema per-host era real.

## Cambios

**`src/lib/circuitBreaker/circuitBreaker.ts`**:
- Renombrar semanticamente `host` → `key` en toda la API pública (`shouldShortCircuit`, `recordFailure`, `recordSuccess`). Firma externa igual — string opaco decidido por el caller.
- Docstrings actualizados: la key es un identificador lógico, no un host.

**`src/utils/fetchWithTimeout.ts`**:
- `extractHost(url)` → `extractCircuitKey(url)` retorna `${host}${pathname}`. Query string excluido para no fragmentar el counter por diferentes params.
- Rename local `host` → `circuitKey` en el flow + breadcrumb wording.
- Sin cambios de signature externa.

**`src/lib/circuitBreaker/circuitBreaker.test.ts`**:
- 6 tests existentes pasan sin cambios (usaban strings arbitrarios como key).
- 2 tests nuevos:
  - `isolates the breaker per key (host+path), not per host`: simula el problema real — 5 fallas en `tucop-backend.../hooks-api/triggerShortcut` no abren el breaker para `.../api/prices/xaut` ni `.../api/positions`.
  - `recordSuccess on one key does not affect another key`: success en pathA no cierra el breaker de pathB.
- Total 8/8 pass.

## Impacto

- **Runtime**: cero contaminación cross-endpoint. Squid tira 502 → solo `/hooks-api/triggerShortcut` queda blocked 30s, el resto del backend sigue accesible.
- **Fetch signatures**: sin cambios. Todos los callers de `fetchWithTimeout` siguen igual.
- **Sentry breadcrumbs**: mensaje "Retry attempt N for host.example/path" en vez de solo "host.example". Más granular para debugging.
- **Sin regresiones**: tests existentes + full jest suite verifican (los 2 fails en `time.test.ts` son flake TZ pre-existente documentado; contracts-research fails son OpenZeppelin tests picked up por config, ninguno relacionado).

## Verificación

- `yarn build:ts` verde (15.66s).
- `yarn lint` verde (32.67s).
- `yarn jest src/lib/circuitBreaker src/utils/fetchWithTimeout` — 16/16 pass.

## Sin dependencias

Contra `Development`. Independiente de #292 (X-Stale) y del PR #291 (docs). Se puede mergear en cualquier orden.