### PR TITLE
feat(firebase): FirebaseDisabledError for dynamicLinks helpers

### DIFF
--- a/src/firebase/dynamicLinks.test.ts
+++ b/src/firebase/dynamicLinks.test.ts
@@ -1,4 +1,5 @@
-import { createJumpstartLink } from 'src/firebase/dynamicLinks'
+import { createJumpstartLink, FirebaseDisabledError } from 'src/firebase/dynamicLinks'
+import * as config from 'src/config'
 import { getDynamicConfigParams } from 'src/statsig'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
@@ -10,6 +11,11 @@ jest.mock('@react-native-firebase/dynamic-links', () => () => ({
 jest.mock('src/statsig')
 
 describe('dynamic links', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(config as any).FIREBASE_ENABLED = true
+  })
+
   it('should create the jumpstart link', async () => {
     jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
       if (configName === StatsigDynamicConfigs.APP_CONFIG) {
@@ -31,5 +37,15 @@ describe('dynamic links', () => {
     expect(result).toEqual(
       `${mockBaseLink}https%3A%2F%2Fcelo%2Eorg%2Fjumpstart%2F0xprivateKey%2Fcelo%2Dmainnet`
     )
+  })
+
+  it('throws FirebaseDisabledError when Firebase is disabled', async () => {
+    ;(config as any).FIREBASE_ENABLED = false
+    await expect(
+      createJumpstartLink('0xprivateKey', NetworkId['celo-mainnet'])
+    ).rejects.toBeInstanceOf(FirebaseDisabledError)
+    // Firebase SDK must not be invoked when the flag is off, so the private
+    // key never reaches the native module.
+    expect(mockBuildLink).not.toHaveBeenCalled()
   })
 })

--- a/src/firebase/dynamicLinks.ts
+++ b/src/firebase/dynamicLinks.ts
@@ -3,6 +3,7 @@ import {
   APP_STORE_ID as appStoreId,
   DYNAMIC_LINK_DOMAIN_URI_PREFIX as baseURI,
   APP_BUNDLE_ID as bundleId,
+  FIREBASE_ENABLED,
 } from 'src/config'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
@@ -21,7 +22,20 @@ const commonDynamicLinkParams: Omit<FirebaseDynamicLinksTypes.DynamicLinkParamet
   },
 }
 
+// Thrown when a Firebase Dynamic Links helper is invoked while Firebase is
+// disabled at the .env level. Callers can catch this specifically to fall
+// back to a plain web URL, disable the "share via link" affordance, or
+// surface a friendly "feature unavailable" message. Kept as its own class
+// so callers do not need to string-match on Firebase's native error.
+export class FirebaseDisabledError extends Error {
+  constructor(feature: string) {
+    super(`Firebase is disabled; cannot ${feature}`)
+    this.name = 'FirebaseDisabledError'
+  }
+}
+
 export async function createInviteLink(address: string) {
+  if (!FIREBASE_ENABLED) throw new FirebaseDisabledError('createInviteLink')
   const { links } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.APP_CONFIG])
   return dynamicLinks().buildShortLink({
     ...commonDynamicLinkParams,
@@ -30,6 +44,7 @@ export async function createInviteLink(address: string) {
 }
 
 export async function createJumpstartLink(privateKey: string, networkId: NetworkId) {
+  if (!FIREBASE_ENABLED) throw new FirebaseDisabledError('createJumpstartLink')
   const { links } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.APP_CONFIG])
   // avoid calling firebase sdk with private key during link creation to protect
   // the private key from being stored


### PR DESCRIPTION
## Summary

Small harm-reduction fix. The two Firebase Dynamic Links helpers now throw a dedicated `FirebaseDisabledError` instead of a raw Firebase native error when `FIREBASE_ENABLED=false` (current state per `.env.mainnet:9`). Callers can catch specifically and degrade gracefully.

This is **NOT** the fix for Sentry TUCOPWALLET-8 (Firebase not initialized). That crash fires from `ReactNativeFirebaseDynamicLinksModule.onNewIntent` on the Android native side, before any JS runs. That one requires a product-level decision (activate Firebase / remove Firebase modules / stub google-services.json). Options captured in `PENDING.md` as a separate entry.

## Changes

`src/firebase/dynamicLinks.ts` (+15 lines):
- New `FirebaseDisabledError` class (exported).
- `createInviteLink` and `createJumpstartLink` guard on `FIREBASE_ENABLED` before calling `dynamicLinks()`.

## Why this specifically

- `createInviteLink` was already gated at the call site (`src/invite/hooks.tsx:22` checks `FIREBASE_ENABLED`). Adding a helper-side guard is defensive redundancy.
- `createJumpstartLink` was **not** gated (`src/jumpstart/JumpstartEnterAmount.tsx:77` calls it directly). Before this PR, tapping "Enviar por link" in the jumpstart flow with Firebase disabled would throw an opaque Firebase native error the caller has no way to recognize. Now it throws `FirebaseDisabledError` which the caller can identify by `err.name === 'FirebaseDisabledError'` or `instanceof`.

## Test plan

- [x] `yarn build:ts` (0 errors)
- [ ] Follow-up: caller in `JumpstartEnterAmount.tsx` should catch `FirebaseDisabledError` and either disable the "Enviar por link" affordance or surface "Feature no disponible" toast. Not in scope for this PR (needs product input on the UX copy).