### PR TITLE
feat(earn/neeru): rich empty state on vault detail with rate hero + how-it-works

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -159,7 +159,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
-        versionName "1.118.7"
+        versionName "1.118.8"
         multiDexEnabled true
         ndk {
             // Reads from reactNativeArchitectures (gradle.properties or CLI override).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -159,7 +159,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
-        versionName "1.118.8"
+        versionName "1.118.7"
         multiDexEnabled true
         ndk {
             // Reads from reactNativeArchitectures (gradle.properties or CLI override).

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2985,7 +2985,7 @@
         "step2": "Starts earning interest 24 hours after the deposit.",
         "step3Flexible": "Withdraw whenever you want, no fee.",
         "step3Fixed": "Withdraw at the end of the lock period. Early withdrawal available with a fee on the interest.",
-        "trustNote": "No banks or middlemen. Your deposit goes to Neeru, a public contract on the Celo network, and only you can withdraw it."
+        "trustNote": "No banks or middlemen. Only you control your deposit."
       }
     },
     "positionRow": {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2970,12 +2970,22 @@
       "aggregateBalance": "Total in {{categoryLabel}}: {{amount}} Pesos",
       "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% monthly",
       "depositCta": "Deposit",
-      "noPositions": "You don't have positions in this option yet",
       "descriptionByCategory": {
         "flexible": "Withdraw anytime with no minimum lock",
         "thirtyDays": "Lock your Pesos for 30 days at a higher rate",
         "sixtyDays": "Lock your Pesos for 60 days at a higher rate",
         "ninetyDays": "Lock your Pesos for 90 days at the highest rate"
+      },
+      "emptyState": {
+        "rateEyebrow": "Estimated rate",
+        "rateValueEa": "{{percentage}}% per year",
+        "rateEquivalentMv": "Equivalent to {{percentage}}% per month",
+        "howItWorksHeader": "How it works",
+        "step1": "Deposit your Pesos from your wallet.",
+        "step2": "Starts earning interest 24 hours after the deposit.",
+        "step3Flexible": "Withdraw whenever you want, no fee.",
+        "step3Fixed": "Withdraw at the end of the lock period. Early withdrawal available with a fee on the interest.",
+        "trustNote": "Your money stays in your wallet, no intermediaries. Contract runs on the Celo network."
       }
     },
     "positionRow": {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2985,7 +2985,7 @@
         "step2": "Starts earning interest 24 hours after the deposit.",
         "step3Flexible": "Withdraw whenever you want, no fee.",
         "step3Fixed": "Withdraw at the end of the lock period. Early withdrawal available with a fee on the interest.",
-        "trustNote": "Your money stays in your wallet, no intermediaries. Contract runs on the Celo network."
+        "trustNote": "No banks or middlemen. Your deposit goes to Neeru, a public contract on the Celo network, and only you can withdraw it."
       }
     },
     "positionRow": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2992,7 +2992,7 @@
         "step2": "Empieza a generar intereses 24 horas despues del deposito.",
         "step3Flexible": "Retiras cuando quieras, sin costo.",
         "step3Fixed": "Retiras al vencimiento del plazo. Retiro anticipado disponible con penalidad sobre los intereses.",
-        "trustNote": "Tu dinero se queda en tu wallet, sin intermediarios. Contrato ejecutado en la red Celo."
+        "trustNote": "Sin bancos ni empresas de por medio. Tu deposito va a Neeru, un contrato publico en la red Celo, y solo tu puedes retirarlo."
       }
     },
     "positionRow": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2977,12 +2977,22 @@
       "aggregateBalance": "Total en {{categoryLabel}}: {{amount}} Pesos",
       "monthlyRate": "{{rate, number(maximumFractionDigits: 2)}}% mensual",
       "depositCta": "Depositar",
-      "noPositions": "Todavia no tienes depositos en esta opcion",
       "descriptionByCategory": {
         "flexible": "Retira en cualquier momento, sin tiempo minimo",
         "thirtyDays": "Bloquea tus Pesos 30 dias a una tasa mas alta",
         "sixtyDays": "Bloquea tus Pesos 60 dias a una tasa mas alta",
         "ninetyDays": "Bloquea tus Pesos 90 dias a la tasa mas alta"
+      },
+      "emptyState": {
+        "rateEyebrow": "Tasa estimada",
+        "rateValueEa": "{{percentage}}% al ano",
+        "rateEquivalentMv": "Equivale a {{percentage}}% al mes",
+        "howItWorksHeader": "Como funciona",
+        "step1": "Depositas tus Pesos desde tu wallet.",
+        "step2": "Empieza a generar intereses 24 horas despues del deposito.",
+        "step3Flexible": "Retiras cuando quieras, sin costo.",
+        "step3Fixed": "Retiras al vencimiento del plazo. Retiro anticipado disponible con penalidad sobre los intereses.",
+        "trustNote": "Tu dinero se queda en tu wallet, sin intermediarios. Contrato ejecutado en la red Celo."
       }
     },
     "positionRow": {

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2992,7 +2992,7 @@
         "step2": "Empieza a generar intereses 24 horas despues del deposito.",
         "step3Flexible": "Retiras cuando quieras, sin costo.",
         "step3Fixed": "Retiras al vencimiento del plazo. Retiro anticipado disponible con penalidad sobre los intereses.",
-        "trustNote": "Sin bancos ni empresas de por medio. Tu deposito va a Neeru, un contrato publico en la red Celo, y solo tu puedes retirarlo."
+        "trustNote": "Sin bancos ni empresas de por medio. Solo tu controlas tu deposito."
       }
     },
     "positionRow": {

--- a/src/earn/neeru/NeeruVaultDetailScreen.tsx
+++ b/src/earn/neeru/NeeruVaultDetailScreen.tsx
@@ -2,12 +2,13 @@ import { BottomSheetModal } from '@gorhom/bottom-sheet'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
 import * as React from 'react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { formatValueToDisplay } from 'src/components/TokenDisplay'
+import { neeruCatalogueCategoryByIdSelector } from 'src/earn/neeru/configSelectors'
 import {
   NEERU_CATEGORY_LABEL_KEYS,
   NeeruCategoryId,
@@ -16,6 +17,7 @@ import {
 import NeeruCloseSheet from 'src/earn/neeru/NeeruCloseSheet'
 import NeeruEmergencyCloseSheet from 'src/earn/neeru/NeeruEmergencyCloseSheet'
 import NeeruPositionRow from 'src/earn/neeru/NeeruPositionRow'
+import { effectiveAnnualPercentFromMonthly } from 'src/earn/neeru/rateConversion'
 import {
   neeruCloseStatusSelector,
   neeruFetchStatusSelector,
@@ -25,6 +27,7 @@ import {
 import { NEERU_LOW_POOL_ERROR } from 'src/earn/neeru/saga'
 import { emergencyCloseStart, fetchPositionsStart } from 'src/earn/neeru/slice'
 import { NeeruIndividualPosition } from 'src/earn/neeru/types'
+import { getTotalYieldRate } from 'src/earn/utils'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -92,6 +95,23 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
     }
   }, [closeStatus])
 
+  // Backend catalogue is the source of truth for both rates (retunes without
+  // a contract upgrade would otherwise leave stale numbers on the empty
+  // state hero). Falls back to the pool's yield rate + monthly->annual
+  // conversion when the catalogue is not loaded yet, so a cold boot still
+  // surfaces a reasonable E.A.
+  const catalogueCategory = useSelector((state) =>
+    categoryId !== null ? neeruCatalogueCategoryByIdSelector(state, categoryId) : null
+  )
+  const monthlyRate = useMemo(() => {
+    if (catalogueCategory) return catalogueCategory.monthlyRatePercentage
+    return getTotalYieldRate(pool).toNumber()
+  }, [catalogueCategory, pool])
+  const annualRate = useMemo(() => {
+    if (catalogueCategory) return catalogueCategory.annualEffectivePercentage
+    return effectiveAnnualPercentFromMonthly(monthlyRate)
+  }, [catalogueCategory, monthlyRate])
+
   if (categoryId === null) {
     return null
   }
@@ -102,6 +122,11 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
   const total = formatValueToDisplay(
     positions.reduce((acc, p) => acc.plus(p.currentPayoutIfClosed.total), new BigNumber(0))
   )
+  const isEmpty = positions.length === 0
+  const withdrawStepKey =
+    categoryId === 0
+      ? 'neeruVaults.detail.emptyState.step3Flexible'
+      : 'neeruVaults.detail.emptyState.step3Fixed'
 
   const handleManagePress = (pos: NeeruIndividualPosition) => {
     setSelectedPosition(pos)
@@ -121,18 +146,64 @@ export default function NeeruVaultDetailScreen({ route }: Props) {
       >
         <Text style={styles.header}>{t('neeruVaults.detail.header', { categoryLabel })}</Text>
         <Text style={styles.description}>{description}</Text>
-        <Text style={styles.total}>
-          {t('neeruVaults.detail.aggregateBalance', { categoryLabel, amount: total })}
-        </Text>
 
-        {positions.length === 0 ? (
-          <Text style={styles.empty}>{t('neeruVaults.detail.noPositions')}</Text>
-        ) : (
-          <View style={styles.positionsList}>
-            {positions.map((p) => (
-              <NeeruPositionRow key={p.positionId} position={p} onManagePress={handleManagePress} />
-            ))}
+        {isEmpty ? (
+          // Rich empty state: rate hero + how-it-works + trust footer.
+          // Replaces the previous sparse "Total en X: 0.00 Pesos" + one-line
+          // "Todavia no tienes depositos" that read as if the page were broken.
+          // Redundant total row is suppressed here (0 balance is implied).
+          <View testID="NeeruVaultDetail.EmptyState" style={styles.emptyCard}>
+            <Text style={styles.emptyRateEyebrow}>
+              {t('neeruVaults.detail.emptyState.rateEyebrow')}
+            </Text>
+            <Text style={styles.emptyRateValue}>
+              {t('neeruVaults.detail.emptyState.rateValueEa', {
+                percentage: annualRate.toFixed(2),
+              })}
+            </Text>
+            <Text style={styles.emptyRateSubtitle}>
+              {t('neeruVaults.detail.emptyState.rateEquivalentMv', {
+                percentage: monthlyRate.toFixed(2),
+              })}
+            </Text>
+
+            <View style={styles.emptyDivider} />
+
+            <Text style={styles.emptyStepsHeader}>
+              {t('neeruVaults.detail.emptyState.howItWorksHeader')}
+            </Text>
+            <View style={styles.emptyStep}>
+              <Text style={styles.emptyStepNumber}>1</Text>
+              <Text style={styles.emptyStepText}>{t('neeruVaults.detail.emptyState.step1')}</Text>
+            </View>
+            <View style={styles.emptyStep}>
+              <Text style={styles.emptyStepNumber}>2</Text>
+              <Text style={styles.emptyStepText}>{t('neeruVaults.detail.emptyState.step2')}</Text>
+            </View>
+            <View style={styles.emptyStep}>
+              <Text style={styles.emptyStepNumber}>3</Text>
+              <Text style={styles.emptyStepText}>{t(withdrawStepKey)}</Text>
+            </View>
+
+            <Text style={styles.emptyTrustNote}>
+              {t('neeruVaults.detail.emptyState.trustNote')}
+            </Text>
           </View>
+        ) : (
+          <>
+            <Text style={styles.total}>
+              {t('neeruVaults.detail.aggregateBalance', { categoryLabel, amount: total })}
+            </Text>
+            <View style={styles.positionsList}>
+              {positions.map((p) => (
+                <NeeruPositionRow
+                  key={p.positionId}
+                  position={p}
+                  onManagePress={handleManagePress}
+                />
+              ))}
+            </View>
+          </>
         )}
 
         <Button
@@ -179,12 +250,65 @@ const styles = StyleSheet.create({
   header: { ...typeScale.titleMedium, color: Colors.black },
   description: { ...typeScale.bodyMedium, color: Colors.gray3 },
   total: { ...typeScale.bodyLarge, color: Colors.black },
-  empty: {
-    ...typeScale.bodyMedium,
-    color: Colors.gray3,
-    marginTop: Spacing.Large32,
-    textAlign: 'center',
-  },
   positionsList: { gap: Spacing.Smallest8 },
   cta: { marginTop: Spacing.Large32 },
+  emptyCard: {
+    backgroundColor: Colors.gray1,
+    borderRadius: 16,
+    padding: Spacing.Thick24,
+    marginTop: Spacing.Smallest8,
+    gap: Spacing.Smallest8,
+  },
+  emptyRateEyebrow: {
+    ...typeScale.labelSmall,
+    color: Colors.gray4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  emptyRateValue: {
+    ...typeScale.titleLarge,
+    color: Colors.accent,
+  },
+  emptyRateSubtitle: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+  },
+  emptyDivider: {
+    height: 1,
+    backgroundColor: Colors.gray2,
+    marginVertical: Spacing.Regular16,
+  },
+  emptyStepsHeader: {
+    ...typeScale.labelSemiBoldSmall,
+    color: Colors.black,
+    marginBottom: Spacing.Smallest8,
+  },
+  emptyStep: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Spacing.Small12,
+    marginBottom: Spacing.Smallest8,
+  },
+  emptyStepNumber: {
+    ...typeScale.labelSemiBoldSmall,
+    color: Colors.white,
+    backgroundColor: Colors.accent,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    textAlign: 'center',
+    lineHeight: 24,
+    overflow: 'hidden',
+  },
+  emptyStepText: {
+    ...typeScale.bodyMedium,
+    color: Colors.black,
+    flex: 1,
+  },
+  emptyTrustNote: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+    marginTop: Spacing.Regular16,
+    fontStyle: 'italic',
+  },
 })

--- a/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx
@@ -80,16 +80,30 @@ describe('NeeruVaultDetailScreen', () => {
     })
   })
 
-  it('shows empty state when no positions', () => {
+  it('shows rich empty state when no positions', () => {
     const store = createMockStore({
       neeru: { ...initialNeeruState, positions: [], fetchStatus: 'success' },
     } as any)
-    const { getByText } = render(
+    const { getByTestId, getByText, queryByText } = render(
       <Provider store={store}>
         <NeeruVaultDetailScreen route={{ params: { pool } } as any} navigation={{} as any} />
       </Provider>
     )
-    expect(getByText('neeruVaults.detail.noPositions')).toBeTruthy()
+    // Rich card is rendered
+    expect(getByTestId('NeeruVaultDetail.EmptyState')).toBeTruthy()
+    // Rate hero, how-it-works header, and 3 steps are visible
+    expect(getByText('neeruVaults.detail.emptyState.rateEyebrow')).toBeTruthy()
+    expect(getByText('neeruVaults.detail.emptyState.howItWorksHeader')).toBeTruthy()
+    expect(getByText('neeruVaults.detail.emptyState.step1')).toBeTruthy()
+    expect(getByText('neeruVaults.detail.emptyState.step2')).toBeTruthy()
+    // Mock pool is category 1 (30 dias fixed tranche), so the withdraw step
+    // is the fixed variant (mentions the lock period + early withdraw fee).
+    expect(getByText('neeruVaults.detail.emptyState.step3Fixed')).toBeTruthy()
+    expect(getByText('neeruVaults.detail.emptyState.trustNote')).toBeTruthy()
+    // Legacy sparse "Total en X: 0.00 Pesos" and one-line "no tienes depositos"
+    // are suppressed in the empty state (they read as if the page were broken)
+    expect(queryByText('neeruVaults.detail.aggregateBalance')).toBeNull()
+    expect(queryByText('neeruVaults.detail.noPositions')).toBeNull()
   })
 
   it('does not render the legacy transparency block', () => {


### PR DESCRIPTION
## Summary

The Neeru vault detail screen's empty state ("Tus depositos Flexible" when the user has no positions yet) was a one-liner "Todavia no tienes depositos en esta opcion" below a "Total en Flexible: 0.00 Pesos" row. User feedback: reads as if the page were broken and gives zero context on what would happen if they tap "Depositar".

## Change

Replaces the empty layout with a single card that leads the user:

1. **Rate hero** in accent color: "XX.XX% al ano" with "Equivale a XX.XX% al mes" subtitle. Source of truth is the backend catalogue (`neeruCatalogueCategoryByIdSelector`); falls back to monthly->annual conversion (`effectiveAnnualPercentFromMonthly`) when the catalogue isn't loaded yet.
2. **Como funciona** numbered steps:
   - Depositas tus Pesos desde tu wallet
   - Empieza a generar intereses 24 horas despues del deposito (matches the on-chain guard `if (nowTs < last + 1 days) return 0` in `FondoCOPmMVP.sol:574`)
   - Withdraw step branches on tranche: Flexible = withdraw whenever without fee. Fixed (30/60/90d) = withdraw at maturity or early with a fee on the interest.
3. **Trust note**: money stays in the wallet, contract runs on Celo. Plain language, no addresses (respects the Neeru zero-exposure policy memory).

When `positions.length > 0` the layout is unchanged: aggregate balance + positions list. The redundant "Total: 0.00 Pesos" row is suppressed only on the empty state (it adds noise when the answer is "you have zero").

## Files

- `src/earn/neeru/NeeruVaultDetailScreen.tsx`: empty-state JSX + styles + rate memos
- `src/earn/neeru/__tests__/NeeruVaultDetailScreen.test.tsx`: updated existing "shows empty state" test to assert the rich card, correct withdraw step (mock pool is category 1 = fixed), and suppression of legacy sparse messages
- `locales/es-419/translation.json` + `locales/base/translation.json`: 9 new keys under `neeruVaults.detail.emptyState`, old `noPositions` key removed (no callers)

## Test plan

- [x] `yarn build:ts` (0 errors)
- [x] `yarn lint src/earn/neeru/NeeruVaultDetailScreen.tsx` (0 errors)
- [x] `yarn test --testPathPattern="src/earn/neeru/__tests__"` (113/113 pass, 7 skipped as before)
- [ ] Visual smoke on emulator: open Earn -> tap any pool (Flexible + a fixed one to see both step 3 variants) -> confirm empty state renders the new card. Then optionally deposit a small amount and reopen to confirm the layout switches to aggregate + positions list.