### PR TITLE
chore(rename): MobileStack -> TuCop tier 1 (cosmetic)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
     <!-- Set custom default icon. This is used when no icon is set for incoming notification messages.
      See README(https://goo.gl/l4GJaQ) for more. -->
     <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/ic_notification_small" />
-    <meta-data tools:replace="android:resource" android:name="com.google.firebase.messaging.default_notification_color" android:resource="@color/mobilestack_notification" />
+    <meta-data tools:replace="android:resource" android:name="com.google.firebase.messaging.default_notification_color" android:resource="@color/tucop_notification" />
 
     <meta-data android:name="CLEVERTAP_BACKGROUND_SYNC" android:value="1"/>
 

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <color name="mobilestack_background">#45CD85</color>
-  <color name="mobilestack_notification">#42D689</color>
+  <color name="tucop_background">#45CD85</color>
+  <color name="tucop_notification">#42D689</color>
   <color name="primary_dark">#000000</color>
 </resources>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- See https://developer.android.com/guide/topics/data/autobackup on how to modify this file -->
 <full-backup-content>
-  <include domain="file" path=".integration/mobilestackandroid"/>
+  <include domain="file" path=".integration/tucopandroid"/>
 </full-backup-content>

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "mobilestack",
-  "displayName": "MobileStack"
+  "name": "tucop",
+  "displayName": "TuCop"
 }


### PR DESCRIPTION
## Summary

Tier 1 of 3 for the MobileStack -> TuCop rename. Only user-invisible identifiers that carry the MobileStack brand. No functional risk.

**What is NOT in this PR** (each in its own PR):
- **Tier 2**: Xcode project + workspace + scheme rename (\`ios/MobileStack.*\` -> \`ios/TuCop.*\`, all CI/fastlane/script refs)
- **Tier 3**: Android Java package rename (\`xyz.mobilestack\` -> \`finance.tucop\`)

**What is NEVER renamed:**
- \`APP_BUNDLE_ID=org.tucop\` (already TuCop)
- \`RELEASE_KEY_ALIAS=mobilestack-key-alias\` in \`android/gradle.properties\` (keystore alias, renaming would break Play Store install continuity)
- \`applicationId\` = \`org.tucop\` (already TuCop)

## Changes

- **\`app.json\`**: \`name\` \`mobilestack\` -> \`tucop\`, \`displayName\` \`MobileStack\` -> \`TuCop\`. Not consumed at runtime; iOS \`AppDelegate.mm:90\` and Android \`MainActivity.kt:24\` both read \`APP_REGISTRY_NAME\` from env (already \`TuCop\`).
- **\`android/app/src/main/res/values/colors.xml\`**: \`mobilestack_background\`/\`mobilestack_notification\` -> \`tucop_background\`/\`tucop_notification\`.
- **\`android/app/src/main/AndroidManifest.xml\`**: updated the Firebase notification color meta-data ref to match (\`@color/tucop_notification\`). Atomic with the colors.xml rename.
- **\`android/app/src/main/res/xml/backup_rules.xml\`**: \`.integration/mobilestackandroid\` -> \`.integration/tucopandroid\`. Nothing in the codebase writes to this path (audited), so it is a vestigial autobackup whitelist rule. Zero user impact.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [ ] Android build validated on next \`yarn dev:android\`: notification color still renders (Firebase message color meta-data)
- [ ] iOS build unaffected (this PR touches no iOS files)