### PR TITLE
feat(sentry): capture percentage-chip taps as UX signal for post-release verification

### DIFF
--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -581,6 +581,7 @@ function EarnEnterAmount({ route }: Props) {
       <EnterAmountOptions
         onPressAmount={onSelectPercentageAmount}
         selectedAmount={selectedPercentage}
+        flow="earn"
         testID="EarnEnterAmount/AmountOptions"
       />
       {tokenAmount && (

--- a/src/gold/GoldBuyEnterAmount.tsx
+++ b/src/gold/GoldBuyEnterAmount.tsx
@@ -554,6 +554,7 @@ export default function GoldBuyEnterAmount({ route }: Props) {
       <EnterAmountOptions
         onPressAmount={onSelectPercentageAmount}
         selectedAmount={selectedPercentage}
+        flow="gold_buy"
         testID="GoldBuyEnterAmount/AmountOptions"
       />
 

--- a/src/gold/GoldSellEnterAmount.tsx
+++ b/src/gold/GoldSellEnterAmount.tsx
@@ -402,6 +402,7 @@ export default function GoldSellEnterAmount(_props: Props) {
       <EnterAmountOptions
         onPressAmount={onSelectPercentageAmount}
         selectedAmount={selectedPercentage}
+        flow="gold_sell"
         testID="GoldSellEnterAmount/AmountOptions"
       />
 

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -341,6 +341,7 @@ export default function EnterAmount({
       <EnterAmountOptions
         onPressAmount={onSelectPercentageAmount}
         selectedAmount={selectedPercentage}
+        flow="send"
         testID="SendEnterAmount/AmountOptions"
       />
 

--- a/src/send/EnterAmountOptions.tsx
+++ b/src/send/EnterAmountOptions.tsx
@@ -8,19 +8,27 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated'
 import Touchable from 'src/components/Touchable'
+import { captureUxSignalOnce } from 'src/sentry/captureUxSignal'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 
+// Flow tag emitted on the "percentage_chip_tap" UX signal so we can tell
+// which screen a user tapped from in Sentry (send vs gold_buy vs earn, etc).
+// Keep values stable, they become Sentry tags and fingerprint segments.
+export type EnterAmountOptionsFlow = 'send' | 'gold_buy' | 'gold_sell' | 'earn' | 'swap'
+
 export default function EnterAmountOptions({
   onPressAmount,
   selectedAmount,
   testID,
+  flow,
 }: {
   onPressAmount(amount: number): void
   selectedAmount: number | null
   testID: string
+  flow: EnterAmountOptionsFlow
 }) {
   const { t } = useTranslation()
   const translateY = useSharedValue(0)
@@ -98,7 +106,25 @@ export default function EnterAmountOptions({
     >
       <View style={styles.contentContainer} testID={testID}>
         {amountOptions.map(({ amount, label }) => (
-          <Touchable borderRadius={100} key={label} onPress={() => onPressAmount(amount)}>
+          <Touchable
+            borderRadius={100}
+            key={label}
+            onPress={() => {
+              // Post-release verification signal (see captureUxSignalOnce).
+              // Fires once per (flow, percentage) per session so we can query
+              // Sentry to confirm real users are hitting these chips on
+              // Android + iOS after the KeyboardAwareScrollView layout fix
+              // (PR #299). No PII, no amounts, no addresses. Percentage is
+              // encoded as an integer (25, 50, 75, 100) for readable tags.
+              const percentageTag = String(Math.round(amount * 100))
+              captureUxSignalOnce(
+                `ux.percentage_chip:${flow}:${percentageTag}`,
+                'percentage_chip_tap',
+                { flow, percentage: percentageTag }
+              )
+              onPressAmount(amount)
+            }}
+          >
             <View
               style={[
                 styles.chip,

--- a/src/sentry/__tests__/captureUxSignal.test.ts
+++ b/src/sentry/__tests__/captureUxSignal.test.ts
@@ -1,0 +1,87 @@
+import * as Sentry from '@sentry/react-native'
+import { _resetCapturedUxSignalsForTests, captureUxSignalOnce } from 'src/sentry/captureUxSignal'
+import * as config from 'src/config'
+
+jest.mock('@sentry/react-native', () => ({
+  withScope: jest.fn((fn) => fn(mockScope)),
+  captureMessage: jest.fn(),
+}))
+
+const mockScope = {
+  setLevel: jest.fn(),
+  setTags: jest.fn(),
+  setFingerprint: jest.fn(),
+}
+
+describe('captureUxSignalOnce', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    _resetCapturedUxSignalsForTests()
+    ;(config as any).SENTRY_ENABLED = true
+  })
+
+  it('no-ops when Sentry is disabled', () => {
+    ;(config as any).SENTRY_ENABLED = false
+    captureUxSignalOnce('ux.chip:send:25', 'percentage_chip_tap', {
+      flow: 'send',
+      percentage: '25',
+    })
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('fires captureMessage at level=info with tags and stable fingerprint', () => {
+    captureUxSignalOnce('ux.chip:earn:50', 'percentage_chip_tap', {
+      flow: 'earn',
+      percentage: '50',
+    })
+    expect(mockScope.setLevel).toHaveBeenCalledWith('info')
+    expect(mockScope.setTags).toHaveBeenCalledWith({ flow: 'earn', percentage: '50' })
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['percentage_chip_tap', 'earn', '50'])
+    expect(Sentry.captureMessage).toHaveBeenCalledWith('percentage_chip_tap')
+  })
+
+  it('dedupes: same key only fires once per session', () => {
+    captureUxSignalOnce('ux.chip:swap:75', 'percentage_chip_tap', {
+      flow: 'swap',
+      percentage: '75',
+    })
+    captureUxSignalOnce('ux.chip:swap:75', 'percentage_chip_tap', {
+      flow: 'swap',
+      percentage: '75',
+    })
+    captureUxSignalOnce('ux.chip:swap:75', 'percentage_chip_tap', {
+      flow: 'swap',
+      percentage: '75',
+    })
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('different keys fire independently', () => {
+    captureUxSignalOnce('ux.chip:send:25', 'percentage_chip_tap', {
+      flow: 'send',
+      percentage: '25',
+    })
+    captureUxSignalOnce('ux.chip:send:50', 'percentage_chip_tap', {
+      flow: 'send',
+      percentage: '50',
+    })
+    captureUxSignalOnce('ux.chip:earn:25', 'percentage_chip_tap', {
+      flow: 'earn',
+      percentage: '25',
+    })
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(3)
+  })
+
+  it('_resetCapturedUxSignalsForTests clears the session dedupe set', () => {
+    captureUxSignalOnce('ux.chip:send:100', 'percentage_chip_tap', {
+      flow: 'send',
+      percentage: '100',
+    })
+    _resetCapturedUxSignalsForTests()
+    captureUxSignalOnce('ux.chip:send:100', 'percentage_chip_tap', {
+      flow: 'send',
+      percentage: '100',
+    })
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/sentry/captureUxSignal.ts
+++ b/src/sentry/captureUxSignal.ts
@@ -1,0 +1,46 @@
+import * as Sentry from '@sentry/react-native'
+import { SENTRY_ENABLED } from 'src/config'
+
+// Session-scoped dedupe. The same (key) fires at most once per app cold-start.
+// Keeps event volume bounded regardless of how many times a user taps the
+// same UI control. Reset on process death, which is the natural session
+// boundary and matches how we reason about "did the feature work for this user
+// at all today".
+const SEEN = new Set<string>()
+
+// Lightweight positive UX signal for post-release verification. Fires a
+// Sentry event at level=info with a fixed fingerprint so all events for the
+// same key group into ONE Sentry issue (count + userCount tell us reach and
+// frequency). Use this when we want telemetry that a specific interaction
+// happened at all in production, not to report errors.
+//
+// Cost: one Sentry event per (key) per session. Given a Set-based dedupe
+// this is at most a handful per user per day even if they tap the control
+// dozens of times.
+//
+// Do NOT use for high-cardinality signals (per-tx breadcrumbs, etc). Those
+// belong in Sentry.addBreadcrumb (auto-attached to any subsequent error).
+export function captureUxSignalOnce(
+  key: string,
+  message: string,
+  tags: Record<string, string>
+): void {
+  if (!SENTRY_ENABLED) return
+  if (SEEN.has(key)) return
+  SEEN.add(key)
+  Sentry.withScope((scope) => {
+    scope.setLevel('info')
+    scope.setTags(tags)
+    // Fingerprint tuple = [message, ...tagValues] so Sentry groups by the
+    // full descriptor (e.g. all "percentage_chip_tap flow=send percentage=25"
+    // events collapse into one issue). Keep tag order stable across call
+    // sites or the grouping fragments.
+    scope.setFingerprint([message, ...Object.values(tags)])
+    Sentry.captureMessage(message)
+  })
+}
+
+// Test-only reset for the session-scoped dedupe Set. Not for runtime use.
+export function _resetCapturedUxSignalsForTests(): void {
+  SEEN.clear()
+}

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -1347,6 +1347,7 @@ export function SwapScreen({ route }: Props) {
       <EnterAmountOptions
         onPressAmount={handleSelectAmountPercentage}
         selectedAmount={selectedPercentage}
+        flow="swap"
         testID="SwapEnterAmount/AmountOptions"
       />
       {tokenBottomSheetsConfig.map(({ fieldType, tokens, filterChips, origin }) => (


### PR DESCRIPTION
## Summary

Post-#299 we can't validate on my Android 16 emulator (Gboard floating input intercepts synthetic taps) whether the chip fix actually works for real users. This adds a lightweight positive-signal telemetry so once 1.118.9 ships we can query Sentry and confirm each of the 5 flows x 4 percentages produces events with real userCount > 0.

## Changes

### New

- `src/sentry/captureUxSignal.ts` — `captureUxSignalOnce(key, message, tags)`. Fires a Sentry event at `level=info` with a stable fingerprint so Sentry groups matching events into ONE issue per (flow, percentage). Module-scoped `Set<string>` dedupes so the same key fires at most once per app cold-start. No PII, no amounts, no addresses.

### Wired

- `src/send/EnterAmountOptions.tsx`: new required `flow` prop (`'send' | 'gold_buy' | 'gold_sell' | 'earn' | 'swap'`), calls `captureUxSignalOnce('ux.percentage_chip:<flow>:<pct>', 'percentage_chip_tap', { flow, percentage })` on each chip press before the parent's `onPressAmount`.
- 5 parent screens pass their flow: `src/gold/GoldBuyEnterAmount.tsx` (`gold_buy`), `src/gold/GoldSellEnterAmount.tsx` (`gold_sell`), `src/earn/EarnEnterAmount.tsx` (`earn`), `src/send/EnterAmount.tsx` (`send`), `src/swap/SwapScreen.tsx` (`swap`).

## How to verify post-release

Once 1.118.9 is live in Play + App Store, wait 24-48h and run (via Sentry MCP):

```
list_issues(account="tucop-finance", query="is:unresolved level:info", statsPeriod="24h")
```

Expected: up to 20 issues with `title=percentage_chip_tap` and tags `flow=<flow>, percentage=<pct>`. Any flow x percentage combo with 0 events after material install base = regression on that specific flow.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `yarn test src/sentry/__tests__/captureUxSignal.test.ts` (5/5 pass)
- [x] `yarn test --testPathPattern="send/EnterAmount|swap/SwapScreen|earn/EarnEnterAmount"` (126/126 pass, no regressions)
- [ ] Post-1.118.9 rollout: confirm at least 1 event per flow x percentage combo lands in Sentry within 24-48h