### PR TITLE
feat(earn): hide TVL row on Neeru pool cards

### DIFF
--- a/src/earn/PoolCard.tsx
+++ b/src/earn/PoolCard.tsx
@@ -280,10 +280,12 @@ export default function PoolCard({
                 </Text>
               )}
             </View>
-            <View style={styles.keyValueRow}>
-              <Text style={styles.keyText}>{t('earnFlow.poolCard.tvl')}</Text>
-              <Text style={styles.valueText}>{tvlString}</Text>
-            </View>
+            {!isNeeruPool && (
+              <View style={styles.keyValueRow}>
+                <Text style={styles.keyText}>{t('earnFlow.poolCard.tvl')}</Text>
+                <Text style={styles.valueText}>{tvlString}</Text>
+              </View>
+            )}
           </View>
           {new BigNumber(balance).gt(0) && !!depositTokenInfo && (
             <View style={styles.withBalanceContainer}>


### PR DESCRIPTION
## Summary

Remove the "Total en Neeru: X Pesos" TVL row from Neeru pool cards. Pool-wide TVL is not information the user needs when deciding on their own deposit, and it added visual noise per user feedback.

Other providers (aave, allbridge) keep the TVL row because there it's a useful signal about pool liquidity for withdraw safety.

## Change

`src/earn/PoolCard.tsx`: wrap the TVL `<View>` in `!isNeeruPool && (...)`. The `tvl`, `tvlInFiat`, `tvlString` derivations stay because non-Neeru pools still render them.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `yarn test --testPathPattern=earn/PoolCard` (7/7 pass)
- [ ] Manual smoke on simulator: Neeru pool cards no longer show TVL row; aave/allbridge cards unchanged