### PR TITLE
chore(statsig): drop unused SHOW_DIGITAL_GOLD enum

### DIFF
--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -40,7 +40,6 @@ export enum StatsigFeatureGates {
   SHOW_UK_COMPLIANT_VARIANT = 'show_uk_compliant_variant',
   ALLOW_EARN_PARTIAL_WITHDRAWAL = 'allow_earn_partial_withdrawal',
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
-  SHOW_DIGITAL_GOLD = 'show_digital_gold',
   SHOW_NEERU_VAULTS = 'show_neeru_vaults',
   WRI_PREFLIGHT_SWAP_SIMULATION = 'wri_preflight_swap_simulation',
   WRI_DOLLARS_SPEND_7702_V1 = 'wri_dollars_spend_7702_v1',


### PR DESCRIPTION
## Summary

Digital Gold is shipped and on for 100% of users. No kill-switch is planned.

The \`SHOW_DIGITAL_GOLD = 'show_digital_gold'\` entry in [\`src/statsig/types.ts\`](src/statsig/types.ts) is zero-referenced across the codebase (verified via grep: only the declaration itself, no consumers in \`src/\`, \`e2e/\`, tests, or anywhere else).

## Change

One-line removal:

\`\`\`diff
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
-  SHOW_DIGITAL_GOLD = 'show_digital_gold',
   SHOW_NEERU_VAULTS = 'show_neeru_vaults',
\`\`\`

## What this does not touch

- The gate \`show_digital_gold\` in the Statsig dashboard is not deleted (that is a separate operation and not needed to make this change).
- Zero runtime impact.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [ ] Mobile CI check