### PR TITLE
fix(earn/neeru): bump positions fetch timeout 15s -> 45s

### DIFF
--- a/src/earn/neeru/__tests__/hardcoded-vs-live.test.ts
+++ b/src/earn/neeru/__tests__/hardcoded-vs-live.test.ts
@@ -12,7 +12,11 @@ const describeLive = RUN_LIVE ? describe : describe.skip
 
 const BACKEND_BASE_URL =
   process.env.NEERU_LIVE_META_BASE_URL ?? 'https://tucop-backend-production.up.railway.app'
-const FETCH_TIMEOUT_MS = 15_000
+// Matches the wallet-side NEERU_FETCH_TIMEOUT_MS bump (45s) so the drift
+// check tolerates the backend's occasional cold-response tail
+// (Railway container spin-up + DB pool warm on first hit after idle can
+// stretch to 20-30s). Below this the CI job flakes on cold cache runs.
+const FETCH_TIMEOUT_MS = 45_000
 
 async function fetchWithTimeout(url: string): Promise<Response> {
   const controller = new AbortController()
@@ -29,7 +33,8 @@ async function fetchWithTimeout(url: string): Promise<Response> {
 }
 
 describeLive('Neeru meta drift check (live backend)', () => {
-  jest.setTimeout(FETCH_TIMEOUT_MS + 5_000)
+  // 2 backend calls in beforeAll, so allow 2x the per-fetch timeout + margin.
+  jest.setTimeout(FETCH_TIMEOUT_MS * 2 + 10_000)
 
   let liveMetaAdapted: NeeruMeta
   let liveCatalogue: any

--- a/src/earn/neeru/api.ts
+++ b/src/earn/neeru/api.ts
@@ -9,7 +9,16 @@ import {
 } from 'src/earn/neeru/types'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 
-const NEERU_FETCH_TIMEOUT_MS = 15_000
+// 15s was too tight in the wild: the /positions endpoint occasionally cold-
+// starts (Railway container spin-up + DB pool warm) and returns in 20-30s.
+// Under the old 15s cap fetchWithTimeout aborted before backend replied, all
+// 3 retries in the wrapper hit the same wall, and the screen fell back to
+// the empty state with a "Aborted" toast even for users who actually have a
+// position. 45s covers the p99 cold-response window observed 2026-08-04.
+// Sentry TUCOPWALLET-4 (43 events / 4 users) and TUCOPWALLET-D (37 events /
+// 2 users) are both AbortError from this same call site; both should stop
+// firing after this bump.
+const NEERU_FETCH_TIMEOUT_MS = 45_000
 // Config endpoints (meta + catalogue) have short backend cache, so a shorter
 // wallet-side timeout is enough. Falling back to hardcoded defaults is quick
 // and always safe, no reason to keep the boot flow waiting.


### PR DESCRIPTION
## Symptom

On iOS with spike v2 wallet (which has a real Neeru position, backend confirmed \`cat=0 amount=10000 COPm\`), opening the vault detail screen for the Flexible category showed the **empty state** ('Tus depositos Flexible' + 'Como funciona' 1-2-3) plus an **error toast**:

> \`earn/neeru/saga :: fetchNeeruPositions failed\` — \`Aborted\`

User perception: "se queda cargando" / "no me muestra nada". Fully misleading because the user actually has the deposit.

## Root cause

Backend \`/api/earn/neeru/positions\` has a **p99 cold-response of 20-30s** (Railway container spin-up + DB pool warm on the first hit after idle). Wallet had \`NEERU_FETCH_TIMEOUT_MS = 15_000\` per attempt, so \`fetchWithTimeout\` aborted before the response arrived.

The retry wrapper in \`fetchWithTimeout\` (3 attempts + backoff) does not reuse a warm connection, so all 3 attempts hit the same 15s wall and the whole call failed with \`AbortError\`. Vault detail then rendered \`isEmpty=true\` because \`positions.length === 0\`.

Direct timing (5 curls from Mac):

\`\`\`
Try 1: 30s TIMEOUT (0 bytes)
Try 2: 20.5s ok
Try 3: 0.75s ok
Try 4: 0.41s ok
Try 5: 0.43s ok
\`\`\`

The median is fast (<1s), but the tail cold-response was clipping every first-load of the day.

## Fix

Bump \`NEERU_FETCH_TIMEOUT_MS\` from \`15_000\` to \`45_000\` in [\`src/earn/neeru/api.ts\`](src/earn/neeru/api.ts). 45s covers the observed cold-response window with headroom; the 3-retry wrapper still catches real backend failures.

## Sentry impact

Both of these Aborted issues fire from this exact call site and should stop after ship:

- TUCOPWALLET-4 (\`AbortError\`, 43 events / 4 users)
- TUCOPWALLET-D (\`AbortError\`, 37 events / 2 users)

## Backend follow-up (not blocking)

Passed to the backend team as a suggestion: investigate the cold-response pattern (pre-warm the DB pool, cache Neeru positions per address for N seconds, or a warmup ping on release deploy). This bump makes the wallet resilient today; the backend optimization is a separate improvement.

## Test plan

- [x] \`yarn build:ts\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn jest src/earn/neeru/__tests__/\`: 113 tests pass (7 skipped)
- [ ] Mobile CI
- [ ] Manual verify on iOS: fresh app cold-launch to vault detail shows the position, not the empty state, on the first mount