### PR TITLE
chore(smoke): tolerate indexer catching up + relax threshold to 500 blocks

### DIFF
--- a/scripts/pre-release-backend-smoke.sh
+++ b/scripts/pre-release-backend-smoke.sh
@@ -62,12 +62,23 @@ DETAIL=$(curl -sf "$BASE/api/earn/neeru/positions?address=$ADDR")
 echo "$DETAIL" | jq -e '.data.positions | type == "array"' >/dev/null \
   || fail "detail endpoint did not return a positions array"
 
-next "feed indexer health (lag under 100 blocks)"
-FEED_HEALTH=$(curl -sf "$BASE/api/transactions/indexer/health")
-LAG=$(echo "$FEED_HEALTH" | jq '.lagBlocks')
-[[ "$LAG" =~ ^-?[0-9]+$ ]] || fail "lagBlocks not numeric: $LAG"
-if [[ "$LAG" -gt 100 ]]; then
-  fail "indexer lag $LAG blocks exceeds 100-block threshold"
+next "feed indexer health (lag under 500 blocks, or catching up)"
+LAG_1=$(curl -sf "$BASE/api/transactions/indexer/health" | jq '.lagBlocks')
+[[ "$LAG_1" =~ ^-?[0-9]+$ ]] || fail "lagBlocks not numeric: $LAG_1"
+if [[ "$LAG_1" -le 500 ]]; then
+  :
+else
+  sleep 10
+  LAG_2=$(curl -sf "$BASE/api/transactions/indexer/health" | jq '.lagBlocks')
+  [[ "$LAG_2" =~ ^-?[0-9]+$ ]] || fail "lagBlocks not numeric on retry: $LAG_2"
+  DELTA=$((LAG_1 - LAG_2))
+  if [[ "$LAG_2" -le 500 ]]; then
+    :
+  elif [[ "$DELTA" -ge 50 ]]; then
+    echo "  indexer catching up: $LAG_1 -> $LAG_2 blocks ($DELTA delta in 10s)"
+  else
+    fail "indexer lag $LAG_2 blocks exceeds 500-block threshold and not catching up (delta=$DELTA in 10s)"
+  fi
 fi
 
 echo


### PR DESCRIPTION
## Summary

- Relaxes the pre-release backend smoke's indexer-health check from a hard 100-block ceiling to 500 blocks, and, if that's exceeded, gives the indexer 10 seconds to prove it's actively catching up (delta >= 50 blocks) before failing.
- Post-mortem from the 1.118.8 pre-release: indexer briefly hit 3876 blocks lag after an RPC hiccup, then caught up seconds later. The old threshold flagged this as a hard failure and blocked the release for no real backend issue.

## Behavior

1. First sample: if `lagBlocks <= 500`, pass immediately.
2. Otherwise wait 10s and re-sample.
3. Pass if the second sample is either under 500, or dropped by at least 50 blocks (proof the indexer is draining backlog).
4. Fail only when the second sample is still above 500 AND is not catching up.

## Test plan

- [x] `bash -n scripts/pre-release-backend-smoke.sh` (syntax check)
- [x] Full run against `https://tucop-backend-production.up.railway.app` (all 6 checks pass, indexer healthy at time of test)
- [ ] Next release cycle validates the retry branch during a real catch-up window