### PR TITLE
fix(sentry): stop capturing errorCode as '[object Object]'

### DIFF
--- a/src/gold/saga.ts
+++ b/src/gold/saga.ts
@@ -324,10 +324,10 @@ function* buyGoldSaga(action: PayloadAction<GoldBuyInfo>) {
       error: error.message,
     })
     captureBusinessError(error, {
-      feature: 'earn',
+      feature: 'gold',
       provider: 'squid',
       action: 'buy_gold_execute',
-      errorCode: String(classifyError(error)),
+      errorCode: classifyError(error).kind,
       extra: { fromAmount, fromTokenId },
     })
   }
@@ -525,10 +525,10 @@ function* sellGoldSaga(action: PayloadAction<GoldSellInfo>) {
       error: error.message,
     })
     captureBusinessError(error, {
-      feature: 'earn',
+      feature: 'gold',
       provider: 'squid',
       action: 'sell_gold_execute',
-      errorCode: String(classifyError(error)),
+      errorCode: classifyError(error).kind,
       extra: { xautAmount, toTokenId },
     })
   }

--- a/src/jumpstart/saga.ts
+++ b/src/jumpstart/saga.ts
@@ -384,7 +384,7 @@ export function* sendJumpstartTransactions(
       feature: 'jumpstart',
       provider: 'jumpstart',
       action: 'send_execute',
-      errorCode: String(classifyError(error)),
+      errorCode: classifyError(error).kind,
       extra: { tokenId: sendToken.tokenId, sendAmount },
     })
   }

--- a/src/sentry/__tests__/captureBusinessError.test.ts
+++ b/src/sentry/__tests__/captureBusinessError.test.ts
@@ -94,4 +94,34 @@ describe('captureBusinessError', () => {
       httpStatus: 502,
     })
   })
+
+  it('coerces a non-string errorCode object to JSON instead of [object Object]', () => {
+    // Real regression: gold/saga.ts was passing classifyError(err) directly,
+    // which is an ErrorClass object. String(obj) collapses to
+    // "[object Object]" and every gold-buy revert landed with the same
+    // useless tag. captureBusinessError must defensively JSON.stringify
+    // any object it receives so the tag stays greppable.
+    captureBusinessError(new Error('boom'), {
+      feature: 'gold',
+      provider: 'squid',
+      action: 'buy_gold_execute',
+      // simulating the old buggy call site that passed a whole object
+      errorCode: { kind: 'revert', message: 'execution reverted', retryable: false } as any,
+    })
+    const tagsArg = mockScope.setTags.mock.calls[0][0]
+    expect(tagsArg.errorCode).toContain('revert')
+    expect(tagsArg.errorCode).not.toBe('[object Object]')
+    const fingerprintArg = mockScope.setFingerprint.mock.calls[0][0]
+    expect(fingerprintArg[3]).not.toBe('[object Object]')
+  })
+
+  it('coerces primitive non-string errorCodes (number, boolean) to their string form', () => {
+    captureBusinessError(new Error('boom'), {
+      feature: 'swap',
+      provider: 'squid',
+      action: 'execute',
+      errorCode: 502 as any,
+    })
+    expect(mockScope.setTags).toHaveBeenCalledWith(expect.objectContaining({ errorCode: '502' }))
+  })
 })

--- a/src/sentry/captureBusinessError.ts
+++ b/src/sentry/captureBusinessError.ts
@@ -7,6 +7,7 @@ import { SENTRY_ENABLED } from 'src/config'
 // strings. Keep names stable, they become the tag values in every event.
 export type BusinessFeature =
   | 'earn' // earn-vaults family (deposits, withdraws, close, emergency)
+  | 'gold' // digital gold buy / sell (XAUt0)
   | 'swap' // any token-to-token swap
   | 'transactions' // generic tx send / receipt / feed
   | 'buckspay' // COPm to COP off-ramp
@@ -46,22 +47,41 @@ export interface BusinessContext {
 // available on the individual events within the issue; if in the future
 // we need finer grouping (e.g. per HTTP status code), we can append more
 // segments here without changing the tag shape.
+// Defensive coercion so a caller passing a non-string errorCode (e.g. an
+// object like classifyError() returns) never lands in Sentry as the
+// useless "[object Object]" string. Strings pass through; primitives
+// stringify normally; objects go through JSON.stringify with a fallback
+// to their constructor name if serialization throws (circular refs).
+function normalizeErrorCode(errorCode: unknown): string | undefined {
+  if (errorCode == null) return undefined
+  if (typeof errorCode === 'string') return errorCode
+  if (typeof errorCode !== 'object') return String(errorCode)
+  try {
+    const json = JSON.stringify(errorCode)
+    // JSON.stringify returns undefined for functions / symbols
+    return json ?? (errorCode as object).constructor?.name ?? 'unknown_object'
+  } catch {
+    return (errorCode as object).constructor?.name ?? 'unstringifiable_object'
+  }
+}
+
 export function captureBusinessError(error: unknown, context: BusinessContext): void {
   if (!SENTRY_ENABLED) return
   const err = error instanceof Error ? error : new Error(String(error))
+  const normalizedErrorCode = normalizeErrorCode(context.errorCode)
   Sentry.withScope((scope) => {
     scope.setTags({
       feature: context.feature,
       provider: context.provider,
       action: context.action,
-      ...(context.errorCode ? { errorCode: context.errorCode } : {}),
+      ...(normalizedErrorCode ? { errorCode: normalizedErrorCode } : {}),
     })
     if (context.extra) scope.setContext('business', context.extra)
     scope.setFingerprint([
       context.feature,
       context.provider,
       context.action,
-      context.errorCode ?? 'unclassified',
+      normalizedErrorCode ?? 'unclassified',
     ])
     Sentry.captureException(err)
   })

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -457,7 +457,7 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
       feature: 'swap',
       provider: 'squid',
       action: 'execute',
-      errorCode: String(classifyError(error)),
+      errorCode: classifyError(error).kind,
       extra: { swapType, submitted },
     })
   }


### PR DESCRIPTION
## Summary

Sentry issue TUCOPWALLET-C (gold buy transaction reverted) had `errorCode: "[object Object]"` on every event, making it impossible to tell slippage from user-reject from RPC failure from actual revert.

Root cause: four call sites (gold buy, gold sell, swap execute, jumpstart send) were passing `classifyError(error)` wrapped in `String()`. `classifyError` returns an `ErrorClass` object `{kind, message, retryable, raw}`; `String(obj)` collapses to the literal `'[object Object]'`.

## Fixes

1. **4 call sites** now pass `classifyError(error).kind` (the string field):
   - `src/gold/saga.ts:330` (gold buy)
   - `src/gold/saga.ts:531` (gold sell)
   - `src/swap/saga.ts:460` (swap execute)
   - `src/jumpstart/saga.ts:387` (jumpstart send)

2. **`captureBusinessError` normalises `errorCode` defensively**: strings pass through, primitives stringify, objects go through `JSON.stringify` with a constructor-name fallback for circular refs. So a future regression of the same shape produces a greppable tag instead of `'[object Object]'`.

3. **`gold` added to `BusinessFeature` enum**: gold sagas were masquerading as `feature: 'earn'`. Now correctly tagged, so Sentry issue counts group gold vs earn separately.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `yarn test src/sentry/__tests__/captureBusinessError.test.ts` (8/8 pass, 2 new cases covering object coercion + primitive coercion)
- [x] `yarn test --testPathPattern="jumpstart/saga|swap/saga"` (26/26 pass)
- [ ] Watch Sentry for the next 24h: new gold buy revert events should carry meaningful `errorCode` tags (`revert`, `slippage`, `gas-insufficient`, `user-rejected`, `rpc-timeout`, `nonce-conflict`, `unknown`) instead of `[object Object]`.

## Follow-up

Once this ships in 1.118.9 and Sentry starts capturing real errorCode values, the TUCOPWALLET-C issue will FINGERPRINT differently (since fingerprint includes errorCode). Old events keep the useless tag; new events regroup by their real classification. Recommend closing TUCOPWALLET-C as resolved once we see the new issues land, and triaging the top errorCode from there.