### PR TITLE
fix(ios): patch fmt/base.h to unblock Xcode 26.5 iOS builds

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -108,11 +108,43 @@ post_install do |installer|
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FOLLY_HAVE_CLOCK_GETTIME=1'
       end
 
-      # Fix fmt library consteval issue with Xcode 26.4 beta
-      # https://github.com/fmtlib/fmt/issues/4116
-      if target.name == 'fmt'
+    end
+
+    # Patch fmt/base.h to disable consteval on Xcode 26.5.
+    # https://github.com/fmtlib/fmt/issues/4116
+    #
+    # fmt 11.0.2 (pinned transitively via React Native 0.77.3) unconditionally
+    # sets `#define FMT_USE_CONSTEVAL 1` in fmt/base.h, so command-line -D
+    # flags cannot override it. Xcode 26.5 clang is strict enough to fail the
+    # consteval evaluation inside format-inl.h, breaking the whole iOS build.
+    #
+    # This rewrites the header at pod-install time so each `#define FMT_USE_CONSTEVAL <n>`
+    # only fires if not already defined. Combined with the -DFMT_USE_CONSTEVAL=0
+    # below, this forces fmt to take the constexpr fallback branch. Header
+    # rewrite is idempotent - a second run finds the guards already in place.
+    #
+    # When React Native ships a newer fmt (>=11.1) that has upstream guards,
+    # delete this whole block.
+    if target.name == 'fmt'
+      # Set the build setting first, so even if the header rewrite fails, the
+      # -D flag is still present for the compiler.
+      target.build_configurations.each do |config|
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_CONSTEVAL=constexpr'
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'
+      end
+      # Header is installed read-only by CocoaPods; chmod +w before patching.
+      fmt_base_h = File.join(installer.sandbox.pod_dir(target.name), 'include', 'fmt', 'base.h')
+      if File.exist?(fmt_base_h)
+        contents = File.read(fmt_base_h)
+        # Guard the two lines that unconditionally re-define FMT_USE_CONSTEVAL 1
+        # so the compile-time -DFMT_USE_CONSTEVAL=0 wins.
+        patched = contents
+          .gsub(/^(#\s*define\s+FMT_USE_CONSTEVAL\s+1)$/, "#ifndef FMT_USE_CONSTEVAL\n\\1\n#endif")
+        if patched != contents
+          File.chmod(0644, fmt_base_h)
+          File.write(fmt_base_h, patched)
+          puts "[fmt patch] Guarded FMT_USE_CONSTEVAL redefinitions in #{fmt_base_h}"
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes the iOS local build with **Xcode 26.5**. Ship-blocker for the App Store archive step (Stage 5 of \`.claude/rules/release-procedure.md\`), since without this every dev needs to keep an older Xcode around or the archive step fails halfway through the pod build.

CI (ubuntu clang) does not hit this because its clang tolerates the pattern loosely; only Apple's Xcode 26.5 clang enforces \`consteval\` strictly, so this only manifested locally.

## The bug in fmt

The historical fix in [\`ios/Podfile\`](ios/Podfile) added \`-DFMT_CONSTEVAL=constexpr\` to the fmt target when Xcode 26.4 beta introduced stricter \`consteval\` enforcement. That fix stopped working on Xcode 26.5 because:

1. **fmt 11.0.2** (pinned transitively via React Native 0.77.3) sets \`#define FMT_USE_CONSTEVAL 1\` in \`fmt/base.h\` without an \`#ifndef\` guard, so a command-line \`-DFMT_USE_CONSTEVAL=0\` gets **overwritten** by the header the moment it is included.
2. The parent guard \`#define FMT_CONSTEVAL consteval\` is also unguarded, so even the older \`-DFMT_CONSTEVAL=constexpr\` override loses on Xcode 26.5, where the header definition is applied deeper in the compile chain.

Symptom (breaks the whole iOS build during pod compile):

\`\`\`
error: call to consteval function 'fmt::basic_format_string<...>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
\`\`\`

## The fix

In [\`ios/Podfile\`](ios/Podfile) \`post_install\` hook, for the \`fmt\` target:

1. Add \`FMT_USE_CONSTEVAL=0\` to \`GCC_PREPROCESSOR_DEFINITIONS\` **first** (so if the header rewrite ever fails, the \`-D\` is still set).
2. Rewrite \`fmt/base.h\` so each \`#define FMT_USE_CONSTEVAL 1\` is wrapped in \`#ifndef FMT_USE_CONSTEVAL\` / \`#endif\`. Compile-time \`-D\` now wins. \`File.chmod(0644, ...)\` is required because CocoaPods installs the header read-only. The rewrite is idempotent: a second \`pod install\` finds the guards already in place and no-ops the write.

Deleteme when React Native ships a fmt \`>=11.1\` that has upstream guards.

## Verification

- \`pod install\` prints \`[fmt patch] Guarded FMT_USE_CONSTEVAL redefinitions ...\` on a clean install
- \`grep -c FMT_USE_CONSTEVAL ios/Pods/fmt/include/fmt/base.h\`: 13 (2 guarded lines become 6 lines with \`#ifndef\`/\`#define\`/\`#endif\`, plus the original 7 \`= 0\` definitions)
- \`grep -c FMT_USE_CONSTEVAL ios/Pods/Pods.xcodeproj/project.pbxproj\`: 2 (fmt target Debug + Release)
- \`xcodebuild -workspace ios/TuCop.xcworkspace -scheme TuCop-mainnetdev -configuration Debug -destination 'platform=iOS Simulator,id=<sim>' build\`: **BUILD SUCCEEDED** on Xcode 26.5
- App installed + launched on iPhone 16 Pro simulator (iOS 26.5), no crash

## Test plan

- [x] \`pod install\` clean run applies the patch
- [x] iOS Debug build succeeds on Xcode 26.5
- [x] Idempotent: second \`pod install\` does not blow up
- [ ] CI \`Mobile\` iOS Archive build