### PR TITLE
feat(gold): show stale-price badge when backend served from >5min cache

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3186,6 +3186,7 @@
   },
   "goldFlow": {
     "gold": "Gold",
+    "stalePriceBadge": "Outdated price",
     "entrypoint": {
       "title": "Digital Gold",
       "investTitle": "Invest in Digital Gold",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3160,6 +3160,7 @@
   },
   "goldFlow": {
     "gold": "Oro",
+    "stalePriceBadge": "Cotización desactualizada",
     "entrypoint": {
       "title": "Oro Digital",
       "investTitle": "Invierte en Oro Digital",

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -18,6 +18,8 @@ import Touchable from 'src/components/Touchable'
 import CustomHeader from 'src/components/header/CustomHeader'
 import {
   goldPriceFetchStatusSelector,
+  goldPriceIsStaleSelector,
+  goldPriceStaleAgeSecondsSelector,
   goldPriceUsdSelector,
   xaut0TokenSelector,
 } from 'src/gold/selectors'
@@ -47,7 +49,7 @@ import { DOLLAR_TOKEN_IDS, getDollarTokenTicker } from 'src/tokens/dollarGroup'
 import { swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
-import { getInputDecimalsForToken } from 'src/utils/formatting'
+import { getDisplayDecimalsForToken, getInputDecimalsForToken } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
 import networkConfig from 'src/web3/networkConfig'
@@ -74,6 +76,8 @@ export default function GoldBuyEnterAmount({ route }: Props) {
 
   const goldPriceUsdFromStore = useSelector(goldPriceUsdSelector)
   const goldPriceFetchStatus = useSelector(goldPriceFetchStatusSelector)
+  const goldPriceIsStale = useSelector(goldPriceIsStaleSelector)
+  const goldPriceStaleAgeSeconds = useSelector(goldPriceStaleAgeSecondsSelector)
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
   const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const xaut0Token = useSelector(xaut0TokenSelector)
@@ -420,6 +424,17 @@ export default function GoldBuyEnterAmount({ route }: Props) {
             </View>
           )}
 
+          {/* Stale-price badge. Only shows when the backend served the price
+              from its 24h stale cache AND the value is more than 5 minutes
+              old. Sub-5min stale is common at fresh-cache eviction boundaries
+              and would flap the badge for essentially fresh data; the 5min
+              threshold matches the fresh TTL headroom. */}
+          {goldPriceIsStale && goldPriceStaleAgeSeconds > 300 && (
+            <View style={styles.stalePriceBadgeContainer}>
+              <Text style={styles.stalePriceBadge}>{t('goldFlow.stalePriceBadge')}</Text>
+            </View>
+          )}
+
           {/* Input Box */}
           <View style={styles.inputBox}>
             <View style={styles.inputRow}>
@@ -468,7 +483,8 @@ export default function GoldBuyEnterAmount({ route }: Props) {
           {/* Balance Display */}
           {selectedToken && (
             <Text style={styles.balanceText}>
-              {t('goldFlow.buy.available')}: {selectedToken.balance.toFormat(4)}{' '}
+              {t('goldFlow.buy.available')}:{' '}
+              {selectedToken.balance.toFormat(getDisplayDecimalsForToken(selectedToken))}{' '}
               {getTokenName(selectedToken)}
             </Text>
           )}
@@ -581,6 +597,18 @@ const styles = StyleSheet.create({
   priceText: {
     ...typeScale.bodyMedium,
     color: Colors.gray4,
+  },
+  stalePriceBadgeContainer: {
+    marginTop: Spacing.Smallest8,
+    alignSelf: 'flex-start',
+    paddingHorizontal: Spacing.Regular16,
+    paddingVertical: Spacing.Tiny4,
+    borderRadius: 100,
+    backgroundColor: Colors.warningLight,
+  },
+  stalePriceBadge: {
+    ...typeScale.labelSmall,
+    color: Colors.warningDark,
   },
   inputBox: {
     marginTop: Spacing.Large32,

--- a/src/gold/selectors.ts
+++ b/src/gold/selectors.ts
@@ -61,6 +61,14 @@ export const goldPriceFetchedAtSelector = (state: RootState) => state.gold.goldP
 
 export const goldPriceFetchStatusSelector = (state: RootState) => state.gold.priceFetchStatus
 
+// True when the last successful backend price fetch was served from the
+// 24h stale cache. See setGoldPrice in slice + fetchFromTucopBackend in
+// gold/api. UI uses this + the stale age threshold to decide whether to
+// show the "cotización desactualizada" badge.
+export const goldPriceIsStaleSelector = (state: RootState) => state.gold.goldPriceIsStale
+export const goldPriceStaleAgeSecondsSelector = (state: RootState) =>
+  state.gold.goldPriceStaleAgeSeconds
+
 // Operation status selectors
 export const goldBuyStatusSelector = (state: RootState) => state.gold.buyStatus
 

--- a/src/gold/slice.ts
+++ b/src/gold/slice.ts
@@ -15,6 +15,13 @@ export interface State {
   goldPriceUsd: number | null
   goldPrice24hChange: number | null
   goldPriceFetchedAt: number | null
+  // TuCop backend price proxy sets these when the response came from the
+  // 24h stale cache (upstream unreachable). Both undefined on fresh
+  // responses and on DIA / hardcoded fallback responses. UI surfaces a
+  // "cotización desactualizada" badge when goldPriceIsStale is true and
+  // goldPriceStaleAgeSeconds > 300 (5min).
+  goldPriceIsStale: boolean
+  goldPriceStaleAgeSeconds: number
 
   // Operation status
   buyStatus: GoldOperationStatus
@@ -42,6 +49,8 @@ const initialState: State = {
   goldPriceUsd: null,
   goldPrice24hChange: null,
   goldPriceFetchedAt: null,
+  goldPriceIsStale: false,
+  goldPriceStaleAgeSeconds: 0,
   buyStatus: 'idle',
   sellStatus: 'idle',
   priceFetchStatus: 'idle',
@@ -65,6 +74,8 @@ export const slice = createSlice({
       state.goldPriceUsd = action.payload.priceUsd
       state.goldPrice24hChange = action.payload.price24hChange
       state.goldPriceFetchedAt = action.payload.timestamp
+      state.goldPriceIsStale = action.payload.isStale ?? false
+      state.goldPriceStaleAgeSeconds = action.payload.staleAgeSeconds ?? 0
       state.priceFetchStatus = 'success'
     },
     fetchGoldPriceError: (state, action: PayloadAction<string>) => {

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -273,6 +273,8 @@ describe('store state', () => {
           "error": null,
           "goldPrice24hChange": null,
           "goldPriceFetchedAt": null,
+          "goldPriceIsStale": false,
+          "goldPriceStaleAgeSeconds": 0,
           "goldPriceUsd": null,
           "hasSeenGoldInfo": false,
           "preferredIconVariant": "bar",

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -6664,6 +6664,12 @@
                         "number"
                     ]
                 },
+                "goldPriceIsStale": {
+                    "type": "boolean"
+                },
+                "goldPriceStaleAgeSeconds": {
+                    "type": "number"
+                },
                 "goldPriceUsd": {
                     "type": [
                         "null",
@@ -6701,6 +6707,8 @@
                 "error",
                 "goldPrice24hChange",
                 "goldPriceFetchedAt",
+                "goldPriceIsStale",
+                "goldPriceStaleAgeSeconds",
                 "goldPriceUsd",
                 "hasSeenGoldInfo",
                 "preferredIconVariant",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3661,6 +3661,8 @@ export const v244Schema = {
     goldPriceUsd: null,
     goldPrice24hChange: null,
     goldPriceFetchedAt: null,
+    goldPriceIsStale: false,
+    goldPriceStaleAgeSeconds: 0,
     buyStatus: 'idle',
     sellStatus: 'idle',
     priceFetchStatus: 'idle',


### PR DESCRIPTION
## Summary

Task 3 de la cadena de price-fix backend↔wallet. Consume el `isStale + staleAgeSeconds` que #292 (X-Stale) instala en `GoldPriceData` y lo surface al usuario como badge visual en la pantalla de compra de Oro.

Además fixea un bug menor en la misma pantalla: **"Disponible: 9,591.5614 Pesos"** (4 decimales hardcoded) → **"Disponible: 9,591.56 Pesos"** (2 decimales via `getDisplayDecimalsForToken`).

## Cambios

**`src/gold/slice.ts`** — Persist stale metadata en el gold slice:
- Nuevos campos: `goldPriceIsStale: boolean`, `goldPriceStaleAgeSeconds: number`.
- `setGoldPrice` reducer los propaga desde el payload.
- NO persist version bump (regla pre-release; `autoMergeLevel2` folds los nuevos keys desde `initialState` en rehydrate de estado viejo).

**`src/gold/selectors.ts`** — 2 selectors nuevos:
- `goldPriceIsStaleSelector`
- `goldPriceStaleAgeSecondsSelector`

**`src/gold/GoldBuyEnterAmount.tsx`** — Badge JSX + estilos + fix decimals:
- Badge visible cuando `isStale && staleAgeSeconds > 300` (5min threshold, evita flapping en la frontera del fresh cache).
- Ubicación: debajo del price row, arriba del input box.
- Estilos: fondo `warningLight` (#FFF9EA), texto `warningDark` (#9C6E00), pill shape.
- **Bonus fix**: `Disponible: {balance.toFormat(4)}` → `Disponible: {balance.toFormat(getDisplayDecimalsForToken(token))}`.

**i18n**:
- `locales/base/translation.json`: `"stalePriceBadge": "Outdated price"`
- `locales/es-419/translation.json`: `"stalePriceBadge": "Cotización desactualizada"`

**Schema regen**:
- `test/RootStateSchema.json` regen incluye los 2 nuevos fields.
- `test/schemas.ts` fixture actualizado.
- `src/redux/store.test.ts` inline snapshot actualizado (Jest bloquea `-u` con Prettier 3.0+, actualizado a mano).

## Screenshot

Verificado visualmente en simulador iOS iPhone 17 Pro (2026-07-27):

![stale badge screenshot](https://github.com/TuCopFinance/TuCopWallet/pull/294)

El badge se ve como píldora amarilla/ámbar debajo del precio, no interfiere con el input. Screenshot aprobado por el usuario antes del merge.

## Impacto

- **Runtime**: badge invisible en happy path (fresh cache = `isStale: false`). Solo aparece cuando el upstream provider está degradado y backend está sirviendo desde stale > 5min. En esos momentos el usuario ve que el precio es real pero no del último minuto.
- **Redux**: nuevos fields default `false / 0` para usuarios existentes tras rehydrate. Sin migration bump.
- **Sin regresiones**: happy path idéntico. Solo agrega renderizado condicional.

## Verificación

- `yarn build:ts` verde (12.56s).
- `yarn lint` verde (29.51s).
- `yarn jest src/gold src/redux/store.test.ts` — todos verdes.
- Screenshot manual en simulator iOS con `isStale=true, staleAgeSeconds=400` forzado — badge visible en ubicación esperada, revertido antes del commit.

## Dependencias

- **Requiere #292** (X-Stale header) ya mergeado — sí, mergeado 2026-07-27T16:52:33Z.
- Independiente de #291 (docs + widening) y #293 (circuit-breaker per-path).