### PR TITLE
chore(rename): xyz.mobilestack -> org.tucop.wallet (tier 3)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -141,7 +141,7 @@ def secrets = loadProjectSecrets("mainnet")
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    namespace "xyz.mobilestack"
+    namespace "org.tucop.wallet"
 
     // AGP 8.x configuration - removed obsolete aaptOptions
 
@@ -172,7 +172,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         resValue "string", "app_name", project.env.get("APP_DISPLAY_NAME")
         resValue "string", "deep_link_url_scheme", project.env.get("DEEP_LINK_URL_SCHEME")
-        resValue "string", "build_config_package", "xyz.mobilestack"
+        resValue "string", "build_config_package", "org.tucop.wallet"
         missingDimensionStrategy 'react-native-camera', 'general'
         vectorDrawables.useSupportLibrary = true
         resValue "bool", "is_profiling_build", System.getenv("IS_PROFILING_BUILD") ?: "false"

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -20,7 +20,7 @@
 -keep class com.segment.analytics.** { *; }
 -keep class androidx.lifecycle.DefaultLifecycleObserver
 
--keep class xyz.mobilestack.BuildConfig { *; }
+-keep class org.tucop.wallet.BuildConfig { *; }
 -keep public class com.horcrux.svg.** {*;}
 -keep class com.rt2zz.reactnativecontacts.** {*;}
 -keepclassmembers class com.rt2zz.reactnativecontacts.** {*;}

--- a/android/app/src/androidTest/AndroidManifest.xml
+++ b/android/app/src/androidTest/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools" package="xyz.mobilestack" android:versionCode="1" android:versionName="1.0">
+  xmlns:tools="http://schemas.android.com/tools" package="org.tucop.wallet" android:versionCode="1" android:versionName="1.0">
   <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" tools:overrideLibrary="com.wix.detox, android.support.test.uiautomator.v18" />
 </manifest>

--- a/android/app/src/androidTest/java/org/tucop/wallet/DetoxTest.java
+++ b/android/app/src/androidTest/java/org/tucop/wallet/DetoxTest.java
@@ -1,4 +1,4 @@
-package xyz.mobilestack;
+package org.tucop.wallet;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
@@ -25,7 +25,7 @@ public class DetoxTest {
     DetoxConfig detoxConfig = new DetoxConfig();
     detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
     detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
-    detoxConfig.rnContextLoadTimeoutSec = (xyz.mobilestack.BuildConfig.DEBUG ? 180 : 60);
+    detoxConfig.rnContextLoadTimeoutSec = (org.tucop.wallet.BuildConfig.DEBUG ? 180 : 60);
 
     Detox.runTests(mActivityRule, detoxConfig);
   }

--- a/android/app/src/main/java/org/tucop/wallet/FirebaseMessagingService.java
+++ b/android/app/src/main/java/org/tucop/wallet/FirebaseMessagingService.java
@@ -1,4 +1,4 @@
-package xyz.mobilestack;
+package org.tucop.wallet;
 
 import android.os.Bundle;
 import android.util.Log;

--- a/android/app/src/main/java/org/tucop/wallet/MainActivity.kt
+++ b/android/app/src/main/java/org/tucop/wallet/MainActivity.kt
@@ -1,4 +1,4 @@
-package xyz.mobilestack
+package org.tucop.wallet
 
 import android.content.Intent
 import android.os.Build

--- a/android/app/src/main/java/org/tucop/wallet/MainApplication.kt
+++ b/android/app/src/main/java/org/tucop/wallet/MainApplication.kt
@@ -1,4 +1,4 @@
-package xyz.mobilestack
+package org.tucop.wallet
 
 import androidx.multidex.MultiDexApplication
 import cl.json.ShareApplication

--- a/android/app/src/main/java/org/tucop/wallet/UserAgentClientFactory.java
+++ b/android/app/src/main/java/org/tucop/wallet/UserAgentClientFactory.java
@@ -1,4 +1,4 @@
-package xyz.mobilestack;
+package org.tucop.wallet;
 
 import android.content.Context;
 import com.facebook.react.modules.network.OkHttpClientFactory;

--- a/android/app/src/main/java/org/tucop/wallet/UserAgentInterceptor.java
+++ b/android/app/src/main/java/org/tucop/wallet/UserAgentInterceptor.java
@@ -1,4 +1,4 @@
-package xyz.mobilestack;
+package org.tucop.wallet;
 
 import android.os.Build;
 import java.io.IOException;


### PR DESCRIPTION
## Summary

Tier 3 of 3 for the MobileStack -> TuCop rename. Renames the Android **internal Java package** from the legacy Valora/MobileStack lineage (\`xyz.mobilestack\`) to \`org.tucop.wallet\`.

**Depends on** #308 and #309 (both merged).

## What this changes

- **Internal Java/Kotlin package** used in every \`.kt\`/\`.java\` file's \`package\` declaration
- **AGP namespace** in \`android/app/build.gradle\`
- **BuildConfig package** (\`resValue \"build_config_package\"\`)
- **ProGuard keep rule** for the BuildConfig class
- **androidTest manifest** \`package=\` attribute

## What this does NOT change (user-invisible = install continuity preserved)

- \`applicationId=org.tucop\` (verified with \`aapt2 dump packagename\` on the built APK: still \`org.tucop\`)
- Bundle ID (\`org.tucop\`)
- Keystore alias (\`mobilestack-key-alias\` in \`android/gradle.properties\`, cannot change without breaking Play Store)
- Deep-link universal-link host (\`tucop.xyz\`)
- Anything the user sees on the device or on Play Store

## Why \`org.tucop.wallet\`

Reverse-DNS convention. \`org.tucop\` is the app's official identity (matches \`applicationId=org.tucop\`, which corresponds to the \`tucop.org\` domain). The \`.wallet\` suffix leaves clean namespace room for future TuCop apps (\`org.tucop.ramp\`, \`org.tucop.backend\`).

## Where you will notice the change

- **Sentry stack traces** now read \`at org.tucop.wallet.MainActivity.onCreate\` instead of \`at xyz.mobilestack.MainActivity.onCreate\` (more legible + coherent with the brand)
- **Android Studio Logcat** during dev
- **Firebase Analytics** debug views

## Files changed

- \`android/app/src/main/java/xyz/mobilestack/\` -> \`android/app/src/main/java/org/tucop/wallet/\` (5 files: \`MainActivity.kt\`, \`MainApplication.kt\`, \`FirebaseMessagingService.java\`, \`UserAgentClientFactory.java\`, \`UserAgentInterceptor.java\`)
- \`android/app/src/androidTest/java/xyz/mobilestack/DetoxTest.java\` -> \`android/app/src/androidTest/java/org/tucop/wallet/DetoxTest.java\` (also updated the fully-qualified \`xyz.mobilestack.BuildConfig.DEBUG\` reference inside the file)
- \`android/app/build.gradle\` (namespace + resValue build_config_package)
- \`android/app/proguard-rules.pro\` (\`-keep class\` rule)
- \`android/app/src/androidTest/AndroidManifest.xml\` (\`package=\` attr)

## Test plan

- [x] \`./gradlew :app:assembleMainnetDebug\`: BUILD SUCCESSFUL in 4m 27s
- [x] \`aapt2 dump packagename\` on the built APK returns \`org.tucop\` (applicationId + install continuity intact)
- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [ ] CI \`Mobile\` check builds Android AAB + iOS Archive
- [ ] Post-merge Sentry: confirm new stack traces show \`org.tucop.wallet.*\` frames on next release