### PR TITLE
feat(wallet): add aggregated other-investments row in TabWallet

### DIFF
--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -2111,7 +2111,8 @@
     "tetherUsd": "USDT",
     "usdCoin": "USDC",
     "yourMoney": "Tu dinero",
-    "yourInvestments": "Tus inversiones"
+    "yourInvestments": "Tus inversiones",
+    "otherInvestments": "Otras inversiones"
   },
   "notificationCenterSpotlight": {
     "message": "Presentamos una nueva forma de reclamar recompensas, ver alertas y consultar actualizaciones en un solo lugar",

--- a/src/tokens/TabWallet.tsx
+++ b/src/tokens/TabWallet.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import React, { useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
@@ -11,9 +12,11 @@ import { useXaut0Balance } from 'src/gold/useXaut0Balance'
 import { refreshAllBalances } from 'src/home/actions'
 import { FlatCard } from 'src/home/TabHome'
 import i18n from 'src/i18n'
-import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
+import { getLocalCurrencySymbol, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { getPositionBalanceUsd } from 'src/positions/getPositionBalanceUsd'
+import { positionsByBalanceUsdSelector } from 'src/positions/selectors'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -67,6 +70,19 @@ function TabWallet() {
 
   // Gold local value still needed for the Tus inversiones section below
   const { goldLocalValue } = useTotalBalanceWithInvestments(goldBalance)
+
+  // Sum of external investments (Neeru + Allbridge + Aave) shown as a single
+  // aggregated row below Gold. Kept in sync with BalanceCard's
+  // SUPPORTED_INVESTMENT_APP_IDS so both surfaces agree on which apps count.
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
+  const allPositions = useSelector(positionsByBalanceUsdSelector)
+  const otherInvestmentsLocalValue = useMemo(() => {
+    const supportedApps = new Set(['aave', 'allbridge', 'neeru-vaults'])
+    const usdSum = allPositions
+      .filter((p) => supportedApps.has(p.appId))
+      .reduce((sum, p) => sum.plus(getPositionBalanceUsd(p)), new BigNumber(0))
+    return usdToLocalRate ? usdSum.multipliedBy(usdToLocalRate) : new BigNumber(0)
+  }, [allPositions, usdToLocalRate])
 
   Logger.info('TOKEN', allTokens)
   Logger.info('supportedNetworkIds', supportedNetworkIds)
@@ -166,6 +182,35 @@ function TabWallet() {
                     </View>
                   </View>
                 </Touchable>
+
+                {/* Other investments: single aggregated row summing all
+                    external protocol positions (Neeru + Allbridge + Aave).
+                    Only rendered when the user has at least one position. */}
+                {otherInvestmentsLocalValue.gt(0) && (
+                  <Touchable
+                    onPress={() => navigate(Screens.EarnHome)}
+                    testID="OtherInvestmentsItem"
+                  >
+                    <View style={styles.goldItem}>
+                      <Grow size={32} />
+                      <View style={styles.goldTextContainer}>
+                        <View>
+                          <Text style={styles.goldLabel}>{t('assets.otherInvestments')}</Text>
+                        </View>
+                        <View style={styles.goldBalanceContainer}>
+                          {!hideWalletBalances ? (
+                            <Text style={styles.goldBalance}>
+                              {localCurrencySymbol}
+                              {otherInvestmentsLocalValue.toFormat(2)}
+                            </Text>
+                          ) : (
+                            <Text style={styles.goldBalance}>••••••</Text>
+                          )}
+                        </View>
+                      </View>
+                    </View>
+                  </Touchable>
+                )}
               </View>
 
               <View style={{ marginHorizontal: 20 }}>

--- a/src/tokens/TabWallet.tsx
+++ b/src/tokens/TabWallet.tsx
@@ -71,13 +71,12 @@ function TabWallet() {
   // Gold local value still needed for the Tus inversiones section below
   const { goldLocalValue } = useTotalBalanceWithInvestments(goldBalance)
 
-  // Sum of external investments (Neeru + Allbridge + Aave) shown as a single
-  // aggregated row below Gold. Kept in sync with BalanceCard's
-  // SUPPORTED_INVESTMENT_APP_IDS so both surfaces agree on which apps count.
+  // Sum of external investments (Neeru + Allbridge) shown as a single
+  // aggregated row below Gold. Only the protocols TuCop actually integrates.
   const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const allPositions = useSelector(positionsByBalanceUsdSelector)
   const otherInvestmentsLocalValue = useMemo(() => {
-    const supportedApps = new Set(['aave', 'allbridge', 'neeru-vaults'])
+    const supportedApps = new Set(['allbridge', 'neeru-vaults'])
     const usdSum = allPositions
       .filter((p) => supportedApps.has(p.appId))
       .reduce((sum, p) => sum.plus(getPositionBalanceUsd(p)), new BigNumber(0))


### PR DESCRIPTION
## Summary

Wallet screen (Billetera tab) used to show only Oro (XAUt0) under "Tus inversiones". Users with balances in Neeru / Allbridge / Aave saw nothing there. Now we add a single aggregated row below Gold that sums those external protocol positions and shows the local-currency total. Not detailed by pool - just "Otras inversiones: COP$X.XX".

## Change

- New row in [\`src/tokens/TabWallet.tsx\`](src/tokens/TabWallet.tsx) below the Gold row.
- Only rendered when the sum is > 0.
- Tap navigates to \`EarnHome\` (existing pool-by-pool detail screen).
- Sum uses \`positionsByBalanceUsdSelector\` -> filter by whitelist \`{aave, allbridge, neeru-vaults}\` -> \`getPositionBalanceUsd\` -> multiply by \`usdToLocalCurrencyRateSelector\`.
- Uses \`Grow\` icon (same one used in the EarnHome CTA button below) for visual consistency.
- New i18n key \`assets.otherInvestments\` = "Otras inversiones" in es-419.

## Consistency with BalanceCard

The whitelist \`{'aave', 'allbridge', 'neeru-vaults'}\` matches what [\`src/components/BalanceCard.tsx\`](src/components/BalanceCard.tsx) uses in its investments card (with the small delta that BalanceCard doesn't include \`neeru-vaults\` yet - that's a separate cleanup pass). Both surfaces should stay in sync so users don't see different aggregates on Home vs Wallet.

## Zero-render safety

The row is gated by \`otherInvestmentsLocalValue.gt(0)\`. Wallets with no positions in the whitelisted apps see zero visual change from before.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] APK builds (\`./gradlew :app:assembleMainnetDebug\`)
- [ ] Mobile CI check
- [ ] Visual verification requires a wallet with Neeru/Allbridge/Aave positions (spike v2 wallet \`0x81dCf9160237...\` deposited to Neeru today at block 73867243 - that wallet will show the row)