### PR TITLE
fix(positions): pass wallet address to getEarnPositions

### DIFF
--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -155,6 +155,11 @@ describe(fetchPositionsSaga, () => {
         })
       )
       .run()
+
+    const calledUrls = mockFetch.mock.calls.map(([url]) => String(url))
+    const earnPositionsCall = calledUrls.find((u) => u.includes('/getEarnPositions'))
+    expect(earnPositionsCall).toBeDefined()
+    expect(earnPositionsCall).toContain(`address=${mockAccount}`)
   })
 
   it("should return unique positions when there's an overlap between positions and earn positions", async () => {

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -104,6 +104,12 @@ async function fetchPositions({
   networkIds.forEach((networkId) => getPositionsUrl.searchParams.append('networkIds', networkId))
 
   const getEarnPositionsUrl = getHooksApiFunctionUrl(hooksApiUrl, 'getEarnPositions')
+  // Backend uses `address` to scope balance and earningItems (rewards) to the
+  // caller. Without it, the response falls back to a generic pool listing with
+  // zeroes; today the dedupe loop below hides that because getPositions
+  // returns Neeru with real per-user values, but a change in that contract
+  // would leave earn cards showing 0 balance and empty rewards.
+  getEarnPositionsUrl.searchParams.set('address', walletAddress)
 
   // const { supportedPools, supportedAppIds } = getDynamicConfigParams(
   //   DynamicConfigs[StatsigDynamicConfigs.EARN_CONFIG]


### PR DESCRIPTION
## Summary

- `src/positions/saga.ts:106` builds the getEarnPositions URL with `networkIds` but never sets `address`, so the backend can only return a generic pool listing with `balance=0` and `earningItems=[]`.
- Today the dedupe loop hides the bug because `getPositions` (which does pass address) also returns Neeru with real per-user values, and it wins the merge.
- The moment `getPositions` stops returning Neeru (e.g. it moves to a purely earn-hosted response, or `partialFailure` trims it), earn cards would silently drop to 0 balance and no rewards for every user.
- Also adds a saga-test assertion on the URL so future edits catch a regression.

## Verified

Live cross-check against production backend confirms `getEarnPositions` returns zeroes without `address`:

```
GET /hooks-api/getEarnPositions?networkIds=celo-mainnet (no address)
  -> category-0: balance="0", earningItems=[]
GET /hooks-api/getEarnPositions?networkIds=celo-mainnet&address=0x8427e4409b73a31b9d4e0d210677c88877472ece
  -> category-0: balance="10002.656409312776653968", earningItems=[]
```

## Related concern (out of scope for this PR)

A user reported "intereses de todos" appearing immediately after a new deposit. The wallet only renders what the backend returns for `/api/earn/neeru/positions?address=X`, and that endpoint returns a per-position `accruedInterest` sourced from the contract. If a fresh deposit shows non-trivial accrued interest at t=0, that is a contract or indexer attribution bug on the backend side. Flagged for backend to investigate; wallet-side change here is defense-in-depth for the separate `getEarnPositions` gap.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `yarn test --testPathPattern=positions/saga` (18/18 pass, including the new URL assertion)
- [ ] Manual smoke on emulator: Neeru pool card shows correct balance after login