### PR TITLE
fix(inputs): render EnterAmountOptions outside KeyboardAwareScrollView

### DIFF
--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -565,11 +565,6 @@ function EarnEnterAmount({ route }: Props) {
             testID="EarnEnterAmount/WithdrawingAndClaimingCard"
           />
         )}
-        <EnterAmountOptions
-          onPressAmount={onSelectPercentageAmount}
-          selectedAmount={selectedPercentage}
-          testID="EarnEnterAmount/AmountOptions"
-        />
         <Button
           onPress={onPressContinue}
           text={t('earnFlow.enterAmount.continue')}
@@ -580,6 +575,14 @@ function EarnEnterAmount({ route }: Props) {
           testID="EarnEnterAmount/Continue"
         />
       </KeyboardAwareScrollView>
+      {/* Percentage Options rendered OUTSIDE the ScrollView so its
+          position:absolute + bottom:0 anchor to the screen, not to
+          the scrolled content. See GoldBuyEnterAmount for full note. */}
+      <EnterAmountOptions
+        onPressAmount={onSelectPercentageAmount}
+        selectedAmount={selectedPercentage}
+        testID="EarnEnterAmount/AmountOptions"
+      />
       {tokenAmount && (
         <FeeDetailsBottomSheet
           forwardedRef={feeDetailsBottomSheetRef}

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -533,13 +533,6 @@ export default function GoldBuyEnterAmount({ route }: Props) {
           />
         )}
 
-        {/* Percentage Options */}
-        <EnterAmountOptions
-          onPressAmount={onSelectPercentageAmount}
-          selectedAmount={selectedPercentage}
-          testID="GoldBuyEnterAmount/AmountOptions"
-        />
-
         {/* Continue Button */}
         <Button
           onPress={onPressContinue}
@@ -552,6 +545,17 @@ export default function GoldBuyEnterAmount({ route }: Props) {
           testID="GoldBuyEnterAmount/Continue"
         />
       </KeyboardAwareScrollView>
+
+      {/* Percentage Options rendered OUTSIDE the ScrollView so its
+          position:absolute + bottom:0 anchor to the screen, not to
+          the scrolled content. Inside the ScrollView the chip container
+          would move with the content when the keyboard opens and end
+          up off-screen (regression exposed by the RN 0.77 upgrade). */}
+      <EnterAmountOptions
+        onPressAmount={onSelectPercentageAmount}
+        selectedAmount={selectedPercentage}
+        testID="GoldBuyEnterAmount/AmountOptions"
+      />
 
       {/* Token Picker */}
       <TokenBottomSheet

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -384,13 +384,6 @@ export default function GoldSellEnterAmount(_props: Props) {
           />
         )}
 
-        {/* Percentage Options */}
-        <EnterAmountOptions
-          onPressAmount={onSelectPercentageAmount}
-          selectedAmount={selectedPercentage}
-          testID="GoldSellEnterAmount/AmountOptions"
-        />
-
         {/* Continue Button */}
         <Button
           onPress={onPressContinue}
@@ -402,6 +395,15 @@ export default function GoldSellEnterAmount(_props: Props) {
           testID="GoldSellEnterAmount/Continue"
         />
       </KeyboardAwareScrollView>
+
+      {/* Percentage Options rendered OUTSIDE the ScrollView so its
+          position:absolute + bottom:0 anchor to the screen, not to
+          the scrolled content. See GoldBuyEnterAmount for full note. */}
+      <EnterAmountOptions
+        onPressAmount={onSelectPercentageAmount}
+        selectedAmount={selectedPercentage}
+        testID="GoldSellEnterAmount/AmountOptions"
+      />
 
       {/* Token Picker */}
       <TokenBottomSheet

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -324,12 +324,6 @@ export default function EnterAmount({
 
         {children}
 
-        <EnterAmountOptions
-          onPressAmount={onSelectPercentageAmount}
-          selectedAmount={selectedPercentage}
-          testID="SendEnterAmount/AmountOptions"
-        />
-
         <ProceedComponent
           tokenAmount={processedAmounts.token.bignum}
           localAmount={processedAmounts.local.bignum}
@@ -340,6 +334,16 @@ export default function EnterAmount({
           showLoading={prepareTransactionsLoading}
         />
       </KeyboardAwareScrollView>
+
+      {/* Percentage Options rendered OUTSIDE the ScrollView so its
+          position:absolute + bottom:0 anchor to the screen, not to
+          the scrolled content. See GoldBuyEnterAmount for full note. */}
+      <EnterAmountOptions
+        onPressAmount={onSelectPercentageAmount}
+        selectedAmount={selectedPercentage}
+        testID="SendEnterAmount/AmountOptions"
+      />
+
       <TokenBottomSheet
         forwardedRef={tokenBottomSheetRef}
         snapPoints={['90%']}


### PR DESCRIPTION
## Summary

Multiple users reported the `25% / 50% / 75% / Max` chips on the amount input screens are not working (either not visible or not responding to taps). Root cause: `<EnterAmountOptions>` was rendered INSIDE `<KeyboardAwareScrollView>` on 4 screens.

The component uses `position: 'absolute', bottom: 0` inside an `Animated.View` to anchor to the keyboard edge. When rendered inside a ScrollView, those coordinates anchor to the scrolled content rather than the viewport. Once RN 0.77 tightened this layout (regression exposed by the 0.72 -> 0.77 upgrade), the chip container ends up scrolled off-screen the moment the keyboard opens and the KeyboardAwareScrollView shifts content up.

`SwapScreen` was not affected because it already rendered `<EnterAmountOptions>` as a sibling of `<ScrollView>`. This PR applies the same pattern to the four regressed screens.

## Changes (4 files)

- `src/gold/GoldBuyEnterAmount.tsx`: move `<EnterAmountOptions>` after `</KeyboardAwareScrollView>`
- `src/gold/GoldSellEnterAmount.tsx`: same
- `src/earn/EarnEnterAmount.tsx`: same
- `src/send/EnterAmount.tsx`: same

The `<Button Continue>` on each screen stays inside the ScrollView (where it belongs, as a normal scrollable element). Only the floating chip container moves out.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `yarn test --testPathPattern="gold/GoldBuyEnterAmount|gold/GoldSellEnterAmount|earn/EarnEnterAmount|send/EnterAmount|swap/SwapScreen"` (126/126 pass, 3 suites)
- [ ] Manual smoke on Android emulator: open GoldBuy, GoldSell, Earn deposit, Send flows. Confirm chips appear above keyboard on tap-input and respond to taps (setting the input value correctly).
- [ ] Manual smoke on iOS simulator: same 4 screens.
- [ ] Regression check on Swap: chips still working (should be unchanged).