### PR TITLE
docs: clarify scope of railway.md include in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,5 +93,5 @@ src/
 @.claude/rules/tokens.md - Token ecosystem & addresses
 @.claude/rules/ios-build.md - iOS schemes & troubleshooting
 @.claude/rules/android-build.md - Android config & SoLoader fix
-@.claude/rules/railway.md - Backend services
+@.claude/rules/railway.md - Backend sibling services (phone verification, twilio, buckspay)
 @.claude/rules/ci-cd.md - CI checks & Knip


### PR DESCRIPTION
## Summary

- Clarify the `@`-include description for `.claude/rules/railway.md` in `CLAUDE.md` so it reflects the file's actual scope: 3 sibling services (phone verification, twilio, buckspay), NOT the main umbrella backend at `tucop-backend-production.up.railway.app`.
- Motivated by a cold-session doc audit: the previous label "Backend services" read like it covered the main backend, sending readers to the wrong file.

## Change

```diff
-@.claude/rules/railway.md - Backend services
+@.claude/rules/railway.md - Backend sibling services (phone verification, twilio, buckspay)
```

## Test plan

- [x] No code change; no build or test impact
- [x] Only the 1-line description in CLAUDE.md is modified
- [x] Pre-commit hook ran (prettier only, since only .md changed)