### PR TITLE
chore: drop dead aave refs, add neeru-vaults to investments whitelist

### DIFF
--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -40,10 +40,10 @@ const PEEK = 60
 const OVERLAP = CARD_BEHIND_HEIGHT - PEEK // 36px
 
 // Investments card surfaces only positions from apps integrated in the
-// wallet (Allbridge, Aave). Random hooks-detected positions are
+// wallet (Allbridge, Neeru vaults). Random hooks-detected positions are
 // excluded so the breakdown matches the user's mental model of "what
 // the wallet manages".
-const SUPPORTED_INVESTMENT_APP_IDS = new Set(['aave', 'allbridge'])
+const SUPPORTED_INVESTMENT_APP_IDS = new Set(['allbridge', 'neeru-vaults'])
 
 // Recurse nested AppToken positions to collect every claimable token.
 function collectClaimableTokens(tokens: Token[]): Token[] {

--- a/src/earn/EarnHome.tsx
+++ b/src/earn/EarnHome.tsx
@@ -69,11 +69,6 @@ const SECTION_ORDER: Array<{ id: string; titleKey: string; match: (item: any) =>
     match: (item) => item?.appId === 'allbridge',
   },
   {
-    id: 'aave',
-    titleKey: 'earnFlow.section.aave',
-    match: (item) => item?.appId === 'aave',
-  },
-  {
     id: 'marranitos',
     titleKey: 'earnFlow.section.marranitos',
     match: (item) =>

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -137,7 +137,7 @@ export const DynamicConfigs = {
         // Somm Real Yield ETH
         `${NetworkId['op-mainnet']}:0xc47bb288178ea40bf520a91826a3dee9e0dbfa4c`,
       ],
-      supportedAppIds: ['aave', 'allbridge'],
+      supportedAppIds: ['allbridge', 'neeru-vaults'],
     },
   },
 } satisfies {


### PR DESCRIPTION
## Summary

Aave is not integrated in TuCop (dead code inherited from the Valora fork). This PR cleans up 3 places where the \`aave\` \`appId\` was still referenced as if it were live, and swaps it for \`neeru-vaults\` in the two spots where that whitelist controls what counts as an "external investment".

Complements #315 (TabWallet other-investments row): now Home stack card + Billetera row + EarnHome sections all agree on which apps TuCop actually integrates.

## Changes

- **\`src/components/BalanceCard.tsx\`** — Home stack card investments filter:
  \`\`\`diff
  - const SUPPORTED_INVESTMENT_APP_IDS = new Set(['aave', 'allbridge'])
  + const SUPPORTED_INVESTMENT_APP_IDS = new Set(['allbridge', 'neeru-vaults'])
  \`\`\`
  Home investments card now sums Neeru positions (once backend hooks-api returns non-zero balance per tranche, see PENDING.md for backend bug).

- **\`src/earn/EarnHome.tsx\`** — \`SECTION_ORDER\`: dropped the \`aave\` entry. Nothing ever populated it because no pool comes back with \`appId=aave\`.

- **\`src/statsig/constants.ts\`** — \`APP_CONFIG.defaultValues.supportedAppIds\`:
  \`\`\`diff
  - supportedAppIds: ['aave', 'allbridge']
  + supportedAppIds: ['allbridge', 'neeru-vaults']
  \`\`\`

## Not in scope

- Backend hooks-api \`getEarnPositions\` bug where Neeru balance per tranche returns 0 (documented in PENDING.md, requires backend session)
- \`src/redux/migrations.ts\` lines 1890-1902 still reference \`aave\` in an old \`providerId\` migration - left as-is because migrations should not be changed after they've run for users.
- \`src/statsig/types.ts\` and other locations may still have residual \`aave\` strings for backward compatibility. Not touching unless they cause an actual bug.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/statsig/index.test.ts src/components/BalanceCard.test.tsx src/earn/EarnHome.test.tsx\` all pass (48 tests)
- [ ] Mobile CI check