### PR TITLE
chore(android): bump target SDK from 35 to 36 (Play Store deadline 2026-08-30)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 35
-          build-tools: 35.0.0
+          api-level: 36
+          build-tools: 36.0.0
 
       - name: Install dependencies
         env:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,10 +4,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         kotlinVersion = "2.0.21"
         // NDK r28 required for 16 KB page size support (Google Play, post-Nov 2025).
         // Earlier libQuickCrypto.so crashed at load due to __cxa_init_primary_exception

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -46,7 +46,7 @@ android.enableJetifier=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-android.suppressUnsupportedCompileSdk=35
+android.suppressUnsupportedCompileSdk=36
 # Add these lines
 nodeExecutableAndArgs=/usr/local/bin/node
 # android.disableAutomaticComponentCreation=true - removed in AGP 8.0


### PR DESCRIPTION
## Summary

Google Play requires apps to target Android 16 (API 36) from **2026-08-30**. Internal deadline was 2026-08-20 per `tasks/ROADMAP.md`. This PR does the minimum bump in one shot.

## Changes

| File | Change |
|------|--------|
| `android/build.gradle` | `buildToolsVersion` 35.0.0 -> 36.0.0, `compileSdkVersion` 35 -> 36, `targetSdkVersion` 35 -> 36 |
| `android/gradle.properties` | `android.suppressUnsupportedCompileSdk` 35 -> 36 (keeps the AGP warning quiet) |
| `.github/workflows/build.yml` | `api-level` 35 -> 36, `build-tools` 35.0.0 -> 36.0.0 |

## Audit of Android 16 behavior changes against this codebase

| Behavior change | Usages | Risk | Action taken |
|---|---|---|---|
| Edge-to-edge obligatorio | 392 files use SafeAreaView / useSafeAreaInsets | Low | None; needs visual QA on Android 16 device |
| Foreground services (stricter) | 0 uses | None | None |
| JobScheduler timeout (10min) | 0 uses | None | None |
| ART hidden APIs (stricter reflection) | 0 uses in android/app/src/main | Low (deps out of scope) | None; Sentry catches any dep regression at first startup |
| Predictive back gesture (default on for target 36) | 5 uses of BackHandler / useBackHandler | Medium | Manifest NOT set explicitly; RN 0.77 bridges to new callback API. Monitor QA; add `android:enableOnBackInvokedCallback` on `<application>` if any regression |

## NOT in this PR (out of scope)

- `android/app/src/androidTest/AndroidManifest.xml:3` still has `targetSdkVersion=27`. That's the Detox E2E harness config, not the shipped app. Separate concern.
- `react-native-quick-crypto` stays on `1.0.18`. Comment in `build.gradle` mentions `1.1.x` for 16 KB NDK cleanup, but 1.118.8 ships fine on the current setup. Not a target-36 blocker.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `cd android && ./gradlew help` (parses the SDK 36 config, `BUILD SUCCESSFUL in 20s`)
- [ ] CI: `Build` workflow succeeds with SDK 36 downloaded via `android-actions/setup-android@v3`
- [ ] Local: `./gradlew bundleMainnetRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a` produces a 16 KB compliant AAB
- [ ] Manual smoke on Android 16 device / AVD `system-images;android-36;google_apis;arm64-v8a`:
  - Home tab, receive, send, swap, gold buy, gold sell, earn deposit, earn withdraw, jumpstart
  - Predictive back gesture on every screen (swipe from edge)
  - Screenshot any edge-to-edge regression (content under status bar / nav bar)
- [ ] Sentry over first 24h post-ship: no spike in `IllegalAccessError`, `NoClassDefFoundError`, or hidden-API-related crashes

## Follow-up if QA finds edge-to-edge regressions

- Wrap the offending screen's root View with `useSafeAreaInsets()` padding, or
- Add `android:fitsSystemWindows="true"` to the specific Activity in the manifest

For a `BackHandler` regression: set `android:enableOnBackInvokedCallback="false"` on `<application>` as a quick fix; migrate to the new callback API when we do the RN upgrade to 0.79+.