### PR TITLE
feat(earn/neeru): warn user when closing Flex position under 24h

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -3026,6 +3026,8 @@
       "penaltyLabel": "Early withdrawal fee ({{percentage}}%)",
       "totalLabel": "Total",
       "earlyWarning": "You are withdrawing before {{date}}. The fee applies only to the interest, never to your deposit.",
+      "flexUnder24hWarning_one": "If you withdraw now you will not earn interest (the Flexible fund pays by complete days). Wait about {{count}} more hour to complete your first day.",
+      "flexUnder24hWarning_other": "If you withdraw now you will not earn interest (the Flexible fund pays by complete days). Wait about {{count}} more hours to complete your first day.",
       "confirmCta": "Confirm withdrawal",
       "amountOnlyCta": "Withdraw only my deposit (no interest)"
     },

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -3034,6 +3034,8 @@
       "penaltyLabel": "Comision por retiro temprano ({{percentage}}%)",
       "totalLabel": "Total",
       "earlyWarning": "Estas retirando antes del {{date}}. La comision se aplica solo al interes, nunca al deposito.",
+      "flexUnder24hWarning_one": "Si retiras ahora no ganas intereses (el fondo Flexible paga por dias completos). Espera aproximadamente {{count}} hora mas para completar tu primer dia.",
+      "flexUnder24hWarning_other": "Si retiras ahora no ganas intereses (el fondo Flexible paga por dias completos). Espera aproximadamente {{count}} horas mas para completar tu primer dia.",
       "confirmCta": "Confirmar retiro",
       "amountOnlyCta": "Retirar solo mi deposito (sin intereses)"
     },

--- a/src/earn/neeru/NeeruCloseSheet.tsx
+++ b/src/earn/neeru/NeeruCloseSheet.tsx
@@ -44,6 +44,16 @@ export default function NeeruCloseSheet({ forwardedRef, position, onClose, onAmo
     ? new BigNumber(payout.interest).minus(payout.interestAfterPenalty).toFixed()
     : '0'
 
+  // Flex category (0) pays interest per complete 24h day via integer division:
+  // closing before 24h from deposit yields 0 interest. Warn the user so they
+  // can wait, since there is no penalty concept for Flex to already flag this.
+  const nowSecs = Math.floor(Date.now() / 1000)
+  const elapsedSecs = position ? nowSecs - position.startTs : 0
+  const isFlexUnder24h = position?.category === 0 && elapsedSecs >= 0 && elapsedSecs < 86400
+  const flexHoursRemaining = isFlexUnder24h
+    ? Math.max(1, Math.ceil((86400 - elapsedSecs) / 3600))
+    : 0
+
   return (
     <BottomSheetModal
       ref={forwardedRef}
@@ -82,6 +92,13 @@ export default function NeeruCloseSheet({ forwardedRef, position, onClose, onAmo
             {payout.isEarly && (
               <Text style={styles.warning}>
                 {t('neeruVaults.closeSheet.earlyWarning', { date: endDate })}
+              </Text>
+            )}
+            {isFlexUnder24h && (
+              <Text testID="NeeruCloseSheet.FlexUnder24hWarning" style={styles.warning}>
+                {t('neeruVaults.closeSheet.flexUnder24hWarning', {
+                  count: flexHoursRemaining,
+                })}
               </Text>
             )}
             <Button

--- a/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
+++ b/src/earn/neeru/__tests__/NeeruCloseSheet.test.tsx
@@ -65,4 +65,72 @@ describe('NeeruCloseSheet', () => {
     )
     expect(queryByTestId('NeeruCloseSheet.AmountOnly')).toBeNull()
   })
+
+  describe('Flex under 24h warning', () => {
+    const flexPosition = (startTsSecondsAgo: number): NeeruIndividualPosition => {
+      const nowSecs = Math.floor(Date.now() / 1000)
+      return {
+        ...pos,
+        category: 0,
+        categoryLabel: 'Flexible',
+        startTs: nowSecs - startTsSecondsAgo,
+        currentPayoutIfClosed: {
+          amount: '10000',
+          interest: '0',
+          penaltyBps: 0,
+          interestAfterPenalty: '0',
+          total: '10000',
+          isEarly: false,
+        },
+      }
+    }
+
+    it('shows the warning when a Flex position is closed under 24h from deposit', () => {
+      const store = createMockStore({ neeru: initialNeeruState } as any)
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <NeeruCloseSheet
+            forwardedRef={React.createRef()}
+            position={flexPosition(3600)}
+            onClose={jest.fn()}
+          />
+        </Provider>
+      )
+      expect(getByTestId('NeeruCloseSheet.FlexUnder24hWarning')).toBeTruthy()
+    })
+
+    it('does not show the warning when a Flex position is at least 24h old', () => {
+      const store = createMockStore({ neeru: initialNeeruState } as any)
+      const { queryByTestId } = render(
+        <Provider store={store}>
+          <NeeruCloseSheet
+            forwardedRef={React.createRef()}
+            position={flexPosition(86400 + 60)}
+            onClose={jest.fn()}
+          />
+        </Provider>
+      )
+      expect(queryByTestId('NeeruCloseSheet.FlexUnder24hWarning')).toBeNull()
+    })
+
+    it('does not show the warning for locked categories under 24h (they get earlyWarning instead)', () => {
+      const store = createMockStore({ neeru: initialNeeruState } as any)
+      const nowSecs = Math.floor(Date.now() / 1000)
+      const lockedUnder24h: NeeruIndividualPosition = {
+        ...pos,
+        category: 1,
+        startTs: nowSecs - 3600,
+      }
+      const { queryByTestId } = render(
+        <Provider store={store}>
+          <NeeruCloseSheet
+            forwardedRef={React.createRef()}
+            position={lockedUnder24h}
+            onClose={jest.fn()}
+          />
+        </Provider>
+      )
+      expect(queryByTestId('NeeruCloseSheet.FlexUnder24hWarning')).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Contexto

Neeru reporto que el contrato del fondo Flexible (category 0) paga interes por dias completos via integer division: cerrar antes de 24h desde el deposito rinde 0 interes, sin penalidad de por medio que lo delate en la UI. Caso motivador: `pid=19` en mainnet cerro a 23h 41min y perdio 2.66 COPm.

## Cambios

- **`NeeruCloseSheet.tsx`**: warning condicional cuando `position.category === 0 && (nowSecs - position.startTs) < 86400`. Muestra las horas restantes (`Math.ceil((86400 - elapsed) / 3600)`, piso 1) para que el usuario pueda esperar. No bloquea el CTA (usuario puede tener urgencia real).
- **`locales/{base,es-419}/translation.json`**: copy pluralizada `flexUnder24hWarning_one/_other` con `{{count}}`, siguiendo el patron `maturityDays_one/_other` que ya vive en el mismo bloque `neeruVaults.closeSheet`.
- **`NeeruCloseSheet.test.tsx`**: 3 tests nuevos (Flex 1h muestra warning, Flex 25h no lo muestra, categoria bloqueada bajo 24h no lo muestra).

## Decisiones

- **Solo Flex** (category 0): las categorias bloqueadas (30/60/90d) ya muestran `earlyWarning` con la penalidad, que cubre el caso.
- **Warning informativo, no bloqueante**: el usuario puede necesitar retirar aunque pierda interes.
- **Guard `elapsedSecs >= 0`** para clock skew (device con reloj adelantado).
- **Copy en parentesis** explica el porque (paga por dias completos) para que no se lea como bug.

## Coordinacion externa

Neeru va a espejar la misma copy en neerufinance.xyz para consistencia.

## Verificacion

- `yarn build:ts` -> 0 errores
- `yarn lint` archivos tocados -> 0 warnings
- `yarn jest NeeruCloseSheet` -> 6/6 pass (3 nuevos + 3 existentes)